### PR TITLE
Move voice pipeline to OSS (Gemma 4 via vLLM) + fix tool-call stall

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -29,9 +29,19 @@ load_dotenv()
 logger = get_logger(__name__)
 
 
+# Pretranslation provider — follows main LLM_PROVIDER by default.
+# Override with PRETRANSLATION_PROVIDER if you want a different provider for pretranslation.
+# Supported: "openai" | "vllm" (OpenAI-compatible endpoint, e.g. local Gemma 4 via vLLM).
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").lower()
+PRETRANSLATION_PROVIDER = os.getenv("PRETRANSLATION_PROVIDER", LLM_PROVIDER).lower()
+if PRETRANSLATION_PROVIDER == "vllm":
+    _PRETRANSLATION_MODEL_DEFAULT = os.getenv("LLM_MODEL_NAME", "gemma-4-31b-it")
+else:
+    _PRETRANSLATION_MODEL_DEFAULT = "gpt-5.1"
+# OPENAI_PRETRANSLATION_MODEL kept as legacy alias; PRETRANSLATION_MODEL takes precedence.
 OPENAI_PRETRANSLATION_MODEL = os.getenv(
-    "OPENAI_PRETRANSLATION_MODEL",
-    "gpt-5.1",
+    "PRETRANSLATION_MODEL",
+    os.getenv("OPENAI_PRETRANSLATION_MODEL", _PRETRANSLATION_MODEL_DEFAULT),
 )
 _openai_client: Optional[AsyncOpenAI] = None
 
@@ -468,12 +478,27 @@ async def translate_text(
 
 
 def _get_openai_client() -> AsyncOpenAI:
+    """Return an OpenAI-compatible async client.
+
+    When PRETRANSLATION_PROVIDER=vllm, point the OpenAI client at the local
+    vLLM `INFERENCE_ENDPOINT_URL` (e.g. http://10.185.25.198:8020/v1) so the
+    same chat-completions call path serves an OSS model like Gemma 4 31B IT.
+    """
     global _openai_client
     if _openai_client is None:
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            raise ValueError("OPENAI_API_KEY is required for OpenAI pretranslation")
-        _openai_client = AsyncOpenAI(api_key=api_key)
+        if PRETRANSLATION_PROVIDER == "vllm":
+            base_url = os.getenv("INFERENCE_ENDPOINT_URL", "").rstrip("/")
+            if not base_url:
+                raise ValueError(
+                    "INFERENCE_ENDPOINT_URL is required when PRETRANSLATION_PROVIDER=vllm"
+                )
+            api_key = os.getenv("INFERENCE_API_KEY") or "dummy"
+            _openai_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        else:
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError("OPENAI_API_KEY is required for OpenAI pretranslation")
+            _openai_client = AsyncOpenAI(api_key=api_key)
     return _openai_client
 
 
@@ -758,7 +783,7 @@ async def translate_to_english_with_gpt5_mini(
             },
             model=OPENAI_PRETRANSLATION_MODEL,
             metadata={
-                "translation_provider": "openai",
+                "translation_provider": PRETRANSLATION_PROVIDER,
                 "pipeline_stage": "query_pretranslation",
             },
         ) as observation:

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1270,12 +1270,58 @@ async def stream_voice_message(
                 process_id=process_id,
                 user_query=processing_query,
             ):
-                async with active_agent.run_stream(
+                # pydantic-ai 0.2.4's run_stream + stream_text(delta=True) does not
+                # drive the agent loop past a tool-call-only first response — Gemma 4
+                # frequently emits tool_calls without text, after which the streamed
+                # iterator yields zero chunks and the run never completes. Switching
+                # to the non-streaming `run()` forces the full tool-call/response loop
+                # and reliably returns the final en text; we then stream the en→gu
+                # translation downstream via translate_text_stream_fast so the
+                # external response contract (gu chunks to the caller) is preserved.
+                agent_result = await active_agent.run(
                     user_prompt=user_message,
                     message_history=model_input_history,
                     deps=deps,
                     usage_limits=usage_limits,
-                ) as response_stream:
+                )
+                _agent_output = (
+                    getattr(agent_result, "output", None)
+                    or getattr(agent_result, "data", None)
+                    or ""
+                )
+                if not isinstance(_agent_output, str):
+                    _agent_output = str(_agent_output)
+                _agent_output = _agent_output.strip()
+
+                class _AgentRunResultStreamShim:
+                    """Adapter so the downstream batching/translation logic keeps
+                    working unchanged: yields the full en text as a single chunk
+                    and exposes the same `new_messages()` accessor."""
+
+                    def __init__(self, result, text: str) -> None:
+                        self._result = result
+                        self._text = text
+
+                    def stream_text(self, *, delta: bool = True):  # noqa: ARG002
+                        text = self._text
+                        async def _gen():
+                            if text:
+                                yield text
+                        return _gen()
+
+                    def new_messages(self):
+                        return self._result.new_messages()
+
+                response_stream = _AgentRunResultStreamShim(agent_result, _agent_output)
+                # Run the rest of the original flow within a no-op async context so
+                # the indentation and finally-clauses below stay structurally intact.
+                from contextlib import asynccontextmanager as _asynccontextmanager
+
+                @_asynccontextmanager
+                async def _noop_async():
+                    yield response_stream
+
+                async with _noop_async() as response_stream:
                     stream_iter = response_stream.stream_text(delta=True)
                     first_text_chunk_received = False
                     sentence_buffer = ""


