### PR TITLE
Fix voice translation spacing across streamed batches

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -854,7 +854,11 @@ async def translate_text_stream_fast(
                                             target_lang,
                                             strip_outer=False,
                                         )
-                                        content = normalize_voice_output(content, target_lang)
+                                        content = normalize_voice_output(
+                                            content,
+                                            target_lang,
+                                            streaming=True,
+                                        )
                                         translated_parts.append(content)
                                         yield content
                                 except json.JSONDecodeError:
@@ -914,7 +918,11 @@ async def translate_text_stream_fast(
                                             target_lang,
                                             strip_outer=False,
                                         )
-                                        content = normalize_voice_output(content, target_lang)
+                                        content = normalize_voice_output(
+                                            content,
+                                            target_lang,
+                                            streaming=True,
+                                        )
                                         translated_parts.append(content)
                                         yield content
                                 except json.JSONDecodeError:

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -839,7 +839,7 @@ async def translate_text_stream_fast(
                         buffer += chunk
                         while b'\n' in buffer:
                             line, buffer = buffer.split(b'\n', 1)
-                            line = line.decode('utf-8').strip()
+                            line = line.decode('utf-8').rstrip('\r')
                             if line.startswith('data: '):
                                 data = line[6:]
                                 if data == '[DONE]':
@@ -899,7 +899,7 @@ async def translate_text_stream_fast(
                         buffer += chunk
                         while b'\n' in buffer:
                             line, buffer = buffer.split(b'\n', 1)
-                            line = line.decode('utf-8').strip()
+                            line = line.decode('utf-8').rstrip('\r')
                             if line.startswith('data: '):
                                 data = line[6:]
                                 if data == '[DONE]':

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -610,6 +610,7 @@ async def stream_voice_message(
     """Async generator for streaming chat messages."""
     request_started_at = time.monotonic()
     last_owner_refresh_at = 0.0
+    last_emitted_sig_char: str | None = None
 
     async def _request_is_stale(reason: str) -> bool:
         nonlocal last_owner_refresh_at
@@ -650,6 +651,37 @@ async def stream_voice_message(
             return True
 
         return False
+
+    def _first_sig_char(text: str) -> str | None:
+        for ch in text or "":
+            if not ch.isspace():
+                return ch
+        return None
+
+    def _last_sig_char(text: str) -> str | None:
+        for ch in reversed(text or ""):
+            if not ch.isspace():
+                return ch
+        return None
+
+    def _prepare_translated_emit(text: str) -> str:
+        nonlocal last_emitted_sig_char
+        if not isinstance(text, str) or not text:
+            return text
+
+        first_sig = _first_sig_char(text)
+        if (
+            last_emitted_sig_char in {".", "!", "?", "।"}
+            and first_sig is not None
+            and re.match(r"[A-Za-z\u0A80-\u0AFF]", first_sig)
+            and not text[0].isspace()
+        ):
+            text = " " + text
+
+        last_sig = _last_sig_char(text)
+        if last_sig is not None:
+            last_emitted_sig_char = last_sig
+        return text
 
     try:
         with _langfuse_session_context(session_id, user_id, process_id):
@@ -1086,7 +1118,7 @@ async def stream_voice_message(
                                                     pass
                                             if await _request_is_stale("before_translated_yield"):
                                                 break
-                                            yield translated_chunk
+                                            yield _prepare_translated_emit(translated_chunk)
                                         translation_batch = []
                                         batch_word_count = 0
 
@@ -1116,7 +1148,7 @@ async def stream_voice_message(
                                         pass
                                 if await _request_is_stale("before_final_translated_yield"):
                                     break
-                                yield translated_chunk
+                                yield _prepare_translated_emit(translated_chunk)
 
                         if sentence_buffer.strip():
                             async for translated_chunk in _yield_translated_text(sentence_buffer):
@@ -1140,7 +1172,7 @@ async def stream_voice_message(
                                         pass
                                 if await _request_is_stale("before_tail_translated_yield"):
                                     break
-                                yield translated_chunk
+                                yield _prepare_translated_emit(translated_chunk)
                 except StopAsyncIteration:
                     pass
                 except RuntimeError as e:

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -90,15 +90,15 @@ def extract_complete_sentences(text: str):
     inline_structural_match = re.search(r"(?=\s#{1,6}\s)|(?=\n#{1,6}\s)|(?=\n\d+\.\s)|(?=\n[-*•]\s)", text)
     if inline_structural_match and inline_structural_match.start() > 0:
         split_at = inline_structural_match.start()
-        head = text[:split_at].rstrip()
-        tail = text[split_at:].lstrip()
+        head = text[:split_at]
+        tail = text[split_at:]
         if head:
             return [head], tail
     structural_match = re.search(r"\n(?=(?:#{1,6}\s|[-*•]\s|\d+\.\s))", text)
     if structural_match:
         split_at = structural_match.start()
-        head = text[:split_at].rstrip()
-        tail = text[split_at:].lstrip()
+        head = text[:split_at]
+        tail = text[split_at:]
         if head:
             return [head], tail
     sentences = sentence_segmenter(text)
@@ -138,7 +138,7 @@ def _split_voice_batch_text(text: str, max_chars: int = VOICE_TRANSLATION_BATCH_
     if split_at < 0:
         return text, ""
 
-    return text[:split_at].rstrip(), text[split_at:].lstrip()
+    return text[:split_at], text[split_at:]
 
 
 def extract_translation_units(text: str):

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -247,6 +247,7 @@ def normalize_voice_output(
     lang_code: str | None,
     *,
     replace_slash: bool = True,
+    streaming: bool = False,
 ) -> str:
     """Normalize model output for voice playback before language filtering."""
     if not text:
@@ -257,6 +258,19 @@ def normalize_voice_output(
 
     if lang == "gu":
         out = normalize_numbers_for_tts(out)
+
+    if streaming:
+        out = _replace_voice_abbreviations(out, lang)
+        out = _remove_quantity_placeholders(out)
+        out = re.sub(r"\.{3,}", ".", out)
+        out = re.sub(r"([!?])\1+", r"\1", out)
+        out = re.sub(r"([,;:])\1+", r"\1", out)
+        if replace_slash:
+            if lang == "gu":
+                out = out.replace("/", " અથવા ")
+            else:
+                out = out.replace("/", " or ")
+        return out
 
     # Strip markdown and structural noise that should never be spoken.
     out = out.replace("**", "").replace("__", "").replace("`", "").replace("~", "")


### PR DESCRIPTION
## Summary
This PR fixes Gujarati voice output cases where adjacent translated batches were emitted back-to-back and produced `<word>.<word>` joins such as `રાખો.તેને`, `હોય.સૌ`, `કરો.જો`.

## Root Cause
The issue was not in raw TranslateGemma output.

Investigation showed:
- Raw SSE translation chunks preserved leading spaces correctly.
- Per-chunk post-processing also preserved those spaces.
- Each translated batch was internally clean.
- The bug appeared only when multiple translated batches were emitted consecutively in `stream_voice_message()` with no preserved separator at the batch boundary.

Typical failing shape:
- batch A ended with `... લો.`
- batch B started with `આ પગલાં...`
- final stream became `... લો.આ પગલાં...`

## Changes
### `app/services/translation.py`
- Stop stripping leading whitespace from streamed SSE lines.
- Use `normalize_voice_output(..., streaming=True)` for streamed translation chunks.

### `helpers/utils.py`
- Add `streaming=True` mode to `normalize_voice_output()`.
- In streaming mode, keep only chunk-safe normalization and avoid whole-text cleanup that can mutate chunk boundaries.

### `app/services/voice.py`
- Preserve whitespace when splitting translation units.
- Track the last emitted non-whitespace character.
- If a translated batch starts with a letter and the previous emitted character was sentence punctuation, insert one separating space before yielding the new batch.

## Validation
Validated on UAT VM5 (`amul-vm5-ai-backend`) with the running Dockerized `voice-oan-api` service.

### Before fix
Full-pipeline sanity check reproduced issues like:
- `.હું`
- `.જો`
- `.સૌ`
- `.બે`
- `.ત્રણ`
- `.ચાર`

### After fix
Reran the same full-pipeline sanity query through `stream_voice_message()`.

Observed result:
- `ISSUE_COUNT 0`
- no remaining `<word>.<word>` matches in final assembled output

## Scope
This branch contains only the spacing-related fixes needed for prod:
- `a2b7f49` Preserve whitespace in voice translation streaming
- `d12d953` Preserve chunk spacing during streaming normalization
- `0464df7` Preserve spacing between translated voice batches
