### PR TITLE
Detect carrier hold messages and suppress anext() noise

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -154,6 +154,40 @@ def _is_fragment_query(query: str) -> bool:
     return False
 
 
+# ── Hold message detection ─────────────────────────────────────────────
+# Carrier IVR "your call is on hold" messages get picked up by STT and
+# sent as user input, creating runaway loops. Detect them and respond
+# with "goodbye" so the STT provider cuts the call.
+_HOLD_MSG_PATTERNS_GU = [
+    "હોલ્ડ પર",            # "on hold" in Gujarati
+    "લાઇન પર રહો",        # "stay on the line"
+    "લાઈન પર રહો",        # variant spelling
+]
+_HOLD_MSG_PATTERNS_EN = [
+    "put your call on hold",
+    "call has been put on hold",
+    "call on hold",
+    "please stay on the line",
+    "please remain on the line",
+]
+_HOLD_GOODBYE = {
+    "gu": "Goodbye.",
+    "en": "Goodbye.",
+}
+
+
+def _is_hold_message(query: str) -> bool:
+    """Return True if the query looks like a carrier hold/IVR message."""
+    lower = query.lower()
+    for pat in _HOLD_MSG_PATTERNS_GU:
+        if pat in lower:
+            return True
+    for pat in _HOLD_MSG_PATTERNS_EN:
+        if pat in lower:
+            return True
+    return False
+
+
 def _greeting_response(target_lang: str) -> str:
     return _GREETING_RESPONSES.get(target_lang, _GREETING_RESPONSES["gu"])
 
@@ -333,6 +367,22 @@ async def stream_voice_message(
                 stt_resp = ModelResponse(parts=[TextPart(content=stt_response)])
                 await update_message_history(session_id, [*history, stt_req, stt_resp])
                 yield stt_response
+                return
+
+            # ── Hold message short-circuit ────────────────────────────────
+            # Carrier IVR "your call is on hold" messages get transcribed by
+            # STT and sent as user input, creating runaway loops of 20+ traces.
+            # Respond with "goodbye" so the STT provider disconnects the call.
+            if _is_hold_message(query):
+                logger.info(
+                    "Hold message detected; responding with goodbye to cut call - session_id=%s process_id=%s query=%r",
+                    session_id, process_id, query[:100],
+                )
+                goodbye = _HOLD_GOODBYE.get(requested_target_lang, _HOLD_GOODBYE["en"])
+                hold_req = ModelRequest(parts=[UserPromptPart(content=query)])
+                hold_resp = ModelResponse(parts=[TextPart(content=goodbye)])
+                await update_message_history(session_id, [*history, hold_req, hold_resp])
+                yield goodbye
                 return
 
             # ── Greeting short-circuit ────────────────────────────────────
@@ -702,9 +752,12 @@ async def stream_voice_message(
                 except StopAsyncIteration:
                     pass
                 except RuntimeError as e:
-                    if "StopAsyncIteration" in str(e):
-                        logger.warning(
-                            "Suppressed stream runtime error during response teardown - session_id=%s process_id=%s error=%s",
+                    if "StopAsyncIteration" in str(e) or "anext()" in str(e):
+                        # anext() errors occur on superseded processes during
+                        # teardown — the final process_id has its own generator
+                        # and is unaffected, so this is just cleanup noise.
+                        logger.debug(
+                            "Suppressed stream runtime error (superseded process teardown) - session_id=%s process_id=%s error=%s",
                             session_id,
                             process_id,
                             e,

--- a/tests/test_voice_fixes.py
+++ b/tests/test_voice_fixes.py
@@ -13,7 +13,7 @@ import os
 # Add project root to path so imports work
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.services.voice import _is_bare_greeting, _is_fragment_query
+from app.services.voice import _is_bare_greeting, _is_fragment_query, _is_hold_message
 from agents.tools.terms import get_ambiguity_hints_for_query
 
 
@@ -154,6 +154,46 @@ class TestAmbiguityTerms:
         result = get_ambiguity_hints_for_query("વાડો કેવી રીતે બનાવવો")
         assert "shed" in result.lower() or "enclosure" in result.lower()
         assert "પાડો" not in result or "NOT પાડો" in result
+
+# ---------------------------------------------------------------------------
+# Hold message detection tests
+# ---------------------------------------------------------------------------
+
+class TestHoldMessageDetection:
+    """Verify _is_hold_message catches carrier IVR hold messages."""
+
+    @pytest.mark.parametrize("query", [
+        # Raw Gujarati STT output (as seen in production traces)
+        "તેને તમારો કોલ હોલ્ડ પર રાખ્યા છે કૃપા કરી લાઇન પર રહો",
+        "તમારો કોલ હોલ્ડ પર રાખ્યા છે કૃપા કરી લાઈન પર રહો",
+        # English translations (post-pretranslation)
+        "Your call has been put on hold, please stay on the line.",
+        "The person you are speaking with has put your call on hold. Please stay on the line.",
+        "The person you called has put your call on hold. Please remain on the line.",
+        "They have put your call on hold.",
+        # Mixed Gujarati/English fragments from STT
+        "હોલ્ડ પર રાખ્યા છે",
+        "કોલ હોલ્ડ પર",
+        "put your call on hold please stay on the line",
+        # Hindi transliteration in Gujarati script
+        "આપ કે કોલ કો હોલ્ડ પર રખા હૈ કૃપયા લાઇન પર બને રહી",
+    ])
+    def test_hold_messages_detected(self, query):
+        assert _is_hold_message(query), f"Should detect hold message: {query!r}"
+
+    @pytest.mark.parametrize("query", [
+        # Normal farmer queries that should NOT be detected as hold messages
+        "મારી ગાયને તાવ આવે છે",
+        "My cow is not eating properly",
+        "hello",
+        "દૂધમાં ફેટ ઓછી છે",
+        "I want to book AI for my cow",
+        # "hold" in a different context
+        "How long can I hold the calf's milk?",
+    ])
+    def test_normal_queries_not_detected(self, query):
+        assert not _is_hold_message(query), f"Should NOT detect as hold: {query!r}"
+
 
     def test_existing_uthla_still_works(self):
         """Existing entry: ઉથલા should still trigger repeat breeder."""


### PR DESCRIPTION
## Summary
- **Hold message detection**: Carrier IVR "your call is on hold" messages get transcribed by STT and sent as user input, creating runaway loops of 20-30 traces per call. Now detected early (before agent pipeline) and short-circuited with "Goodbye." — which tells the STT provider to disconnect the call. Based on conversation with Moksh (STT team) confirming "goodbye" triggers call disconnect.
- **anext() noise suppression**: `RuntimeError: anext(): asynchronous generator is already running` errors on superseded processes are now caught and logged at debug level instead of propagating. These only affect earlier process_ids during teardown — the final process has its own generator and is unaffected.

Evidence: sessions `8e9ed2b0` and `824d97d5` from 2026-04-03 voice audit — 28 and 25 traces respectively, all from carrier hold messages looping.

## Test plan
- [x] 10 new test cases: hold message detection (Gujarati, English, Hindi transliteration, mixed) + negative cases (normal farmer queries)
- [x] All 74 existing tests pass
- [ ] Monitor Langfuse post-deploy: hold message sessions should have 1-2 traces max instead of 20+
- [ ] Verify anext() RuntimeErrors no longer appear in error logs (moved to debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)