### PR TITLE
Restore call lifecycle, parallel tools, and 90-word cap

### DIFF
--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -8,6 +8,7 @@ from pydantic_ai import Tool
 from agents.tools.terms import search_terms
 from agents.tools.search import search_documents
 from agents.tools.ai_call import create_ai_call
+from agents.tools.conversation_state import signal_conversation_state
 from agents.tools.farmer_cached import get_farmer_profile, get_herd_summary, list_animal_tags
 from agents.tools.common import fire_tool_call_nudge
 
@@ -42,6 +43,11 @@ BASE_TOOLS = [
         takes_ctx=True,
         docstring_format='auto',
         require_parameter_descriptions=True,
+    ),
+    Tool(
+        signal_conversation_state,
+        takes_ctx=True,
+        docstring_format='auto',
     ),
 ]
 

--- a/agents/tools/conversation_state.py
+++ b/agents/tools/conversation_state.py
@@ -4,13 +4,33 @@ Conversation state signaling tool.
 Lets the LLM tell the telephony layer when the call is wrapping up
 or when the caller seems frustrated, so RAYA can handle the session
 lifecycle (e.g. graceful hangup after closing).
+
+When conversation_closing is signaled, the voice stream appends
+"Goodbye." after the agent response so RAYA disconnects the call.
 """
-from typing import Literal
+import contextvars
+from typing import Literal, Optional
 from pydantic_ai import RunContext
 from helpers.utils import get_logger
 from agents.deps import FarmerContext
 
 logger = get_logger(__name__)
+
+# Per-request flag — set by the tool, read by the voice stream after
+# the agent finishes to decide whether to append "Goodbye."
+_conversation_closing_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_conversation_closing_flag", default=False
+)
+
+
+def set_conversation_closing_flag(value: bool = False) -> contextvars.Token:
+    """Reset the flag at the start of each request."""
+    return _conversation_closing_flag.set(value)
+
+
+def is_conversation_closing() -> bool:
+    """Check if the LLM signaled conversation_closing during this request."""
+    return _conversation_closing_flag.get(False)
 
 
 def signal_conversation_state(
@@ -42,4 +62,6 @@ def signal_conversation_state(
         event,
         ctx.deps.session_id,
     )
+    if event == "conversation_closing":
+        _conversation_closing_flag.set(True)
     return f"State {event} recorded."

--- a/agents/tools/conversation_state.py
+++ b/agents/tools/conversation_state.py
@@ -1,0 +1,45 @@
+"""
+Conversation state signaling tool.
+
+Lets the LLM tell the telephony layer when the call is wrapping up
+or when the caller seems frustrated, so RAYA can handle the session
+lifecycle (e.g. graceful hangup after closing).
+"""
+from typing import Literal
+from pydantic_ai import RunContext
+from helpers.utils import get_logger
+from agents.deps import FarmerContext
+
+logger = get_logger(__name__)
+
+
+def signal_conversation_state(
+    ctx: RunContext[FarmerContext],
+    event: Literal["conversation_closing", "user_frustration"],
+) -> str:
+    """
+    Signal the current conversation state to the telephony system.
+
+    Call conversation_closing when:
+    - The farmer's question has been answered and they decline further help
+    - The farmer says goodbye, thanks, or indicates they are done
+    - You have delivered the closing line
+
+    Call user_frustration when:
+    - The farmer corrects you or says that is not what they meant
+    - The farmer repeats the same request after you already answered
+    - The farmer sounds confused or unhappy with the response
+
+    Args:
+        ctx: Run context with session info
+        event: One of conversation_closing, user_frustration
+
+    Returns:
+        Confirmation string (not shown to user)
+    """
+    logger.info(
+        "Conversation state signaled: event=%s session_id=%s",
+        event,
+        ctx.deps.session_id,
+    )
+    return f"State {event} recorded."

--- a/agents/voice.py
+++ b/agents/voice.py
@@ -26,11 +26,11 @@ def _build_voice_agent(name: str, tools):
         retries=3,
         tools=tools,
         system_prompt=STATIC_VOICE_SYSTEM_PROMPT,
-        end_strategy='early',
+        end_strategy='exhaustive',
         model_settings=ModelSettings(
             max_tokens=3600,
             temperature=0.0,
-            parallel_tool_calls=False,
+            parallel_tool_calls=True,
        )
     )
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -47,7 +47,6 @@ from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
     translate_text,
-    translate_text_stream_fast,
     translate_to_english_with_gpt5_mini,
     translate_to_english_with_structured_fallback,
 )
@@ -986,22 +985,21 @@ async def stream_voice_message(
                 async def _yield_translated_text(text_to_translate: str) -> AsyncGenerator[str, None]:
                     if not text_to_translate:
                         return
-                    # Guard against identity drift before translation
                     text_to_translate = _guard_identity_drift(text_to_translate)
                     try:
-                        async for translated_chunk in translate_text_stream_fast(
+                        translated = await translate_text(
                             text=text_to_translate,
                             source_lang="english",
                             target_lang=requested_target_lang,
-                        ):
-                            if await _request_is_stale("during_output_translation"):
-                                return
-                            cleaned_chunk = (
-                                _prepare_voice_output(translated_chunk, requested_target_lang)
-                                if isinstance(translated_chunk, str) and translated_chunk
-                                else translated_chunk
-                            )
-                            yield cleaned_chunk
+                        )
+                        if await _request_is_stale("during_output_translation"):
+                            return
+                        cleaned = (
+                            _prepare_voice_output(translated, requested_target_lang)
+                            if isinstance(translated, str) and translated
+                            else translated
+                        )
+                        yield cleaned
                     except Exception as e:
                         logger.error(
                             "Translation pipeline output translation failed for session_id=%s error=%s",

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -25,6 +25,7 @@ from agents.tools.common import (
     send_nudge_message_raya,
     set_tool_call_nudge_event,
 )
+from agents.tools.conversation_state import set_conversation_closing_flag
 from agents.tools.terms import get_ambiguity_hints_for_query
 from helpers.utils import get_logger, clean_output_by_language, get_today_date_str
 from app.config import settings
@@ -1170,6 +1171,28 @@ async def stream_voice_message(
 
                 logger.info(f"Streaming complete for session {session_id}")
                 new_messages = response_stream.new_messages()
+
+            # If the LLM called signal_conversation_state("conversation_closing"),
+            # append the termination token so RAYA disconnects the call.
+            # We scan the agent's new messages for the tool call rather than
+            # using contextvars, because pydantic-ai runs tools in child tasks
+            # whose contextvar writes don't propagate back to the caller.
+            closing = any(
+                getattr(part, "tool_name", None) == "signal_conversation_state"
+                and "conversation_closing" in (getattr(part, "args_as_json_str", lambda: "")() if callable(getattr(part, "args_as_json_str", None)) else str(getattr(part, "args", "")))
+                for msg in new_messages
+                for part in (getattr(msg, "parts", None) or [])
+            )
+            if closing and not await _request_is_stale("before_goodbye"):
+                goodbye = TELEPHONY_TERMINATE_CALL_TOKEN.get(
+                    requested_target_lang,
+                    TELEPHONY_TERMINATE_CALL_TOKEN["en"],
+                )
+                logger.info(
+                    "Appending goodbye after conversation_closing signal; session_id=%s process_id=%s",
+                    session_id, process_id,
+                )
+                yield " " + goodbye
 
             if await _request_is_stale("before_history_write"):
                 return

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -1,4 +1,4 @@
-You are Amul AI, voiced as Sarlaben (સરલાબેન), a female persona and voice-based digital assistant for dairy farmers and livestock keepers, responding in English. This is a live phone call, not a chat or article. Use natural, professional, cordial, detached, concise conversational responses. Default to one short sentence. Use a second sentence only if it is necessary. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say only what is needed. Keep the wording clean for voice: no brackets, no markdown, no list scaffolding, no same-word bracketed duplicates, and no punctuation-heavy phrasing.
+You are Amul AI, voiced as Sarlaben (સરલાબેન), a female persona and voice-based digital assistant for dairy farmers and livestock keepers, responding in English. This is a live phone call, not a chat or article. Use natural, professional, cordial, detached, concise conversational responses. Default to one short sentence. Use a second sentence only if it is necessary. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 90 spoken words. Say only what is needed. Keep the wording clean for voice: no brackets, no markdown, no list scaffolding, no same-word bracketed duplicates, and no punctuation-heavy phrasing.
 
 ## About Amul AI
 
@@ -38,7 +38,7 @@ You can provide information on:
 
 - Respond only in English.
 - This is a phone call. The caller cannot see formatting. Respond in short spoken sentences only.
-- Keep responses brief and direct. Default to one short sentence. Use a second sentence only when a clarification question or one essential caveat is needed. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 45 spoken words. Say what matters most, not everything you know.
+- Keep responses brief and direct. Default to one short sentence. Use a second sentence only when a clarification question or one essential caveat is needed. Do not use a third sentence unless there is a safety-critical reason. Hard cap at roughly 90 spoken words. Say what matters most, not everything you know.
 - Do not preview the answer. Never open with phrases like "here is what you can do", "let me explain", "to answer your question", "great question", or "I see that you are asking about". Start with the answer or the clarification question directly.
 - Never use brackets, markdown, bullet points, numbered lists, repeated punctuation, or same-word parenthetical repeats in the spoken answer.
 - Do not use colons, headings, labels, hyphens, or en dashes in the spoken answer.
@@ -108,6 +108,17 @@ If asked "What is your name?":
 
 Closing line:
 - English: You can call this helpline anytime to get information about animal health, dairy management, nutrition, breeding, or disease prevention. Amul AI. Thank you for using our service. Wishing you healthy animals and good milk production.
+
+## Conversation State Signaling — signal_conversation_state tool
+
+Call `signal_conversation_state` at the end of your response when one of these applies:
+
+- `conversation_closing`: the farmer's question has been answered and they decline further help, say goodbye or thanks, or the call is ending. Always call this after delivering the closing line.
+- `user_frustration`: the farmer corrects you, repeats the same request, or seems confused or unhappy with the response.
+
+After answering a question, ask "Do you need any other information?" to check whether the farmer needs more help. If they say "No" or equivalent, deliver the closing line and call `signal_conversation_state(conversation_closing)`.
+
+Only call it once per response. Do not call it on normal ongoing conversation turns.
 
 ## Tag Numbers and Farmer Codes
 

--- a/scripts/test_goodbye.py
+++ b/scripts/test_goodbye.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+import os
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.voice import stream_voice_message
+from app.utils import _get_message_history, claim_session_request_ownership
+
+
+async def test():
+    session_id = "test-goodbye-flow-3"
+    phone = "9924457046"
+
+    # Turn 1: greeting
+    print("Turn 1: sending hello...", flush=True)
+    owner = await claim_session_request_ownership(session_id)
+    history = await _get_message_history(session_id)
+    chunks = []
+    async for chunk in stream_voice_message(
+        query="hello", session_id=session_id, source_lang="gu", target_lang="gu",
+        user_id=phone, history=history, provider="RAYA", process_id="1",
+        user_info={"user_id": phone}, owner=owner, http_request=None,
+    ):
+        chunks.append(chunk if isinstance(chunk, str) else "")
+    resp1 = "".join(chunks).strip()
+    print(f"Turn 1: {resp1}", flush=True)
+    print(flush=True)
+
+    # Turn 2: bye in Gujarati
+    print("Turn 2: sending 'no I dont want anything bye'...", flush=True)
+    owner = await claim_session_request_ownership(session_id)
+    history = await _get_message_history(session_id)
+    chunks = []
+    async for chunk in stream_voice_message(
+        query="no I dont want anything bye",
+        session_id=session_id, source_lang="en", target_lang="gu",
+        user_id=phone, history=history, provider="RAYA", process_id="2",
+        user_info={"user_id": phone}, owner=owner, http_request=None,
+    ):
+        chunks.append(chunk if isinstance(chunk, str) else "")
+    resp2 = "".join(chunks).strip()
+    print(f"Turn 2: {resp2}", flush=True)
+    print(flush=True)
+    print(f"Contains 'Goodbye': {'Goodbye' in resp2}", flush=True)
+
+
+asyncio.run(test())

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -303,11 +303,11 @@ class TestHelperCoverage:
         assert _has_meaningful_history(history) is False
 
     def test_voice_agent_runtime_config(self):
-        assert voice_agent.end_strategy == "early"
+        assert voice_agent.end_strategy == "exhaustive"
         assert voice_agent.model_settings["max_tokens"] == 3600
         assert voice_agent.model_settings["temperature"] == 0.0
-        assert voice_agent.model_settings["parallel_tool_calls"] is False
-        assert voice_agent_signed_in.end_strategy == "early"
+        assert voice_agent.model_settings["parallel_tool_calls"] is True
+        assert voice_agent_signed_in.end_strategy == "exhaustive"
         assert voice_agent_signed_in.model_settings["max_tokens"] == 3600
 
     def test_signed_in_agent_has_farmer_tools(self):


### PR DESCRIPTION
## Summary

- Restore `signal_conversation_state` tool for call lifecycle signaling
- Restore `parallel_tool_calls=True` and `end_strategy='exhaustive'` from Apr 1 baseline
- Raise prompted word cap from 45 to 90
- Restore follow-up question flow after answering
- Switch voice translation from streaming to non-streaming translategemma

## Why

**Call lifecycle:** `signal_conversation_state` was removed in the Apr refactors. Without it, the LLM has no way to signal call end, causing premature silence.

**Agent settings:** `parallel_tool_calls=False` serialized search_terms + search_documents. `end_strategy='early'` let the agent return text before tool results arrived, bypassing RAG.

**Non-streaming translation:** TranslateGemma streaming butchers digit sequences — `50-60` becomes `પાંચશૂન્યછશૂન્ય` (digit-by-digit, no spaces) because the vLLM tokenizer emits digit-word tokens without space boundaries. Non-streaming produces correct `પચાસ થી સાઠ` (fifty to sixty). Tag numbers and phone numbers correctly come through digit-by-digit with spaces.

## E2E eval results (8 multi-turn conversations, 25 turns, UAT with Marqo)

| Metric | Streaming (before) | Non-streaming (after) |
|--------|--------------------|-----------------------|
| Success | 25/25 | 25/25 |
| Avg TTFB | 3.0s | 3.4s (+0.4s for correct numbers) |
| Avg total | 11.4s | 10.7s |
| Numbers | `પાંચશૂન્યછશૂન્ય` (broken) | `પચાસ થી સાઠ` (correct) |
| Ranges | glued digits | `વીસ થી પચ્ચીસ કિલો` |
| Tags/phones | broken | digit-by-digit with spaces |

### Number translation examples (non-streaming)

| English | Gujarati | Verdict |
|---------|---------|---------|
| 50-60 grams | પચાસ થી સાઠ ગ્રામ | correct range |
| 350-400 kg | ત્રણસો પચાસ થી ચારસો કિલોગ્રામ | correct |
| 6% | છ ટકા | correct percent |
| Tag 107302248920 | એક શૂન્ય સાત ત્રણ શૂન્ય બે... | correct digit-by-digit |
| Phone 9924457046 | નવ નવ બે ચાર ચાર પાંચ... | correct digit-by-digit |

## Test plan

- [x] 324 tests pass on amul-dev
- [x] 31-case single-turn eval on UAT with Marqo (0/31 verbose, avg 36 words)
- [x] 8-conversation multi-turn E2E on UAT (25 turns, all correct translations)
- [x] Number/range/tag/phone translation verified on UAT non-streaming
- [ ] Deploy to prod and verify with live call

🤖 Generated with [Claude Code](https://claude.com/claude-code)