### PR TITLE
Fix TTS garbling of Gujarati compound numbers

### DIFF
--- a/agents/services/farmer_context.py
+++ b/agents/services/farmer_context.py
@@ -16,6 +16,7 @@ from agents.tools.farmer_animal_backends import (
     merge_animal_data,
     normalize_phone,
 )
+from helpers.gujarati_numbers import number_to_gujarati, tag_to_gujarati
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -44,7 +45,9 @@ def _add_field(lines: list, label: str, value: Any) -> None:
     if value is None or value == "" or value == 0:
         return
     if isinstance(value, float):
-        lines.append(f"- **{label}:** {value:g}")
+        lines.append(f"- **{label}:** {number_to_gujarati(value)} ({value:g})")
+    elif isinstance(value, int):
+        lines.append(f"- **{label}:** {number_to_gujarati(value)} ({value})")
     else:
         lines.append(f"- **{label}:** {value}")
 
@@ -183,7 +186,8 @@ async def get_farmer_full_context_string(mobile_number: str) -> str:
             lines.append("- No animal tags found for this farmer.")
             continue
 
-        lines.append(f"- **Animal tags:** {', '.join(tags)}")
+        tag_entries = [f"{t} ({tag_to_gujarati(t)})" for t in tags]
+        lines.append(f"- **Animal tags:** {', '.join(tag_entries)}")
 
         # Fetch animal details in parallel
         animal_tasks = [_fetch_animal_details(tag, token1 or "", token3) for tag in tags]

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -13,6 +13,7 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart, Te
 from agents.voice import voice_agent
 from agents.tools.farmer import normalize_phone_to_mobile
 from agents.services.farmer_context import get_farmer_full_context_string
+from helpers.gujarati_numbers import normalize_numbers_for_tts
 from agents.tools.common import get_random_nudge_message, send_nudge_message_raya, set_tool_call_nudge_event
 from helpers.utils import get_logger, clean_output_by_language
 from app.config import settings
@@ -496,6 +497,8 @@ async def stream_voice_message(
                                 if isinstance(translated_chunk, str) and translated_chunk
                                 else translated_chunk
                             )
