### PR TITLE
Prod: tighten structural batching and non-blocking farmer cache

### DIFF
--- a/agents/models/farmer.py
+++ b/agents/models/farmer.py
@@ -54,15 +54,34 @@ class FarmerDataEnvelope(BaseModel):
     farmers: List[FarmerRecord] = []
     fetchedAt: Optional[str] = None
     source: Optional[str] = None  # "cache" | "api"
+    stale: bool = False
+    staleReason: Optional[str] = None
+    refreshAfter: Optional[str] = None
+    lookupStatus: Optional[str] = None  # "found" | "not_found"
 
     @classmethod
-    def from_records(cls, records: list, source: str = "api") -> "FarmerDataEnvelope":
+    def from_records(
+        cls,
+        records: list,
+        source: str = "api",
+        lookup_status: str = "found",
+    ) -> "FarmerDataEnvelope":
         """Create envelope from raw record dicts."""
         farmers = [FarmerRecord.model_validate(r) if isinstance(r, dict) else r for r in records]
         return cls(
             farmers=farmers,
             fetchedAt=datetime.now(timezone.utc).isoformat(),
             source=source,
+            lookupStatus=lookup_status,
+        )
+
+    @classmethod
+    def not_found(cls, source: str = "api") -> "FarmerDataEnvelope":
+        return cls(
+            farmers=[],
+            fetchedAt=datetime.now(timezone.utc).isoformat(),
+            source=source,
+            lookupStatus="not_found",
         )
 
     def to_summary(self) -> FarmerSummary:

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -1,27 +1,52 @@
 """
 Cache layer for farmer data fetched from PashuGPT APIs.
-Uses Redis (via aiocache) with 24h TTL. Cache key is a SHA-256 hash of the
-normalized phone number so raw phone numbers don't appear as Redis keys.
 
-Both backends share the same Redis instance and prefix (sva-cache-), so a
-farmer cached by the chat service is available to voice and vice versa.
+Voice reads farmer context from Redis only. Freshness is controlled separately
+from key expiry:
+- refresh interval: 24h
+- cache retention: 7d
+
+This lets the request path return cached data immediately, mark it stale in the
+read result, and schedule a background refresh without blocking the caller.
 """
 import hashlib
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from app.core.cache import cache
+from app.core.cache import cache, redis_client, build_cache_key
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
 
-FARMER_CACHE_TTL = 60 * 60 * 24  # 24 hours
+FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days retention in Redis
+FARMER_REFRESH_INTERVAL = 60 * 60 * 24  # refresh once a day
+FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
 FARMER_CACHE_NAMESPACE = "farmer"
+FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
 
 
 def _cache_key(phone: str) -> str:
     """Build cache key from phone number hash."""
     return hashlib.sha256(phone.encode()).hexdigest()
+
+
+def _refresh_lock_key(phone: str) -> str:
+    return build_cache_key(_cache_key(phone), namespace=FARMER_REFRESH_LOCK_NAMESPACE)
+
+
+def _compute_freshness(envelope: FarmerDataEnvelope) -> tuple[bool, Optional[str], Optional[str]]:
+    if not envelope.fetchedAt:
+        return True, "missing_fetched_at", None
+    try:
+        fetched_at = datetime.fromisoformat(envelope.fetchedAt.replace("Z", "+00:00"))
+    except ValueError:
+        return True, "invalid_fetched_at", None
+
+    refresh_after = fetched_at + timedelta(seconds=FARMER_REFRESH_INTERVAL)
+    refresh_after_iso = refresh_after.astimezone(timezone.utc).isoformat()
+    is_stale = datetime.now(timezone.utc) >= refresh_after.astimezone(timezone.utc)
+    return is_stale, ("expired" if is_stale else None), refresh_after_iso
 
 
 async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
@@ -32,6 +57,8 @@ async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         if raw and isinstance(raw, dict):
             envelope = FarmerDataEnvelope.model_validate(raw)
             envelope.source = "cache"
