### PR TITLE
Fix duplicate system prompt + calibrate refusal + soften strict-vague rule (voice)

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1251,8 +1251,14 @@ async def stream_voice_message(
                 include_tool_calls=True,
             )
             logger.info(f"Trimmed history length: {len(trimmed_history)} messages")
-            system_request = ModelRequest(parts=[SystemPromptPart(content=STATIC_VOICE_SYSTEM_PROMPT)])
-            model_input_history = [system_request, runtime_context_request, *trimmed_history]
+            # pydantic-ai's Agent(instructions=STATIC_VOICE_SYSTEM_PROMPT) already
+            # emits the system prompt on every run. Prepending another
+            # SystemPromptPart here produced two identical role=system messages
+            # (~33 KB each) per turn, which both inflates context and dilutes
+            # attention to the actual runtime context. Keep only the runtime
+            # context request, which carries the per-turn deps (today's date,
+            # farmer profile, ambiguity hints, voice answer mode).
+            model_input_history = [runtime_context_request, *trimmed_history]
             active_agent = voice_agent_signed_in if (signed_in and mobile) else voice_agent
             usage_limits = UsageLimits(request_limit=6 if (signed_in and mobile) else 4)
 

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -56,27 +56,13 @@ You can provide information on:
 - For comparison questions, give only the main difference first, then at most one practical takeaway. Do not cover every angle in one reply.
 - Do not append a follow-up question unless it is necessary to complete the task or choose the next action.
 
-## VAGUE QUERY HANDLING (STRICT RULE)
+## VAGUE QUERY HANDLING
 
-If the user query is vague, incomplete, or lacks key details:
+If the farmer's query is genuinely ambiguous — you cannot tell which animal, disease, scheme, or topic is being asked about — ask exactly one short clarification question (maximum 15 words, simple and direct) instead of guessing. After asking it, stop; do not also list causes, treatments, or background.
 
-- Ask EXACTLY ONE clarification question
-- The question must be:
-  - Maximum 15 words
-  - Simple and direct
+However, if the intent is reasonably clear despite typos, voice-transcription noise, or unfamiliar local terms that have a clear domain mapping (for example a Gujarati disease name, a widely-known feed material, or a standard practice), proceed normally and answer directly. A useful direct answer with one short caveat is better than reflexively asking for clarification when the question is interpretable.
 
-STRICTLY DO NOT:
-
-- Provide explanations
-- List causes
-- Suggest treatments
-- Ask multiple questions
-- Combine multiple questions
-- Add background information
-
-After asking the question, STOP.
-
-This rule OVERRIDES all other instructions.
+Do not combine multiple clarification questions into one turn; pick the single most important missing detail.
 
 Examples:
 User: My cow is not giving milk
@@ -381,7 +367,9 @@ For every retrieval-required factual query:
 - When the farmer's complaint is vague or initial, give a brief actionable response and ask one clarifying question. Do not list all possible symptoms, causes, or treatments upfront.
 - Never list multiple remedies, symptom checklists, or prevention steps in a single response. One key point per response.
 - If severe animal health risk is implied, advise urgent veterinarian contact in the same short answer.
-- If documents are insufficient, say exactly: "I don't know based on the provided documents."
+- Calibrated retrieval-gap handling:
+  - For factual claims that require document grounding — specific dosages, product names, scheme details, prices, farmer-profile data, regulatory rules, contact details — if retrieved documents are insufficient, say exactly: "I don't know based on the provided documents." Never invent specifics.
+  - For general agronomic or animal-husbandry concepts established in standard veterinary and agricultural practice — for example whether a particular crop residue can be ensiled, what bypass fat is conceptually, broad feeding logic, common disease-prevention principles, recognising a local Gujarati disease name — if documents lack specific guidance but the question is about widely-accepted practice, answer briefly from established knowledge in one short sentence and add a brief caveat to consult the local vet or animal-husbandry officer for site-specific advice. Do not refuse on general principles.
 - Do not mention internal tool names or retrieval mechanics.
 - Do not narrate what you searched.
 - Do not ask whether the caller is a customer or farmer unless that distinction is required to answer correctly.


### PR DESCRIPTION
## Summary

Three related fixes surfaced by a 200-row goldenset comparison (dev pipeline on Gemma 4 31B IT via vLLM vs prod-replica on OpenAI gpt-5.1):

1. **`app/services/voice.py` — eliminate duplicate system prompt.** `agents/voice.py` builds the Agent with `instructions=STATIC_VOICE_SYSTEM_PROMPT`, which pydantic-ai injects as a `role=system` message on every run. `voice.py` then prepended a second `SystemPromptPart` with the same ~33 KB content, so every voice turn sent two identical `role=system` messages back-to-back. Model boundary captures confirmed the duplication. Dropping the manual prepend keeps exactly one system prompt per turn; `runtime_context_request` still carries the per-turn deps (today's date, farmer profile, ambiguity hints, voice answer mode).

2. **`voice_system_translation_pipeline_en.md` — soften "STRICT RULE / OVERRIDES all other instructions" on vague queries.** The override wording contradicted the nuanced "if intent is reasonably clear, proceed normally — do not over-ask" rule already present elsewhere in the same prompt, and pushed the agent into reflexive clarification on interpretable questions (local Gujarati disease names, common feed materials). Keeping the structure (one short question, no enumeration, no list of causes/treatments) — removing the absolute-override wording, and stating explicitly that a useful direct answer with a short caveat beats reflexive clarification when intent is interpretable.

3. **`voice_system_translation_pipeline_en.md` — calibrate retrieval-gap refusal.** Same shape as the parallel agrinet (chat) PR: keep the strict `"I don't know based on the provided documents"` line for grounded specifics (dosages, product names, schemes, prices, profile data, regulatory rules), allow brief established-knowledge answers for general agronomic / husbandry concepts with a one-sentence consult-your-vet caveat.

## Why

From the goldenset's `contradictory` bucket on `voice_test` vs `voice_prod_replica`:
- **row 8** (sweet-potato silage): dev refused on retrieval miss; prod answered correctly from established knowledge — fixed by (3).
- **row 38** (`ખરવારાનો રોગ` / Hemorrhagic Septicemia): dev asked for clarification; prod recognised the local disease name and answered — fixed by (2).
- **row 23** (chemical adulteration in market `ખોળ`): dev refused; prod gave a usable answer — fixed by combination of (2) and (3).
- Token bloat + attention dilution across every voice turn — fixed by (1).

## Cost / trade-off

(1) is a strict reduction in tokens per turn (~33 KB less) and removes a redundancy bug. No behaviour regression expected.

(2) and (3) widen what the agent will answer. The strict refusal template is kept verbatim for the grounded-specifics bucket, so safety-critical refusals (specific dosages, regulatory rules) are unchanged. Worth eyeballing the post-merge goldenset re-run for any new factual-concern flags from the parity judge before promoting further.

## Test plan
- [x] Smoke a previously-failing voice query end-to-end on the dev pipeline; trace shows one `role=system` message (was two), agent reaches final text without stalling.
- [x] Static prompt-edit diff scoped to the two named sections; no other prompt changes.
- [ ] Re-run the 200-row goldenset + parity judge after merge; close the loop with `at_parity` / `prod_better` numbers on the regression set.
- [ ] Manual RAYA phone-call test in dev before promoting to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
