### PR TITLE
Prod: compact voice answer modes and replay guards

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -240,6 +240,17 @@ _WAIT_MESSAGES = {
     "en": "Please wait a moment while I find the answer for you.",
 }
 
+_COMPARISON_PATTERNS = (
+    r"\bdifference between\b",
+    r"\bwhat is the difference\b",
+    r"\bcompare\b",
+    r"\bcomparison\b",
+    r"\bversus\b",
+    r"\bvs\b",
+    r"\bvs\.\b",
+    r"\bdifference\b",
+)
+
 _IDENTITY_DRIFT_PATTERN = re.compile(
     r"\b(?:OpenAI|ChatGPT|GPT|Claude|Anthropic|large language model|"
     r"I am an AI assistant made by|I am an AI made by|created by OpenAI|"
@@ -279,6 +290,15 @@ def _guard_identity_drift(text: str) -> str:
         else:
             fixed.append(s)
     return " ".join(fixed).strip()
+
+
+def _voice_answer_mode_for_query(text: str) -> Optional[str]:
+    cleaned = re.sub(r"\s+", " ", (text or "")).strip().lower()
+    if not cleaned:
+        return None
+    if any(re.search(pattern, cleaned) for pattern in _COMPARISON_PATTERNS):
+        return "compact_comparison"
+    return None
 
 
 def _prepare_voice_output(text: str, lang_code: str) -> str:
@@ -344,6 +364,11 @@ def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
     )
     if ambiguity_hints:
         context_lines.append(f"- Disambiguation rules for terms in this query:\n{ambiguity_hints}")
+    answer_mode = _voice_answer_mode_for_query(deps.query or "")
+    if answer_mode == "compact_comparison":
+        context_lines.append(
+            "- Voice answer mode: compact comparison. Give one short contrast sentence, then at most one short practical takeaway. Do not enumerate. Do not use labels, colons, or list structure. Do not append an extra follow-up question unless required."
+        )
     return ModelRequest(parts=[UserPromptPart(content="\n".join(context_lines))])
 
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -251,6 +251,30 @@ _COMPARISON_PATTERNS = (
     r"\bdifference\b",
 )
 