+            envelope.lookupStatus = envelope.lookupStatus or ("found" if envelope.farmers else "not_found")
+            envelope.stale, envelope.staleReason, envelope.refreshAfter = _compute_freshness(envelope)
             return envelope
     except Exception as e:
         logger.warning(f"Failed to read farmer cache for phone hash {key[:8]}...: {e}")
@@ -51,15 +78,52 @@ async def set_cached_farmer_data(phone: str, data: FarmerDataEnvelope) -> None:
 from agents.tools.farmer import fetch_farmer_info_raw
 
 
+async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
+    """
+    Refresh farmer data from upstream APIs and update Redis.
+    Returns the refreshed envelope or None on refresh failure.
+    """
+    lock_key = _refresh_lock_key(phone)
+    acquired = False
+    try:
+        acquired = await redis_client.set(lock_key, "1", ex=FARMER_REFRESH_LOCK_TTL, nx=True)
+        if not acquired:
+            logger.debug("Farmer refresh already in flight for phone hash %s...", _cache_key(phone)[:8])
+            return None
+
+        records = await fetch_farmer_info_raw(phone)
+        if records:
+            envelope = FarmerDataEnvelope.from_records(records, source="api", lookup_status="found")
+        else:
+            envelope = FarmerDataEnvelope.not_found(source="api")
+        await set_cached_farmer_data(phone, envelope)
+        return envelope
+    except Exception as e:
+        logger.warning("Farmer refresh failed for phone hash %s...: %s", _cache_key(phone)[:8], e)
+        return None
+    finally:
+        if acquired:
+            try:
+                await redis_client.delete(lock_key)
+            except Exception:
+                pass
+
+
+async def get_farmer_data_cached_only(phone: str) -> Optional[FarmerDataEnvelope]:
+    """Read farmer context from Redis only; never block on upstream APIs."""
+    return await get_cached_farmer_data(phone)
+
+
+def should_refresh_farmer_data(envelope: Optional[FarmerDataEnvelope]) -> bool:
+    if envelope is None:
+        return True
+    return envelope.stale
+
+
 async def get_or_fetch_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
-    """Cache-first farmer data retrieval. Check Redis, else fetch from APIs and cache."""
+    """Legacy cache-first retrieval. Prefer cached-only reads on the voice path."""
     cached = await get_cached_farmer_data(phone)
     if cached:
         return cached
 
-    records = await fetch_farmer_info_raw(phone)
-    if records:
-        envelope = FarmerDataEnvelope.from_records(records, source="api")
-        await set_cached_farmer_data(phone, envelope)
-        return envelope
-    return None
+    return await refresh_farmer_data(phone)

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -14,7 +14,11 @@ from pydantic_ai.usage import UsageLimits
 
 from agents.voice import voice_agent, voice_agent_signed_in
 from agents.tools.farmer import normalize_phone_to_mobile