### PR DESCRIPTION
## Summary

Moves the voice pipeline to run end-to-end on OSS models (Gemma 4 31B IT via vLLM, TranslateGemma 27B base for translation). Two changes:

1. **gu→en pretranslation supports vLLM** (`app/services/translation.py`). Adds a `vllm` branch in `_get_openai_client()` that points the OpenAI client at the local `INFERENCE_ENDPOINT_URL` (OpenAI-compatible). Set `PRETRANSLATION_PROVIDER=vllm` to enable; `PRETRANSLATION_MODEL` defaults to `LLM_MODEL_NAME` (e.g. `gemma-4-31b-it`). The legacy `OPENAI_PRETRANSLATION_MODEL` env var is kept for back-compat. Langfuse pretranslation traces now record the actual provider in metadata instead of a hardcoded `"openai"`.

2. **Voice agent stalling fix** (`app/services/voice.py`). On `pydantic-ai 0.2.4`, `agent.run_stream()` + `stream_text(delta=True)` doesn't drive the agent loop past a tool-call-only first response. Gemma 4 frequently emits assistant turns with `content: ""` + `tool_calls: [...]`, after which `stream_text` yields zero chunks and the run ends without producing any text — the voice service streamed an empty response and the Langfuse trace showed a single chat generation with no follow-up. Switched the agent invocation to non-streaming `run()` and wrapped the result in a small shim that exposes `stream_text()` (yielding the full en text once) and `new_messages()`. All the downstream sentence batching + en→gu translation streaming (via `translate_text_stream_fast`) keeps working unchanged.

Cost: lose incremental streaming of the agent's en output (small TTFA cost on the gu→en→en→gu path). Win: full tool-call loop completes reliably on OSS models. A future upgrade of `pydantic-ai` to 1.x would let us go back to streaming, but that's a separate effort because it also requires rewriting voice's custom `BoundaryCaptureOpenAIModel` against the new internal API.

## Validation

200-row goldenset run on `Amul_Task_Sheet_subset_200_all_fields.csv`, voice container pinned to `LLM_PROVIDER=vllm` + `LLM_MODEL_NAME=gemma-4-31b-it` + `PRETRANSLATION_PROVIDER=vllm`. CSV extraction from real Langfuse traces.

| Column | Before fix | After fix |
|---|---:|---:|
| `question_en` (from `query_pretranslation` trace) | 200/200 | **200/200** |
| `question_gu` | 200/200 | **200/200** |
| `answer_en` (from final `chat gemma-4-31b-it` GENERATION) | 0/200 | **199/200** |
| `answer_gu` (from `stream_translation` observations, concatenated) | 42/200 | **199/200** |
| `search_results` | 0/200 | 0/200 |

Langfuse trace after fix shows two `chat gemma-4-31b-it` GENERATIONs inside `Voice Agent Signed In run` (tool-call turn → tool execution → final-text turn) plus the expected `stream_translation` observations for the en→gu post-translation.

`search_results` stays empty because pydantic-ai 0.2.4 doesn't capture `TOOL` observation outputs (the `marqo_search` sub-observation only records `hit_count`). This is a known limitation of voice's pinned pydantic-ai version and not introduced by this PR.

## Test plan
- [x] Smoke a previously-failing query (`પશુ કિસાન ક્રેડિટ કાર્ડ (KCC) લોન મળે છે કે નહીં?`) — voice now returns a coherent gu answer end-to-end.
- [x] Langfuse trace for the smoke shows 2 agent generations + tool execution + stream_translation.
- [x] 200-row goldenset run completes with 199/200 populated `answer_en` and `answer_gu`.
- [ ] Manual phone-call test through RAYA in dev before promoting to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