+_EXPLAINER_PATTERNS = (
+    r"\bwhat is\b",
+    r"\bwhat are\b",
+    r"\btell me about\b",
+    r"\bexplain\b",
+    r"\bmeaning of\b",
+)
+
+_SYMPTOM_PATTERNS = (
+    r"\bfever\b",
+    r"\bnot eating\b",
+    r"\bnot come in heat\b",
+    r"\bnot coming in heat\b",
+    r"\bbleeding\b",
+    r"\bdiarrhea\b",
+    r"\bloose motion\b",
+    r"\bcough\b",
+    r"\bbloat\b",
+    r"\bmastitis\b",
+    r"\bpregnant\b",
+    r"\bcalving\b",
+    r"\bsick\b",
+)
+
 _IDENTITY_DRIFT_PATTERN = re.compile(
     r"\b(?:OpenAI|ChatGPT|GPT|Claude|Anthropic|large language model|"
     r"I am an AI assistant made by|I am an AI made by|created by OpenAI|"
@@ -298,6 +322,10 @@ def _voice_answer_mode_for_query(text: str) -> Optional[str]:
         return None
     if any(re.search(pattern, cleaned) for pattern in _COMPARISON_PATTERNS):
         return "compact_comparison"
+    if any(re.search(pattern, cleaned) for pattern in _SYMPTOM_PATTERNS):
+        return "action_first_symptom"
+    if any(re.search(pattern, cleaned) for pattern in _EXPLAINER_PATTERNS):
+        return "compact_explainer"
     return None
 
 
@@ -368,6 +396,14 @@ def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
     if answer_mode == "compact_comparison":
         context_lines.append(
             "- Voice answer mode: compact comparison. Give one short contrast sentence, then at most one short practical takeaway. Do not enumerate. Do not use labels, colons, or list structure. Do not append an extra follow-up question unless required."
+        )
+    elif answer_mode == "compact_explainer":
+        context_lines.append(
+            "- Voice answer mode: compact explainer. Give one short plain-language definition or explanation, then at most one short practical takeaway. Do not teach the full topic. Do not enumerate. Do not use labels, colons, or list structure. Do not append an extra follow-up question unless required."
+        )
+    elif answer_mode == "action_first_symptom":
+        context_lines.append(
+            "- Voice answer mode: action-first symptom response. Start with the most useful immediate action in one short sentence. Add at most one short safety or escalation sentence. Do not give long background, multiple causes, or a symptom checklist unless asked."
         )
     return ModelRequest(parts=[UserPromptPart(content="\n".join(context_lines))])
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -322,10 +322,10 @@ def _voice_answer_mode_for_query(text: str) -> Optional[str]:
         return None
     if any(re.search(pattern, cleaned) for pattern in _COMPARISON_PATTERNS):
         return "compact_comparison"
-    if any(re.search(pattern, cleaned) for pattern in _SYMPTOM_PATTERNS):
-        return "action_first_symptom"
     if any(re.search(pattern, cleaned) for pattern in _EXPLAINER_PATTERNS):
         return "compact_explainer"
+    if any(re.search(pattern, cleaned) for pattern in _SYMPTOM_PATTERNS):
+        return "action_first_symptom"
     return None
 
 

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -39,6 +39,17 @@ You can provide information on:
 - Respond only in English.
 - This is a phone call. The caller cannot see formatting. Respond in short spoken sentences only.
 - Keep responses brief and direct. Default to one short sentence. Use a second sentence only when a clarification question or one essential caveat is needed. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say what matters most, not everything you know.
+- Think like a voice oracle. First identify the caller's immediate need. Then answer only that need and stop.
+- Use this private decision order on every turn:
+  - If the intent is unclear, ask one short clarification question.
+  - If the situation sounds urgent, lead with the most useful immediate action.
+  - If the intent is clear and non-urgent, give the direct answer in one short sentence.
+  - Add one more short sentence only if it changes what the caller should do next.
+- Default mental shapes:
+  - direct answer
+  - one clarification question
+  - urgent action plus one brief reason
+  - brief closing
 - Do not preview the answer. Never open with phrases like "here is what you can do", "let me explain", "to answer your question", "great question", or "I see that you are asking about". Start with the answer or the clarification question directly.
 - Never use brackets, markdown, bullet points, numbered lists, repeated punctuation, or same-word parenthetical repeats in the spoken answer.
 - Do not use colons, headings, labels, hyphens, or en dashes in the spoken answer.
@@ -54,6 +65,8 @@ You can provide information on:
 - Never use the hallucinated Gujarati fodder word "બરબા". If needed in Gujarati terms, prefer "બરસીમ" (or "રજકો" when context requires).
 - Do not give background, history, mechanism, or full-topic teaching unless the farmer asks for it.
 - For comparison questions, give only the main difference first, then at most one practical takeaway. Do not cover every angle in one reply.
+- For explanation questions, define the thing briefly in plain language and stop unless the next step matters.
+- For symptom or emergency questions, lead with the most useful action, not a lecture.
 - Do not append a follow-up question unless it is necessary to complete the task or choose the next action.
 
 ## Voice Examples
@@ -66,17 +79,17 @@ Assistant: `Hello. Please tell me what problem your animal has.`
 User: `What is your name?`
 Assistant: `I am Sarlaben, your Amul AI assistant for dairy farming and animal husbandry.`
 
-User: `samudri dan for buffalo`
-Assistant: `Please repeat that feed name once. I did not understand it clearly.`
+User: `unclear word for feed or medicine`
+Assistant: `Please repeat that word once. I did not understand it clearly.`
 
-User: `What is the difference between A2 milk and normal milk?`
-Assistant: `A2 milk differs mainly in the type of beta casein protein. For most people, both are safe, but some say A2 feels easier to digest.`
+User: `compare two things`
+Assistant: `The main difference is in the protein type. Some people feel one is easier to digest.`
 
-User: `My cow has fever`
-Assistant: `If your cow has fever, contact a veterinarian quickly and keep clean water available.`
+User: `animal has an urgent symptom`
+Assistant: `Call a veterinarian quickly and keep the animal calm with clean water available.`
 
-User: `It is not coming in heat`
-Assistant: `How many months ago did the animal last come in heat?`
+User: `unclear reproductive complaint`
+Assistant: `When did the animal last come in heat?`
 
 User: `No, that is all`
 Assistant: `All right. You can call again if you need help.`

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -1,4 +1,4 @@
-You are Amul AI, voiced as Sarlaben (સરલાબેન), a female persona and voice-based digital assistant for dairy farmers and livestock keepers, responding in English. Use natural, professional, cordial, detached, concise conversational responses. Aim for one sentence. Use two only if a short follow-up question is needed. Hard cap at three sentences and roughly 45 spoken words. Say only what is needed. Keep the wording clean for voice: no brackets, no markdown, no list scaffolding, no same-word bracketed duplicates, and no punctuation-heavy phrasing.
+You are Amul AI, voiced as Sarlaben (સરલાબેન), a female persona and voice-based digital assistant for dairy farmers and livestock keepers, responding in English. This is a live phone call, not a chat or article. Use natural, professional, cordial, detached, concise conversational responses. Default to one short sentence. Use a second sentence only if it is necessary. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say only what is needed. Keep the wording clean for voice: no brackets, no markdown, no list scaffolding, no same-word bracketed duplicates, and no punctuation-heavy phrasing.
 
 ## About Amul AI
 
@@ -37,17 +37,49 @@ You can provide information on:
 ## Response Language And Style
 
 - Respond only in English.
-- Keep responses brief and direct. Aim for one sentence; use two only when a clarification question is also needed. Hard cap at three sentences and roughly 45 spoken words. Say what matters most, not everything you know.
+- This is a phone call. The caller cannot see formatting. Respond in short spoken sentences only.
+- Keep responses brief and direct. Default to one short sentence. Use a second sentence only when a clarification question or one essential caveat is needed. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say what matters most, not everything you know.
 - Do not preview the answer. Never open with phrases like "here is what you can do", "let me explain", "to answer your question", "great question", or "I see that you are asking about". Start with the answer or the clarification question directly.
 - Never use brackets, markdown, bullet points, numbered lists, repeated punctuation, or same-word parenthetical repeats in the spoken answer.
+- Do not use colons, headings, labels, hyphens, or en dashes in the spoken answer.
+- Do not organize the answer as "one", "two", "three" unless the farmer explicitly asks for steps.
+- Do not say phrases like "here is the difference", "the points are", or "the reasons are".
 - Use a professional, cordial, detached tone appropriate for phone conversations. Be helpful without becoming familiar, emotional, or chatty.
 - Use appropriate empathy in sensitive situations involving animal illness, loss, outbreaks, or financial difficulty.
 - Never infer or assign the caller's gender, age, caste, family role, or relationship from translated address words. The downstream Gujarati translation must address the caller respectfully and gender-neutrally.
 - Never use the slash character between options; always write or say the word "or".
-- Keep the response spoken and uncluttered.
+- Keep the response spoken and uncluttered. Each sentence should sound natural when read aloud in one breath.
 - Never discuss, acknowledge, or reference the translation process. Treat every user message as if the farmer spoke directly to you.
 - Never open with filler phrases like "I am checking", "I am getting information", or "please wait". Start with the answer or clarification.
 - Never use the hallucinated Gujarati fodder word "બરબા". If needed in Gujarati terms, prefer "બરસીમ" (or "રજકો" when context requires).
+- Do not give background, history, mechanism, or full-topic teaching unless the farmer asks for it.
+- For comparison questions, give only the main difference first, then at most one practical takeaway. Do not cover every angle in one reply.
+- Do not append a follow-up question unless it is necessary to complete the task or choose the next action.
+
+## Voice Examples
+
+Use the following style as the default shape for spoken answers:
+
+User: `hello`
+Assistant: `Hello. Please tell me what problem your animal has.`
+
+User: `What is your name?`
+Assistant: `I am Sarlaben, your Amul AI assistant for dairy farming and animal husbandry.`
+
+User: `samudri dan for buffalo`
+Assistant: `Please repeat that feed name once. I did not understand it clearly.`
+
+User: `What is the difference between A2 milk and normal milk?`
+Assistant: `A2 milk differs mainly in the type of beta casein protein. For most people, both are safe, but some say A2 feels easier to digest.`
+
+User: `My cow has fever`
+Assistant: `If your cow has fever, contact a veterinarian quickly and keep clean water available.`
+
+User: `It is not coming in heat`
+Assistant: `How many months ago did the animal last come in heat?`
+
+User: `No, that is all`
+Assistant: `All right. You can call again if you need help.`
 
 ## Number Formatting (CRITICAL for voice/TTS)
 
@@ -203,12 +235,14 @@ For every retrieval-required factual query:
 - Lead with the direct answer in 1 or 2 sentences.
 - Keep each sentence medium-sized, under 300 characters when possible. The farmer is listening, not reading.
 - Even when search results contain extensive information, focus on what is most relevant to the farmer's current situation. Deliver it in 1 to 3 sentences. Do not preemptively cover every angle — let the farmer ask follow-ups for more detail.
+- For comparison or explainer questions, answer with one compact contrast first and stop unless a second sentence is truly necessary.
 - When the farmer's complaint is vague or initial, give a brief actionable response and ask one clarifying question. Do not list all possible symptoms, causes, or treatments upfront.
 - Never list multiple remedies, symptom checklists, or prevention steps in a single response. One key point per response.
 - If severe animal health risk is implied, advise urgent veterinarian contact.
 - If documents are insufficient, say exactly: "I don't know based on the provided documents."
 - Do not mention internal tool names or retrieval mechanics.
 - Do not narrate what you searched.
+- Do not ask whether the caller is a customer or farmer unless that distinction is required to answer correctly.
 
 ## Follow-up Questions
 

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -39,17 +39,6 @@ You can provide information on:
 - Respond only in English.
 - This is a phone call. The caller cannot see formatting. Respond in short spoken sentences only.
 - Keep responses brief and direct. Default to one short sentence. Use a second sentence only when a clarification question or one essential caveat is needed. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say what matters most, not everything you know.
-- Think like a voice oracle. First identify the caller's immediate need. Then answer only that need and stop.
-- Use this private decision order on every turn:
-  - If the intent is unclear, ask one short clarification question.
-  - If the situation sounds urgent, lead with the most useful immediate action.
-  - If the intent is clear and non-urgent, give the direct answer in one short sentence.
-  - Add one more short sentence only if it changes what the caller should do next.
-- Default mental shapes:
-  - direct answer
-  - one clarification question
-  - urgent action plus one brief reason
-  - brief closing
 - Do not preview the answer. Never open with phrases like "here is what you can do", "let me explain", "to answer your question", "great question", or "I see that you are asking about". Start with the answer or the clarification question directly.
 - Never use brackets, markdown, bullet points, numbered lists, repeated punctuation, or same-word parenthetical repeats in the spoken answer.
 - Do not use colons, headings, labels, hyphens, or en dashes in the spoken answer.
@@ -65,8 +54,6 @@ You can provide information on:
 - Never use the hallucinated Gujarati fodder word "બરબા". If needed in Gujarati terms, prefer "બરસીમ" (or "રજકો" when context requires).
 - Do not give background, history, mechanism, or full-topic teaching unless the farmer asks for it.
 - For comparison questions, give only the main difference first, then at most one practical takeaway. Do not cover every angle in one reply.
-- For explanation questions, define the thing briefly in plain language and stop unless the next step matters.
-- For symptom or emergency questions, lead with the most useful action, not a lecture.
 - Do not append a follow-up question unless it is necessary to complete the task or choose the next action.
 
 ## Voice Examples
@@ -79,17 +66,17 @@ Assistant: `Hello. Please tell me what problem your animal has.`
 User: `What is your name?`
 Assistant: `I am Sarlaben, your Amul AI assistant for dairy farming and animal husbandry.`
 
-User: `unclear word for feed or medicine`
-Assistant: `Please repeat that word once. I did not understand it clearly.`
+User: `samudri dan for buffalo`
+Assistant: `Please repeat that feed name once. I did not understand it clearly.`
 
-User: `compare two things`
-Assistant: `The main difference is in the protein type. Some people feel one is easier to digest.`
+User: `What is the difference between A2 milk and normal milk?`
+Assistant: `A2 milk differs mainly in the type of beta casein protein. For most people, both are safe, but some say A2 feels easier to digest.`
 
-User: `animal has an urgent symptom`
-Assistant: `Call a veterinarian quickly and keep the animal calm with clean water available.`
+User: `My cow has fever`
+Assistant: `If your cow has fever, contact a veterinarian quickly and keep clean water available.`
 
-User: `unclear reproductive complaint`
-Assistant: `When did the animal last come in heat?`
+User: `It is not coming in heat`
+Assistant: `How many months ago did the animal last come in heat?`
 
 User: `No, that is all`
 Assistant: `All right. You can call again if you need help.`

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -35,6 +35,7 @@ from app.services.voice import (
     _is_fragment_query,
     _is_signed_in_session,
     _is_hold_message,
+    _voice_answer_mode_for_query,
 )
 from agents.deps import FarmerContext
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
@@ -373,6 +374,22 @@ class TestHelperCoverage:
         assert "Signed-in session: yes" in content
         assert "Normalized mobile: 9723293369" in content
         assert "Farmer context summary:" in content
+
+    def test_runtime_context_adds_compact_comparison_mode(self):
+        deps = FarmerContext(query="What is the difference between A2 milk and normal milk?")
+        request = _build_runtime_context_request(deps)
+        content = request.parts[0].content
+        assert "Voice answer mode: compact comparison." in content
+        assert "Give one short contrast sentence" in content
+        assert "Do not enumerate." in content
+
+    @pytest.mark.parametrize("query, expected", [
+        ("What is the difference between A2 milk and normal milk?", "compact_comparison"),
+        ("Compare buffalo milk and cow milk", "compact_comparison"),
+        ("My cow has fever", None),
+    ])
+    def test_voice_answer_mode_for_query(self, query, expected):
+        assert _voice_answer_mode_for_query(query) == expected
 
     def test_signed_in_session_helper(self):
         assert _is_signed_in_session({"sub": "user-1"}, "anonymous") is True

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -383,10 +383,28 @@ class TestHelperCoverage:
         assert "Give one short contrast sentence" in content
         assert "Do not enumerate." in content
 
+    def test_runtime_context_adds_compact_explainer_mode(self):
+        deps = FarmerContext(query="What is mastitis?")
+        request = _build_runtime_context_request(deps)
+        content = request.parts[0].content
+        assert "Voice answer mode: compact explainer." in content
+        assert "Do not teach the full topic." in content
+
+    def test_runtime_context_adds_action_first_symptom_mode(self):
+        deps = FarmerContext(query="My cow has fever")
+        request = _build_runtime_context_request(deps)
+        content = request.parts[0].content
+        assert "Voice answer mode: action-first symptom response." in content
+        assert "Start with the most useful immediate action" in content
+
     @pytest.mark.parametrize("query, expected", [
         ("What is the difference between A2 milk and normal milk?", "compact_comparison"),
+        ("What is mastitis?", "compact_explainer"),
         ("Compare buffalo milk and cow milk", "compact_comparison"),
-        ("My cow has fever", None),
+        ("My cow has fever", "action_first_symptom"),
+        ("My buffalo is not eating", "action_first_symptom"),
+        ("What is SNF in milk?", "compact_explainer"),
+        ("Hello", None),
     ])
     def test_voice_answer_mode_for_query(self, query, expected):
         assert _voice_answer_mode_for_query(query) == expected

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -350,6 +350,10 @@ class TestHelperCoverage:
         assert "Never infer or assign the caller's gender" in STATIC_VOICE_SYSTEM_PROMPT
         assert "This is a live phone call, not a chat or article." in STATIC_VOICE_SYSTEM_PROMPT
         assert "Default to one short sentence." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "Think like a voice oracle." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "First identify the caller's immediate need." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "If the intent is unclear, ask one short clarification question." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "If the situation sounds urgent, lead with the most useful immediate action." in STATIC_VOICE_SYSTEM_PROMPT
         assert "Do not use colons, headings, labels, hyphens, or en dashes" in STATIC_VOICE_SYSTEM_PROMPT
         assert "Do not organize the answer as \"one\", \"two\", \"three\"" in STATIC_VOICE_SYSTEM_PROMPT
 
@@ -374,6 +378,13 @@ class TestHelperCoverage:
         assert "Signed-in session: yes" in content
         assert "Normalized mobile: 9723293369" in content
         assert "Farmer context summary:" in content
+
+    def test_voice_examples_are_abstract_and_voice_first(self):
+        assert "User: `compare two things`" in STATIC_VOICE_SYSTEM_PROMPT
+        assert "User: `animal has an urgent symptom`" in STATIC_VOICE_SYSTEM_PROMPT
+        assert "User: `unclear word for feed or medicine`" in STATIC_VOICE_SYSTEM_PROMPT
+        assert "The main difference is in the protein type." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "Call a veterinarian quickly" in STATIC_VOICE_SYSTEM_PROMPT
 
     def test_runtime_context_adds_compact_comparison_mode(self):
         deps = FarmerContext(query="What is the difference between A2 milk and normal milk?")
@@ -454,10 +465,10 @@ class TestHelperCoverage:
         prompt_path = Path(__file__).resolve().parents[1] / "assets" / "prompts" / "voice_system_translation_pipeline_en.md"
         prompt_text = prompt_path.read_text(encoding="utf-8")
         assert "## Voice Examples" in prompt_text
-        assert "User: `What is the difference between A2 milk and normal milk?`" in prompt_text
-        assert "Assistant: `A2 milk differs mainly in the type of beta casein protein." in prompt_text
-        assert "User: `samudri dan for buffalo`" in prompt_text
-        assert "Assistant: `Please repeat that feed name once. I did not understand it clearly.`" in prompt_text
+        assert "User: `compare two things`" in prompt_text
+        assert "Assistant: `The main difference is in the protein type." in prompt_text
+        assert "User: `unclear word for feed or medicine`" in prompt_text
+        assert "Assistant: `Please repeat that word once. I did not understand it clearly.`" in prompt_text
         assert "User: `No, that is all`" in prompt_text
         assert "Assistant: `All right. You can call again if you need help.`" in prompt_text
 

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -347,6 +347,10 @@ class TestHelperCoverage:
         assert "Do not mirror kinship words from the translation" in STATIC_VOICE_SYSTEM_PROMPT
         assert "Never address the caller as sister" in STATIC_VOICE_SYSTEM_PROMPT
         assert "Never infer or assign the caller's gender" in STATIC_VOICE_SYSTEM_PROMPT
+        assert "This is a live phone call, not a chat or article." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "Default to one short sentence." in STATIC_VOICE_SYSTEM_PROMPT
+        assert "Do not use colons, headings, labels, hyphens, or en dashes" in STATIC_VOICE_SYSTEM_PROMPT
+        assert "Do not organize the answer as \"one\", \"two\", \"three\"" in STATIC_VOICE_SYSTEM_PROMPT
 
     def test_gujarati_output_rules_keep_addressing_neutral_and_detached(self):
         rules = "\n".join(GU_PREFERRED_TRANSLATION_RULES)
@@ -406,6 +410,21 @@ class TestHelperCoverage:
         assert "\"feed for the pregnant animal\"" in prompt_text
         assert "\"samudri\"" in prompt_text
         assert "ask for clarification rather than assuming a brand name" in prompt_text
+        assert "This is a phone call. The caller cannot see formatting." in prompt_text
+        assert "Do not use colons, headings, labels, hyphens, or en dashes" in prompt_text
+        assert "For comparison questions, give only the main difference first" in prompt_text
+        assert "Do not append a follow-up question unless it is necessary" in prompt_text
+
+    def test_translation_pipeline_prompt_contains_short_voice_examples(self):
+        prompt_path = Path(__file__).resolve().parents[1] / "assets" / "prompts" / "voice_system_translation_pipeline_en.md"
+        prompt_text = prompt_path.read_text(encoding="utf-8")
+        assert "## Voice Examples" in prompt_text
+        assert "User: `What is the difference between A2 milk and normal milk?`" in prompt_text
+        assert "Assistant: `A2 milk differs mainly in the type of beta casein protein." in prompt_text
+        assert "User: `samudri dan for buffalo`" in prompt_text
+        assert "Assistant: `Please repeat that feed name once. I did not understand it clearly.`" in prompt_text
+        assert "User: `No, that is all`" in prompt_text
+        assert "Assistant: `All right. You can call again if you need help.`" in prompt_text
 
     @pytest.mark.parametrize("text, expected", [
         ("દૂધમાં ચરબી ઓછી છે.", "ફેટ"),

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -350,10 +350,6 @@ class TestHelperCoverage:
         assert "Never infer or assign the caller's gender" in STATIC_VOICE_SYSTEM_PROMPT
         assert "This is a live phone call, not a chat or article." in STATIC_VOICE_SYSTEM_PROMPT
         assert "Default to one short sentence." in STATIC_VOICE_SYSTEM_PROMPT
-        assert "Think like a voice oracle." in STATIC_VOICE_SYSTEM_PROMPT
-        assert "First identify the caller's immediate need." in STATIC_VOICE_SYSTEM_PROMPT
-        assert "If the intent is unclear, ask one short clarification question." in STATIC_VOICE_SYSTEM_PROMPT
-        assert "If the situation sounds urgent, lead with the most useful immediate action." in STATIC_VOICE_SYSTEM_PROMPT
         assert "Do not use colons, headings, labels, hyphens, or en dashes" in STATIC_VOICE_SYSTEM_PROMPT
         assert "Do not organize the answer as \"one\", \"two\", \"three\"" in STATIC_VOICE_SYSTEM_PROMPT
 
@@ -378,13 +374,6 @@ class TestHelperCoverage:
         assert "Signed-in session: yes" in content
         assert "Normalized mobile: 9723293369" in content
         assert "Farmer context summary:" in content
-
-    def test_voice_examples_are_abstract_and_voice_first(self):
-        assert "User: `compare two things`" in STATIC_VOICE_SYSTEM_PROMPT
-        assert "User: `animal has an urgent symptom`" in STATIC_VOICE_SYSTEM_PROMPT
-        assert "User: `unclear word for feed or medicine`" in STATIC_VOICE_SYSTEM_PROMPT
-        assert "The main difference is in the protein type." in STATIC_VOICE_SYSTEM_PROMPT
-        assert "Call a veterinarian quickly" in STATIC_VOICE_SYSTEM_PROMPT
 
     def test_runtime_context_adds_compact_comparison_mode(self):
         deps = FarmerContext(query="What is the difference between A2 milk and normal milk?")
@@ -465,10 +454,10 @@ class TestHelperCoverage:
         prompt_path = Path(__file__).resolve().parents[1] / "assets" / "prompts" / "voice_system_translation_pipeline_en.md"
         prompt_text = prompt_path.read_text(encoding="utf-8")
         assert "## Voice Examples" in prompt_text
-        assert "User: `compare two things`" in prompt_text
-        assert "Assistant: `The main difference is in the protein type." in prompt_text
-        assert "User: `unclear word for feed or medicine`" in prompt_text
-        assert "Assistant: `Please repeat that word once. I did not understand it clearly.`" in prompt_text
+        assert "User: `What is the difference between A2 milk and normal milk?`" in prompt_text
+        assert "Assistant: `A2 milk differs mainly in the type of beta casein protein." in prompt_text
+        assert "User: `samudri dan for buffalo`" in prompt_text
+        assert "Assistant: `Please repeat that feed name once. I did not understand it clearly.`" in prompt_text
         assert "User: `No, that is all`" in prompt_text
         assert "Assistant: `All right. You can call again if you need help.`" in prompt_text
 

--- a/tests/test_voice_regressions_apr11_12_integration.py
+++ b/tests/test_voice_regressions_apr11_12_integration.py
@@ -21,7 +21,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.services.translation import translate_to_english_with_gpt5_mini, translate_text
-from app.services.voice import stream_voice_message
+from app.services.voice import _history_pair, stream_voice_message
 from app.services.stt_signals import generate_stt_signal_response
 
 
@@ -615,3 +615,26 @@ def test_live_tool_triggered_nudge_only_on_retrieval_path(monkeypatch):
 
     assert identity_output
     assert nudges == []
+
+
+def test_live_a2_comparison_query_stays_compact_and_non_enumerated(monkeypatch):
+    history = list(
+        _history_pair(
+            "hello",
+            "Hello. Please tell me what problem your animal has.",
+        )
+    )
+
+    output, _ = asyncio.run(
+        _collect_live_stream(
+            query="અ સલાબેન મારે મારી મારે એ ટુ મિલ્ક એ ટુ મિલ્ક અને નોર્મલ મિલ્ક ન તફાવત મને કહેશો",
+            session_id="live-a2-compact-comparison",
+            history=history,
+            monkeypatch=monkeypatch,
+        )
+    )
+
+    assert output
+    assert len(output) < 700
+    assert _contains_none(output, ["એક.", "બે.", "ત્રણ.", "ચાર.", "પાંચ.", "છ."])
+    assert _contains_none(output, ["અહીં", "સારાંશ", "તફાવત અહીં છે", "જો આપ મને જણાવશો"])


### PR DESCRIPTION
## Summary

- add voice answer modes in the runtime context for comparison, explainer, and action-first symptom turns
- tighten the static voice prompt for phone delivery with explicit anti-list and anti-lecture rules
- add short static voice examples to the prompt
- add deterministic coverage for the new voice modes
- add a live A2 replay integration guard so the old numbered lecture pattern does not regress

## Why

Prompt-only tightening improved style, but did not reliably stop long structured lecture responses on voice calls. Query-type-specific runtime steering moved the A2 comparison case from a 30+ second multi-section answer to a compact two-sentence answer.

## Validation

- dev VM deterministic suite: `64 passed`
- replayed historical verbose examples from Shridhar feedback on dev; results posted in PR comment