-from agents.services.farmer_cache import get_or_fetch_farmer_data
+from agents.services.farmer_cache import (
+    get_farmer_data_cached_only,
+    refresh_farmer_data,
+    should_refresh_farmer_data,
+)
 from agents.tools.common import (
     get_timeout_nudge_message,
     get_tool_nudge_message,
@@ -57,7 +61,7 @@ logger = get_logger(__name__)
 
 class SentenceSegmenter:
     sep = 'ŽžŽžSentenceSeparatorŽžŽž'
-    latin_terminals = '!?.'
+    latin_terminals = '!?.:;'
     jap_zh_terminals = '。！？'
     terminals = latin_terminals + jap_zh_terminals
 
@@ -76,15 +80,64 @@ class SentenceSegmenter:
 
 
 sentence_segmenter = SentenceSegmenter()
+VOICE_TRANSLATION_BATCH_CHAR_LIMIT = 600
+VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS = 180
 
 
 def extract_complete_sentences(text: str):
     if not text:
         return [], ""
+    structural_match = re.search(r"\n(?=(?:#{1,6}\s|[-*•]\s|\d+\.\s))", text)
+    if structural_match:
+        split_at = structural_match.start()
+        head = text[:split_at].rstrip()
+        tail = text[split_at:].lstrip()
+        if head:
+            return [head], tail
     sentences = sentence_segmenter(text)
     if len(sentences) <= 1:
         return [], text
     return sentences[:-1], sentences[-1]
+
+
+def _split_voice_batch_text(text: str, max_chars: int = VOICE_TRANSLATION_BATCH_CHAR_LIMIT) -> tuple[str, str]:
+    if len(text) <= max_chars:
+        return text, ""
+
+    window = text[:max_chars]
+    split_at = -1
+    for pattern in ("\n\n", "\n", ". ", "? ", "! ", ": ", "; ", "। ", "。 "):
+        idx = window.rfind(pattern)
+        if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
+            split_at = idx + len(pattern.rstrip())
+            break
+
+    if split_at < 0:
+        idx = window.rfind(" ")
+        if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
+            split_at = idx
+
+    if split_at < 0:
+        split_at = max_chars
+
+    return text[:split_at].rstrip(), text[split_at:].lstrip()
+
+
+def extract_translation_units(text: str):
+    if not text:
+        return [], ""
+
+    ready_sentences, remaining = extract_complete_sentences(text)
+    ready_units = [unit for unit in ready_sentences if unit and unit.strip()]
+
+    while remaining and len(remaining) >= VOICE_TRANSLATION_BATCH_CHAR_LIMIT:
+        head, tail = _split_voice_batch_text(remaining)
+        if not head or head == remaining:
+            break
+        ready_units.append(head)
+        remaining = tail
+
+    return ready_units, remaining
 
 
 def _batch_starts_new_line_or_list(text: str) -> bool:
@@ -374,6 +427,14 @@ def _is_signed_in_session(user_info: Optional[dict], user_id: str) -> bool:
     return bool(user_info)
 
 
+async def get_or_fetch_farmer_data(mobile: str):
+    """
+    Backward-compatible alias for tests and callers that still patch the old symbol.
+    Voice request flow now uses Redis-only reads from this alias.
+    """
+    return await get_farmer_data_cached_only(mobile)
+
+
 def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
     tool_groups = ["retrieval", "booking"]
     if deps.signed_in and deps.mobile:
@@ -432,7 +493,10 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
     lines = [
         f"- Farmer records matched: {len(envelope.farmers)}",
         f"- Farmer data source: {envelope.source or 'unknown'}",
+        f"- Farmer cache state: {'stale' if envelope.stale else 'fresh'}",
     ]
+    if envelope.refreshAfter:
+        lines.append(f"- Farmer refresh after: {envelope.refreshAfter}")
     if first.farmerName:
         lines.append(f"- Farmer name: {first.farmerName}")
     if societies:
@@ -470,6 +534,8 @@ def should_translate_batch(
         return ends_sentence and word_count >= 3
 
     # Phase 2: subsequent batches — balance quality vs latency.
+    if len(batch_text) >= VOICE_TRANSLATION_BATCH_CHAR_LIMIT:
+        return True
     if word_count >= 40:
         return True  # force flush, don't hoard
 
@@ -747,6 +813,14 @@ async def stream_voice_message(
             processing_lang = "en"
             pretranslation_confidence = "unknown"
             history_user_text = query
+            mobile = normalize_phone_to_mobile(user_id)
+            signed_in = _is_signed_in_session(user_info, user_id)
+            farmer_info = ""
+            farmer_cache_task = (
+                asyncio.create_task(get_or_fetch_farmer_data(mobile))
+                if mobile
+                else None
+            )
 
             if requested_source_lang not in {"en", "english"}:
                 logger.info(
@@ -812,19 +886,25 @@ async def stream_voice_message(
                 yield _prepare_voice_output(low_conf_resp_for_caller, requested_target_lang)
                 return
 
-            mobile = normalize_phone_to_mobile(user_id)
-            signed_in = _is_signed_in_session(user_info, user_id)
-            farmer_info = ""
-            if mobile:
+            if farmer_cache_task is not None:
                 try:
-                    envelope = await get_or_fetch_farmer_data(mobile)
+                    envelope = await farmer_cache_task
                     farmer_info = _build_compact_farmer_summary(envelope)
                     logger.info(
-                        "Farmer summary loaded for mobile %s source=%s summary_chars=%s",
+                        "Farmer summary loaded from cache for mobile %s source=%s stale=%s summary_chars=%s",
                         mobile,
-                        getattr(envelope, "source", None),
+                        getattr(envelope, "source", None) if envelope else None,
+                        getattr(envelope, "stale", None) if envelope else None,
                         len(farmer_info),
                     )
+                    if mobile and should_refresh_farmer_data(envelope):
+                        asyncio.create_task(refresh_farmer_data(mobile))
+                        logger.info(
+                            "Farmer cache refresh scheduled in background for mobile %s stale=%s status=%s",
+                            mobile,
+                            getattr(envelope, "stale", None) if envelope else None,
+                            getattr(envelope, "lookupStatus", None) if envelope else None,
+                        )
                 except Exception as e:
                     logger.warning(f"Failed to load farmer summary for mobile {mobile}: {e}")
 
@@ -948,11 +1028,11 @@ async def stream_voice_message(
                             continue
 
                         sentence_buffer += chunk
-                        complete_sentences, remaining = extract_complete_sentences(sentence_buffer)
-                        if complete_sentences:
-                            for sentence in complete_sentences:
-                                translation_batch.append(sentence)
-                                batch_word_count += len(sentence.split())
+                        ready_units, remaining = extract_translation_units(sentence_buffer)
+                        if ready_units:
+                            for unit in ready_units:
+                                translation_batch.append(unit)
+                                batch_word_count += len(unit.split())
 
                             batch_text = "".join(translation_batch)
                             if should_translate_batch(batch_text, batch_word_count, is_first_batch=not first_text_chunk_received):

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -87,6 +87,13 @@ VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS = 180
 def extract_complete_sentences(text: str):
     if not text:
         return [], ""
+    inline_structural_match = re.search(r"(?=\s#{1,6}\s)|(?=\n#{1,6}\s)|(?=\n\d+\.\s)|(?=\n[-*•]\s)", text)
+    if inline_structural_match and inline_structural_match.start() > 0:
+        split_at = inline_structural_match.start()
+        head = text[:split_at].rstrip()
+        tail = text[split_at:].lstrip()
+        if head:
+            return [head], tail
     structural_match = re.search(r"\n(?=(?:#{1,6}\s|[-*•]\s|\d+\.\s))", text)
     if structural_match:
         split_at = structural_match.start()
@@ -106,19 +113,30 @@ def _split_voice_batch_text(text: str, max_chars: int = VOICE_TRANSLATION_BATCH_
 
     window = text[:max_chars]
     split_at = -1
-    for pattern in ("\n\n", "\n", ". ", "? ", "! ", ": ", "; ", "। ", "。 "):
+    for pattern in ("\n\n", "\n", ". ", "? ", "! ", ": ", "; ", "। ", "。 ", "### ", "## ", "# "):
         idx = window.rfind(pattern)
         if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
             split_at = idx + len(pattern.rstrip())
             break
 
     if split_at < 0:
-        idx = window.rfind(" ")
-        if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
-            split_at = idx
+        structural_markers = (
+            r"\n(?=#{1,6}\s)",
+            r"\n(?=\d+\.\s)",
+            r"\n(?=[-*•]\s)",
+            r"(?<=:)\s+",
+            r"(?<=;)\s+",
+        )
+        for pattern in structural_markers:
+            matches = list(re.finditer(pattern, window))
+            if matches:
+                idx = matches[-1].start()
+                if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
+                    split_at = idx
+                    break
 
     if split_at < 0:
-        split_at = max_chars
+        return text, ""
 
     return text[:split_at].rstrip(), text[split_at:].lstrip()
 
@@ -1031,34 +1049,47 @@ async def stream_voice_message(
                         ready_units, remaining = extract_translation_units(sentence_buffer)
                         if ready_units:
                             for unit in ready_units:
-                                translation_batch.append(unit)
-                                batch_word_count += len(unit.split())
+                                candidate_units = [unit]
+                                if len(unit) >= VOICE_TRANSLATION_BATCH_CHAR_LIMIT:
+                                    candidate_units = []
+                                    remaining_unit = unit
+                                    while remaining_unit:
+                                        head, tail = _split_voice_batch_text(remaining_unit)
+                                        if not tail or head == remaining_unit:
+                                            candidate_units.append(remaining_unit)
+                                            break
+                                        candidate_units.append(head)
+                                        remaining_unit = tail
 
-                            batch_text = "".join(translation_batch)
-                            if should_translate_batch(batch_text, batch_word_count, is_first_batch=not first_text_chunk_received):
-                                async for translated_chunk in _yield_translated_text(batch_text):
-                                    if (
-                                        not first_text_chunk_received
-                                        and isinstance(translated_chunk, str)
-                                        and translated_chunk
-                                        and translated_chunk.strip()
-                                    ):
-                                        first_text_chunk_received = True
-                                        if nudge_task: nudge_task.cancel()
-                                        logger.info(
-                                            "Nudge canceled (first translated chunk received); session_id=%s process_id=%s",
-                                            session_id,
-                                            process_id,
-                                        )
-                                        try:
-                                            await nudge_task
-                                        except asyncio.CancelledError:
-                                            pass
-                                    if await _request_is_stale("before_translated_yield"):
-                                        break
-                                    yield translated_chunk
-                                translation_batch = []
-                                batch_word_count = 0
+                                for candidate in candidate_units:
+                                    translation_batch.append(candidate)
+                                    batch_word_count += len(candidate.split())
+                                    batch_text = "".join(translation_batch)
+
+                                    if should_translate_batch(batch_text, batch_word_count, is_first_batch=not first_text_chunk_received):
+                                        async for translated_chunk in _yield_translated_text(batch_text):
+                                            if (
+                                                not first_text_chunk_received
+                                                and isinstance(translated_chunk, str)
+                                                and translated_chunk
+                                                and translated_chunk.strip()
+                                            ):
+                                                first_text_chunk_received = True
+                                                if nudge_task: nudge_task.cancel()
+                                                logger.info(
+                                                    "Nudge canceled (first translated chunk received); session_id=%s process_id=%s",
+                                                    session_id,
+                                                    process_id,
+                                                )
+                                                try:
+                                                    await nudge_task
+                                                except asyncio.CancelledError:
+                                                    pass
+                                            if await _request_is_stale("before_translated_yield"):
+                                                break
+                                            yield translated_chunk
+                                        translation_batch = []
+                                        batch_word_count = 0
 
                             sentence_buffer = remaining
 

--- a/helpers/gujarati_numbers.py
+++ b/helpers/gujarati_numbers.py
@@ -150,6 +150,11 @@ _NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
 # Matches digit sequences of 10+ digits (tag numbers, phone numbers)
 _LONG_DIGIT_RE = re.compile(r"\d{10,}")
 
+# Numeric ranges such as 20-25 or 350–400
+_RANGE_RE = re.compile(
+    r"(?<!\d[-–—])(\d+(?:\.\d+)?)\s*[-–—]\s*(\d+(?:\.\d+)?)(?![-–—]\d)"
+)
+
 
 def normalize_numbers_for_tts(text: str) -> str:
     """Replace digit sequences in Gujarati text with Gujarati words.
@@ -160,6 +165,21 @@ def normalize_numbers_for_tts(text: str) -> str:
     """
     if not text:
         return text
+
+    def _replace_range(m: re.Match) -> str:
+        left = m.group(1)
+        right = m.group(2)
+
+        def _to_words(s: str) -> str:
+            if "." in s:
+                return number_to_gujarati(float(s))
+            return number_to_gujarati(int(s))
+
+        return f"{_to_words(left)} થી {_to_words(right)}"
+
+    # Convert numeric ranges before plain number substitution so 350-400
+    # does not survive as a glued punctuation sequence for TTS.
+    text = _RANGE_RE.sub(_replace_range, text)
 
     # First pass: convert long digit sequences (tags, phone numbers) to digit-by-digit
     def _replace_long(m: re.Match) -> str:

--- a/tests/test_gujarati_numbers.py
+++ b/tests/test_gujarati_numbers.py
@@ -179,11 +179,20 @@ class TestTextNormalization:
         assert "ત્રણસો સડસઠ" in result
 
     def test_range_numbers(self):
-        """Numbers separated by dash should each convert independently."""
+        """Numeric ranges should be spoken naturally as a Gujarati range."""
         text = "2-3 દિવસ"
         result = normalize_numbers_for_tts(text)
-        assert "બે" in result
-        assert "ત્રણ" in result
+        assert result == "બે થી ત્રણ દિવસ"
+
+    def test_large_range_numbers(self):
+        text = "350-400 કિલો"
+        result = normalize_numbers_for_tts(text)
+        assert result == "ત્રણસો પચાસ થી ચારસો કિલો"
+
+    def test_en_dash_range_numbers(self):
+        text = "20–25 દિવસ"
+        result = normalize_numbers_for_tts(text)
+        assert result == "વીસ થી પચ્ચીસ દિવસ"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -36,6 +36,8 @@ from app.services.voice import (
     _is_signed_in_session,
     _is_hold_message,
     _voice_answer_mode_for_query,
+    extract_translation_units,
+    should_translate_batch,
 )
 from agents.deps import FarmerContext
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
@@ -426,14 +428,40 @@ class TestHelperCoverage:
                 )
             ],
             source="cache",
+            stale=True,
+            refreshAfter="2026-04-18T00:00:00+00:00",
         )
         summary = _build_compact_farmer_summary(envelope)
         assert "Farmer records matched: 1" in summary
         assert "Farmer data source: cache" in summary
+        assert "Farmer cache state: stale" in summary
+        assert "Farmer refresh after: 2026-04-18T00:00:00+00:00" in summary
         assert "Farmer name: Rameshbhai" in summary
         assert "Farmer code available: yes" in summary
         assert "Known animal tags: 1001, 1002, 1003" in summary
         assert "##" not in summary
+
+    def test_extract_translation_units_force_splits_oversized_buffer(self):
+        text = (
+            "This is a very long answer without a sentence break that keeps going and going "
+            "so the caller should not have to wait forever before translation starts because "
+            "we need an earlier forced split in the buffered text for voice delivery "
+            * 6
+        )
+        ready, remaining = extract_translation_units(text)
+        assert ready
+        assert all(len(unit) <= 600 for unit in ready)
+        assert remaining != text
+
+    def test_extract_translation_units_breaks_at_structural_headers(self):
+        text = "Call a veterinarian quickly:\n### 1. Base feed\nGive roughage and water"
+        ready, remaining = extract_translation_units(text)
+        assert ready == ["Call a veterinarian quickly:"]
+        assert remaining.startswith("### 1. Base feed")
+
+    def test_should_translate_batch_forces_flush_on_large_char_batch(self):
+        batch_text = "word " * 140
+        assert should_translate_batch(batch_text, word_count=20, is_first_batch=False) is True
 
     def test_translation_pipeline_prompt_has_unclear_input_confirmation_rules(self):
         prompt_path = Path(__file__).resolve().parents[1] / "assets" / "prompts" / "voice_system_translation_pipeline_en.md"


### PR DESCRIPTION
## Summary
- tighten structural translation batching for voice streaming
- make farmer context reads Redis-only on the hot path with background refresh
- fix Gujarati number range normalization for TTS

## Why
- latest production traces still showed oversized translation batches and blocked farmer fetches on the request path
- this PR removes the hot-path farmer API dependency and improves structural flush behavior without arbitrary mid-sentence chopping

## Included
- structural batching improvements around colons, headers, lists, and numbered sections
- background farmer cache refresh with stale metadata
- Gujarati numeric range normalization like 350-400 -> spoken Gujarati range
- deterministic regression coverage