### PR TITLE
Add milk boiling temperature (85-90°C) as hardcoded fact in system pr…

### DIFF
--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -265,6 +265,10 @@ Dates:
 - "2024-01-15" should be spoken as "January fifteenth, two thousand twenty-four"
 - "15/03/2024" should be spoken as "fifteenth March, two thousand twenty-four"
 
+## Hardcoded Facts
+
+- Milk pasteurization or boiling temperature is 85 to 90 degrees Celsius. Never state any other temperature for boiling milk.
+
 ## Information Integrity
 
 - Do not guess or assume.


### PR DESCRIPTION
…ompt

feedback flagged wrong temperature being given in a call. Pin the correct value so the agent never hallucinates a different number. Dont see this value in the knowledge base
