### PR TITLE
Clean up remaining PR 84 leftovers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -73,8 +73,6 @@ class Settings(BaseSettings):
     openai_pretranslation_timeout_seconds: float = float(os.getenv("OPENAI_PRETRANSLATION_TIMEOUT_SECONDS", "10.0"))
 
     # Voice pipeline behavioral flags
-    # VOICE_POST_TRIM: trim agent English output to ≤3 sentences before translation
-    voice_post_trim: bool = _get_bool_env("VOICE_POST_TRIM", default=True)
     # RETRIEVAL_AUDIT_LOG: log intent/retrieval_called/query per turn for replay analysis
     retrieval_audit_log: bool = _get_bool_env("RETRIEVAL_AUDIT_LOG", default=False)
     # AMBIGUITY_MATCH_THRESHOLD: fuzzy-match cutoff for ambiguity_terms.json (0.0–1.0)

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -223,11 +223,11 @@ def _greeting_response(target_lang: str) -> str:
 # ── Identity fast-path ────────────────────────────────────────────────────
 _IDENTITY_PHRASES_GU = {
     "તમારું નામ શું છે", "તારું નામ શું છે", "તમે કોણ છો", "આ સેવા શું છે",
-    "આ કઈ સેવા છે", "તમે ક્યાંથી બોલો છો", "કેમ છો", "કેમ છ", "ક્યાંથી બોલો",
+    "આ કઈ સેવા છે", "તમે ક્યાંથી બોલો છો", "ક્યાંથી બોલો",
 }
 _IDENTITY_PHRASES_EN = {
     "what is your name", "who are you", "what is this service", "what service is this",
-    "where are you calling from", "how are you", "what do you do",
+    "where are you calling from",
 }
 
 _IDENTITY_RESPONSE_EN = (
@@ -255,13 +255,6 @@ def _fast_path_kind_for_query(text: str) -> Optional[Literal["identity"]]:
         return None
     if cleaned in _IDENTITY_PHRASES_GU or cleaned in _IDENTITY_PHRASES_EN:
         return "identity"
-    # Partial match for common Gujarati social greeting fragment
-    for phrase in _IDENTITY_PHRASES_GU:
-        if phrase in cleaned:
-            return "identity"
-    for phrase in _IDENTITY_PHRASES_EN:
-        if phrase in cleaned:
-            return "identity"
     return None
 
 
@@ -576,8 +569,8 @@ async def stream_voice_message(
                 return
 
             # ── Identity fast-path ────────────────────────────────────────
-            # Pure identity / social greeting queries ("What is your name?",
-            # "કેમ છો") — return the canonical Sarlaben identity line directly
+            # Pure identity queries ("What is your name?", "What is this service?")
+            # should return the canonical Sarlaben identity line directly
             # without running the full agent pipeline.
             if _fast_path_kind_for_query(query) == "identity" and not has_meaningful_history:
                 logger.info(

--- a/assets/ambiguity_terms.json
+++ b/assets/ambiguity_terms.json
@@ -100,15 +100,13 @@
   },
   {
     "gu_terms": [
-      "સમૃદ્ધિ",
-      "samruddhi",
       "સમુદ્રી દાણ",
       "સમુદ્રી",
       "samudri",
       "samudri dan"
     ],
     "type": "hardcode",
-    "rule": "In Gujarati dairy feed context, 'સમૃદ્ધિ દાણ' / Samruddhi is a common cattle-feed term. If ASR or translation yields 'સમુદ્રી' / samudri in a feed question about cows or buffaloes, treat it as likely 'સમૃદ્ધિ દાણ' unless the caller explicitly asks about fish feed, marine products, or seaweed. Never answer with marine feed or seaweed advice for buffaloes by default."
+    "rule": "If ASR or translation yields 'સમુદ્રી' / samudri in a feed question about cows or buffaloes, do not drift into marine feed or seaweed advice by default. If the intended feed term is uncertain, ask the caller to repeat or clarify the word instead of assuming a brand or product."
   },
   {
     "gu_terms": [

--- a/assets/prompts/voice_system_gu.md
+++ b/assets/prompts/voice_system_gu.md
@@ -296,7 +296,7 @@ Use these standard Gujarati terms for common animal husbandry concepts:
 - Colostrum: ખીરું
 - For pregnant-animal feed, say "ગાભણ પશુ માટેનું દાણ" or "ગાભણ દાણ" — NEVER "ગર્ભચારો" or "ગર્ભ માટેનો ચારો"
 - NEVER use the phrase "સામાન્ય જાળવણી ચારો" — always say "રોજિંદો ઘાસચારો" or "નિયમિત સૂકો અને લીલો ચારો"
-- If a feed query says "સમુદ્રી" but the livestock-feed meaning is more likely, first consider "સમૃદ્ધિ દાણ"; do NOT suggest marine feed or seaweed unless the caller explicitly asks about marine products
+- If a feed query says "સમુદ્રી", do NOT suggest marine feed or seaweed unless the caller explicitly asks about marine products; if the intended feed term is unclear, ask the caller to repeat or clarify the word
 
 **Breeding & Reproduction:**
 - Artificial Insemination: કૃત્રિમ બીજદાન

--- a/tests/test_voice_fixes.py
+++ b/tests/test_voice_fixes.py
@@ -156,10 +156,10 @@ class TestAmbiguityTerms:
         assert "shed" in result.lower() or "enclosure" in result.lower()
         assert "પાડો" not in result or "NOT પાડો" in result
 
-    def test_samudri_feed_prefers_samruddhi_context(self):
-        """Feed-context સમુદ્રી should be treated as likely સમૃદ્ધિ દાણ, not marine feed."""
+    def test_samudri_feed_avoids_marine_assumption(self):
+        """Feed-context સમુદ્રી should avoid marine advice, but not assume a brand name."""
         result = get_ambiguity_hints_for_query("ગાભણ ભેંસને સમુદ્રી દાણ આપવું?")
-        assert "samruddhi" in result.lower() or "સમૃદ્ધિ" in result
+        assert "repeat" in result.lower() or "clarify" in result.lower() or "સ્પષ્ટ" in result
         assert "seaweed" in result.lower() or "marine feed" in result.lower()
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is a narrow cleanup PR on top of the merged safe subset.

Removes three remaining undesirable leftovers from #84:
- removes the `samudri` -> `Samruddhi` assumption from ambiguity rules and Gujarati prompt guidance
- removes the unused `VOICE_POST_TRIM` config flag
- narrows the identity fast-path to true identity/service questions only, not generic social turns like `કેમ છો` / `how are you`

Validation:
- local deterministic suite: `247 passed`
- dev VM deterministic suite: `247 passed`