+                            if isinstance(cleaned_chunk, str) and cleaned_chunk and requested_target_lang == "gu":
+                                cleaned_chunk = normalize_numbers_for_tts(cleaned_chunk)
                             yield cleaned_chunk
                     except Exception as e:
                         logger.error(
@@ -535,6 +538,8 @@ async def stream_voice_message(
                                 if isinstance(chunk, str) and chunk
                                 else chunk
                             )
+                            if isinstance(cleaned_chunk, str) and cleaned_chunk and requested_target_lang == "gu":
+                                cleaned_chunk = normalize_numbers_for_tts(cleaned_chunk)
                             if await _request_is_stale("before_direct_yield"):
                                 break
                             yield cleaned_chunk

--- a/helpers/gujarati_numbers.py
+++ b/helpers/gujarati_numbers.py
@@ -1,0 +1,179 @@
+"""
+Gujarati number-to-words converter and text normalizer for TTS output.
+
+Converts digit sequences in text to Gujarati words so that TTS engines
+pronounce them correctly instead of garbling compound numbers.
+
+Examples:
+    136      → એકસો છત્રીસ
+    3.56     → ત્રણ પોઈન્ટ પાંચ છ
+    15       → પંદર
+    tag 1062853187210 → એક શૂન્ય છ બે આઠ પાંચ ત્રણ એક આઠ સાત બે એક શૂન્ય
+"""
+
+import re
+
+# --- Lookup tables ---
+
+_ONES = {
+    0: "શૂન્ય",
+    1: "એક",
+    2: "બે",
+    3: "ત્રણ",
+    4: "ચાર",
+    5: "પાંચ",
+    6: "છ",
+    7: "સાત",
+    8: "આઠ",
+    9: "નવ",
+}
+
+# Gujarati has unique words for 1-99 (Indian numbering irregularity)
+_1_TO_99 = {
+    1: "એક", 2: "બે", 3: "ત્રણ", 4: "ચાર", 5: "પાંચ",
+    6: "છ", 7: "સાત", 8: "આઠ", 9: "નવ", 10: "દસ",
+    11: "અગિયાર", 12: "બાર", 13: "તેર", 14: "ચૌદ", 15: "પંદર",
+    16: "સોળ", 17: "સત્તર", 18: "અઢાર", 19: "ઓગણીસ",
+    20: "વીસ", 21: "એકવીસ", 22: "બાવીસ", 23: "ત્રેવીસ",
+    24: "ચોવીસ", 25: "પચ્ચીસ", 26: "છવ્વીસ", 27: "સત્તાવીસ",
+    28: "અઠ્ઠાવીસ", 29: "ઓગણત્રીસ",
+    30: "ત્રીસ", 31: "એકત્રીસ", 32: "બત્રીસ", 33: "તેત્રીસ",
+    34: "ચોત્રીસ", 35: "પાંત્રીસ", 36: "છત્રીસ", 37: "સાડત્રીસ",
+    38: "આડત્રીસ", 39: "ઓગણચાલીસ",
+    40: "ચાલીસ", 41: "એકતાલીસ", 42: "બેતાલીસ", 43: "ત્રેતાલીસ",
+    44: "ચુંમાલીસ", 45: "પિસ્તાલીસ", 46: "છેતાલીસ", 47: "સુડતાલીસ",
+    48: "અડતાલીસ", 49: "ઓગણપચાસ",
+    50: "પચાસ", 51: "એકાવન", 52: "બાવન", 53: "ત્રેપન",
+    54: "ચોપન", 55: "પંચાવન", 56: "છપ્પન", 57: "સત્તાવન",
+    58: "અઠ્ઠાવન", 59: "ઓગણસાઠ",
+    60: "સાઠ", 61: "એકસઠ", 62: "બાસઠ", 63: "ત્રેસઠ",
+    64: "ચોસઠ", 65: "પાંસઠ", 66: "છાસઠ", 67: "સડસઠ",
+    68: "અડસઠ", 69: "અગણોતેર",
+    70: "સિત્તેર", 71: "એકોતેર", 72: "બોતેર", 73: "તોતેર",
+    74: "ચુમોતેર", 75: "પંચોતેર", 76: "છોતેર", 77: "સિત્યોતેર",
+    78: "ઇઠ્યોતેર", 79: "ઓગણાએંસી",
+    80: "એંસી", 81: "એક્યાસી", 82: "બ્યાસી", 83: "ત્યાસી",
+    84: "ચોર્યાસી", 85: "પંચાસી", 86: "છ્યાસી", 87: "સત્યાસી",
+    88: "અઠ્ઠ્યાસી", 89: "નેવ્યાસી",
+    90: "નેવું", 91: "એકાણું", 92: "બાણું", 93: "ત્રાણું",
+    94: "ચોરાણું", 95: "પંચાણું", 96: "છન્નું", 97: "સત્તાણું",
+    98: "અઠ્ઠાણું", 99: "નવ્વાણું",
+}
+
+_HUNDREDS = {
+    1: "એકસો", 2: "બસો", 3: "ત્રણસો", 4: "ચારસો", 5: "પાંચસો",
+    6: "છસો", 7: "સાતસો", 8: "આઠસો", 9: "નવસો",
+}
+
+
+def _int_to_gujarati(n: int) -> str:
+    """Convert a non-negative integer to Gujarati words.
+
+    Uses the Indian numbering system (lakh, crore etc.).
+    """
+    if n < 0:
+        return "ઋણ " + _int_to_gujarati(-n)
+    if n == 0:
+        return _ONES[0]
+    if n <= 99:
+        return _1_TO_99[n]
+
+    parts: list[str] = []
+
+    # Crore (1,00,00,000)
+    if n >= 10_000_000:
+        crore = n // 10_000_000
+        parts.append(_int_to_gujarati(crore) + " કરોડ")
+        n %= 10_000_000
+
+    # Lakh (1,00,000)
+    if n >= 100_000:
+        lakh = n // 100_000
+        parts.append(_int_to_gujarati(lakh) + " લાખ")
+        n %= 100_000
+
+    # Thousand (1,000)
+    if n >= 1000:
+        thousand = n // 1000
+        parts.append(_int_to_gujarati(thousand) + " હજાર")
+        n %= 1000
+
+    # Hundred (100)
+    if n >= 100:
+        h = n // 100
+        parts.append(_HUNDREDS[h])
+        n %= 100
+
+    # Remainder 1-99
+    if n > 0:
+        parts.append(_1_TO_99[n])
+
+    return " ".join(parts)
+
+
+def number_to_gujarati(value: float | int) -> str:
+    """Convert a number (int or float) to Gujarati words.
+
+    Integers: 136 → "એકસો છત્રીસ"
+    Floats:   3.56 → "ત્રણ પોઈન્ટ પાંચ છ"  (decimals read digit-by-digit)
+    """
+    if isinstance(value, int) or (isinstance(value, float) and value == int(value)):
+        return _int_to_gujarati(int(value))
+
+    text = f"{value:g}"
+    if "." not in text:
+        return _int_to_gujarati(int(value))
+
+    int_part_str, dec_part_str = text.split(".", 1)
+    int_part = int(int_part_str)
+    int_word = _int_to_gujarati(int_part)
+
+    # Decimal digits read one at a time: 3.56 → "ત્રણ પોઈન્ટ પાંચ છ"
+    dec_digits = " ".join(_ONES[int(d)] for d in dec_part_str)
+    return f"{int_word} પોઈન્ટ {dec_digits}"
+
+
+def tag_to_gujarati(tag: str) -> str:
+    """Convert a tag number to digit-by-digit Gujarati words.
+
+    Tag numbers are identifiers, not quantities, so they are read digit by digit.
+    "1062853187210" → "એક શૂન્ય છ બે આઠ પાંચ ત્રણ એક આઠ સાત બે એક શૂન્ય"
+    """
+    return " ".join(_ONES[int(d)] for d in tag if d.isdigit())
+
+
+# --- Text normalizer for TTS output ---
+
+# Matches sequences of digits, optionally with one decimal point
+_NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
+
+# Matches digit sequences of 10+ digits (tag numbers, phone numbers)
+_LONG_DIGIT_RE = re.compile(r"\d{10,}")
+
+
+def normalize_numbers_for_tts(text: str) -> str:
+    """Replace digit sequences in Gujarati text with Gujarati words.
+
+    - Long digit sequences (10+ digits, e.g. tag numbers) → digit-by-digit
+    - Regular numbers → natural Gujarati words (e.g. 136 → એકસો છત્રીસ)
+    - Decimals → "X પોઈન્ટ Y Z" (e.g. 3.56 → ત્રણ પોઈન્ટ પાંચ છ)
+    """
+    if not text:
+        return text
+
+    # First pass: convert long digit sequences (tags, phone numbers) to digit-by-digit
+    def _replace_long(m: re.Match) -> str:
+        return tag_to_gujarati(m.group())
+
+    text = _LONG_DIGIT_RE.sub(_replace_long, text)
+
+    # Second pass: convert remaining number sequences to words
+    def _replace_number(m: re.Match) -> str:
+        s = m.group()
+        if "." in s:
+            return number_to_gujarati(float(s))
+        return number_to_gujarati(int(s))
+
+    text = _NUMBER_RE.sub(_replace_number, text)
+
+    return text

--- a/tests/test_gujarati_numbers.py
+++ b/tests/test_gujarati_numbers.py
@@ -1,0 +1,224 @@
+"""
+Tests for helpers.gujarati_numbers – Gujarati number-to-words converter and TTS normalizer.
+"""
+import pytest
+from helpers.gujarati_numbers import (
+    number_to_gujarati,
+    tag_to_gujarati,
+    normalize_numbers_for_tts,
+    _int_to_gujarati,
+)
+
+
+# ---------------------------------------------------------------------------
+# number_to_gujarati – integers
+# ---------------------------------------------------------------------------
+
+class TestIntegerConversion:
+    """Core integer-to-Gujarati-words tests."""
+
+    @pytest.mark.parametrize("n, expected", [
+        (0, "શૂન્ય"),
+        (1, "એક"),
+        (9, "નવ"),
+    ])
+    def test_single_digits(self, n, expected):
+        assert number_to_gujarati(n) == expected
+
+    @pytest.mark.parametrize("n, expected", [
+        (10, "દસ"),
+        (15, "પંદર"),
+        (19, "ઓગણીસ"),
+        (20, "વીસ"),
+        (25, "પચ્ચીસ"),
+        (29, "ઓગણત્રીસ"),
+        (35, "પાંત્રીસ"),
+        (45, "પિસ્તાલીસ"),
+        (54, "ચોપન"),
+        (69, "અગણોતેર"),
+        (70, "સિત્તેર"),
+        (82, "બ્યાસી"),
+        (99, "નવ્વાણું"),
+    ])
+    def test_teens_and_tens(self, n, expected):
+        """These are the compound numbers that TTS was garbling."""
+        assert number_to_gujarati(n) == expected
+
+    @pytest.mark.parametrize("n, expected", [
+        (100, "એકસો"),
+        (136, "એકસો છત્રીસ"),
+        (200, "બસો"),
+        (367, "ત્રણસો સડસઠ"),
+        (369, "ત્રણસો અગણોતેર"),
+        (500, "પાંચસો"),
+        (999, "નવસો નવ્વાણું"),
+    ])
+    def test_hundreds(self, n, expected):
+        assert number_to_gujarati(n) == expected
+
+    @pytest.mark.parametrize("n, expected", [
+        (1000, "એક હજાર"),
+        (1500, "એક હજાર પાંચસો"),
+        (5000, "પાંચ હજાર"),
+        (10000, "દસ હજાર"),
+        (99999, "નવ્વાણું હજાર નવસો નવ્વાણું"),
+    ])
+    def test_thousands(self, n, expected):
+        assert number_to_gujarati(n) == expected
+
+    @pytest.mark.parametrize("n, expected", [
+        (100000, "એક લાખ"),
+        (250000, "બે લાખ પચાસ હજાર"),
+    ])
+    def test_lakhs(self, n, expected):
+        assert number_to_gujarati(n) == expected
+
+    def test_crore(self):
+        assert number_to_gujarati(10000000) == "એક કરોડ"
+
+    def test_float_whole_number_treated_as_int(self):
+        """136.0 should produce the same output as 136."""
+        assert number_to_gujarati(136.0) == "એકસો છત્રીસ"
+
+
+# ---------------------------------------------------------------------------
+# number_to_gujarati – decimals
+# ---------------------------------------------------------------------------
+
+class TestDecimalConversion:
+    """Decimal numbers should read as 'integer પોઈન્ટ digit digit ...'"""
+
+    @pytest.mark.parametrize("value, expected", [
+        (3.5, "ત્રણ પોઈન્ટ પાંચ"),
+        (6.69, "છ પોઈન્ટ છ નવ"),
+        (8.86, "આઠ પોઈન્ટ આઠ છ"),
+        (3.56, "ત્રણ પોઈન્ટ પાંચ છ"),
+        (4.34, "ચાર પોઈન્ટ ત્રણ ચાર"),
+        (54.25, "ચોપન પોઈન્ટ બે પાંચ"),
+        (0.5, "શૂન્ય પોઈન્ટ પાંચ"),
+    ])
+    def test_decimal_values(self, value, expected):
+        assert number_to_gujarati(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# tag_to_gujarati – digit-by-digit reading
+# ---------------------------------------------------------------------------
+
+class TestTagConversion:
+
+    def test_standard_12_digit_tag(self):
+        result = tag_to_gujarati("106285318721")
+        assert result == "એક શૂન્ય છ બે આઠ પાંચ ત્રણ એક આઠ સાત બે એક"
+
+    def test_tag_with_zeros(self):
+        result = tag_to_gujarati("100066235408")
+        assert result == "એક શૂન્ય શૂન્ય શૂન્ય છ છ બે ત્રણ પાંચ ચાર શૂન્ય આઠ"
+
+    def test_tag_ignores_non_digits(self):
+        result = tag_to_gujarati("10-62")
+        assert result == "એક શૂન્ય છ બે"
+
+
+# ---------------------------------------------------------------------------
+# normalize_numbers_for_tts – full text normalization
+# ---------------------------------------------------------------------------
+
+class TestTextNormalization:
+
+    def test_integer_in_sentence(self):
+        text = "તમારી પાસે 35 ગાયો છે"
+        result = normalize_numbers_for_tts(text)
+        assert "પાંત્રીસ" in result
+        assert "35" not in result
+
+    def test_decimal_in_sentence(self):
+        text = "ફેટ 6.69 છે"
+        result = normalize_numbers_for_tts(text)
+        assert "છ પોઈન્ટ છ નવ" in result
+        assert "6.69" not in result
+
+    def test_long_tag_number_digit_by_digit(self):
+        text = "ટેગ નંબર 1062853187210 ની ગાય"
+        result = normalize_numbers_for_tts(text)
+        # Should be digit-by-digit (13 digits → long sequence)
+        assert "એક શૂન્ય છ બે" in result
+        # Should NOT be read as a compound number
+        assert "કરોડ" not in result
+
+    def test_mixed_numbers(self):
+        text = "દૈનિક ઉત્પાદન 367 લિટર, ફેટ 3.56 છે"
+        result = normalize_numbers_for_tts(text)
+        assert "ત્રણસો સડસઠ" in result
+        assert "ત્રણ પોઈન્ટ પાંચ છ" in result
+        assert "367" not in result
+        assert "3.56" not in result
+
+    def test_empty_string(self):
+        assert normalize_numbers_for_tts("") == ""
+
+    def test_no_numbers(self):
+        text = "નમસ્તે, હું સરલાબેન છું"
+        assert normalize_numbers_for_tts(text) == text
+
+    def test_phone_number_digit_by_digit(self):
+        text = "મોબાઇલ નંબર 9979138134"
+        result = normalize_numbers_for_tts(text)
+        assert "નવ નવ સાત નવ" in result
+        assert "9979138134" not in result
+
+    def test_preserves_surrounding_text(self):
+        text = "કુલ 4 પશુ છે"
+        result = normalize_numbers_for_tts(text)
+        assert result == "કુલ ચાર પશુ છે"
+
+    def test_multiple_separate_numbers(self):
+        text = "બે ખાતા: 136 લિટર અને 367 લિટર"
+        result = normalize_numbers_for_tts(text)
+        assert "એકસો છત્રીસ" in result
+        assert "ત્રણસો સડસઠ" in result
+
+    def test_range_numbers(self):
+        """Numbers separated by dash should each convert independently."""
+        text = "2-3 દિવસ"
+        result = normalize_numbers_for_tts(text)
+        assert "બે" in result
+        assert "ત્રણ" in result
+
+
+# ---------------------------------------------------------------------------
+# Edge cases from Shridhar's feedback
+# ---------------------------------------------------------------------------
+
+class TestFeedbackCases:
+    """Numbers that were specifically garbled in the March 25-26 feedback."""
+
+    def test_136_liters(self):
+        """[qh] 'એકસો છત્રીસ લિટર' was being garbled."""
+        assert number_to_gujarati(136) == "એકસો છત્રીસ"
+
+    def test_369(self):
+        """Was garbled as 'ઓગણું સિત્તેર'."""
+        assert number_to_gujarati(369) == "ત્રણસો અગણોતેર"
+
+    def test_367(self):
+        """Was garbled as 'ઓંસઠ'."""
+        assert number_to_gujarati(367) == "ત્રણસો સડસઠ"
+
+    def test_35_animals(self):
+        """[rl] Was garbled as 'પિસ્તાઈસ'."""
+        assert number_to_gujarati(35) == "પાંત્રીસ"
+
+    def test_54_point_25(self):
+        """[qx] Was garbled as 'ચોંયાવન પોઇન્ટ બે પાંચ'."""
+        assert number_to_gujarati(54.25) == "ચોપન પોઈન્ટ બે પાંચ"
+
+    def test_fat_3_point_56(self):
+        """[qi] Was garbled as 'ત્રણ પોઈન્ટ પાંચ છટ્ઠું'."""
+        assert number_to_gujarati(3.56) == "ત્રણ પોઈન્ટ પાંચ છ"
+
+    def test_fat_6_point_69(self):
+        assert number_to_gujarati(6.69) == "છ પોઈન્ટ છ નવ"
+
+    def test_snf_8_point_86(self):
+        assert number_to_gujarati(8.86) == "આઠ પોઈન્ટ આઠ છ"


### PR DESCRIPTION
## Summary
- Adds a custom Gujarati number-to-words converter (`helpers/gujarati_numbers.py`) that correctly handles all 1-99 compound forms, hundreds, thousands, lakhs, crores, decimals, and tag numbers
- **Pre-converts** numeric farmer context data (milk production, fat %, SNF, animal counts, tag numbers) to Gujarati words before injecting into the system prompt, so the LLM sees correct words directly
- **Post-processes** streaming voice output to catch any remaining digit sequences the LLM didn't convert, as a safety net — only applied when `target_lang == "gu"`
- Includes 60 tests covering all number ranges, decimal handling, tag digit-by-digit reading, full text normalization, and regression tests for every garbled number from Shridhar's March 25-26 feedback

## Context
Shridhar's call log review (March 25-26) identified 15+ instances of TTS garbling compound Gujarati numbers — e.g. 369 → "ઓગણું સિત્તેર" (should be ત્રણસો અગણોતેર), 35 → "પિસ્તાઈસ" (should be પાંત્રીસ), 3.56 → "છટ્ઠું". Root cause: the LLM was asked via prompt to convert numbers to words but did so inconsistently, especially for numbers with irregular Gujarati forms.

## Test plan
- [x] `pytest tests/test_gujarati_numbers.py` — 60/60 passing
- [ ] Verify on a test call that farmer data numbers are spoken correctly
- [ ] Verify decimal fat/SNF values pronounced as "X પોઈન્ટ Y Z"
- [ ] Verify 12-digit tag numbers read digit-by-digit

🤖 Generated with [Claude Code](https://claude.com/claude-code)