### PR TITLE
feat(pretranslation): filter type=ask + refine glossary (v5)

### DIFF
--- a/agents/tools/terms.py
+++ b/agents/tools/terms.py
@@ -355,7 +355,7 @@ def _load_ambiguity_terms() -> list:
 _AMBIGUITY_TERMS = _load_ambiguity_terms()
 
 
-def get_ambiguity_hints_for_query(query: str, threshold: float | None = None) -> str:
+def get_ambiguity_hints_for_query(query: str, threshold: float | None = None, include_ask: bool = True) -> str:
     """
     Fuzzy-match incoming query (any language) against ambiguity_terms.json.
     Returns a formatted string of matching rules to inject into the system prompt,
@@ -365,6 +365,11 @@ def get_ambiguity_hints_for_query(query: str, threshold: float | None = None) ->
         query: The raw user query string.
         threshold: Minimum similarity 0-1 (default 0.80, lower than glossary since
                    Gujarati term matching is fuzzier).
+        include_ask: If False, skip entries with type == "ask" (those rules tell
+                     the answering agent to ask a clarifying question and must
+                     NOT leak into the pretranslation prompt — otherwise the
+                     translator dutifully appends the clarifying question to
+                     its English output).
 
     Returns:
         Formatted rules string, e.g.:
@@ -392,6 +397,8 @@ def get_ambiguity_hints_for_query(query: str, threshold: float | None = None) ->
         gu_terms = entry.get("gu_terms", [])
         rule = entry.get("rule", "").strip()
         if not rule or not gu_terms:
+            continue
+        if not include_ask and entry.get("type") == "ask":
             continue
 
         # Check each trigger term against the query using substring + fuzzy

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -567,7 +567,10 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
     )
 
     # -- Ambiguity hints from ambiguity_terms.json ---------------------
-    ambiguity_hints = get_ambiguity_hints_for_query(text)
+    # include_ask=False so "ask" type entries (clarifying-question rules
+    # meant for the answering agent) don't leak into the translator prompt
+    # and get echoed back as appended follow-up questions.
+    ambiguity_hints = get_ambiguity_hints_for_query(text, include_ask=False)
     if ambiguity_hints:
         domain_preamble += f"\nDomain-specific disambiguation rules for terms in this message:\n{ambiguity_hints}\n"
 

--- a/assets/ambiguity_terms.json
+++ b/assets/ambiguity_terms.json
@@ -377,17 +377,17 @@
       "pao mukti"
     ],
     "type": "hardcode",
-    "rule": "'પાહો મુકવો' / 'પાહો છોડવો' in a buffalo / cow dairy context refers to the **milk let-down reflex** — the cow or buffalo releasing milk for milking or for the calf. 'પાહો નહિ મુકતી' = 'she is not letting down milk' (a common problem after the calf dies, the calf is taken away, or the animal is stressed). It is NOT about a male calf, a bottle/nipple, or any social rejection between calves. Translate as 'not letting down milk' or 'milk let-down is failing / inhibited'. Treat the question as a milk let-down / oxytocin / dam-calf bond question."
+    "rule": "'પાહો મુકવો' / 'પાહો છોડવો' / 'પાહો છૂટવો' in a buffalo / cow dairy context refers to **the cow or buffalo accepting / allowing the calf to suckle and triggering the milk let-down reflex**. 'પાહો નહિ મુકતી' literally means 'she is not letting (the calf) approach / suckle' and idiomatically means 'she is refusing to nurse the calf / milk let-down is inhibited' (a common problem when the calf has died, has been removed, or the dam is stressed). It is NOT about a male calf, a bottle / nipple, or social rejection between calves. Render the meaning as 'not letting the calf suckle / nurse' or 'not letting down milk' depending on which is more natural in the sentence. Treat the question as a milk let-down / oxytocin / dam-calf bond issue."
   },
   {
     "gu_terms": [
       "શંકર ગાય",
       "શંકર ગાયો",
-      "શંકર વાછરડી",
+      "શંકરી ગાય",
       "shankar gay",
       "shankar cow"
     ],
     "type": "hardcode",
-    "rule": "'શંકર ગાય' (Shankar cow / Shankar gai) is a colloquial regional Gujarati label for a **specific local crossbred / improved breed cow** common in the Banaskantha-Patan-Mehsana belt. When used as a noun phrase with 'ગાય' / 'ગાયો' / 'વાછરડી', keep the proper-noun form 'Shankar cow' (or 'Shankar gai') in English. **Do NOT normalize the breed name to 'crossbred', 'Sahiwal', 'Holstein', 'HF', 'Jersey', or any other specific breed** — the speaker is asking specifically about Shankar-type animals. Translate the rest of the sentence normally but preserve 'Shankar' as the breed identifier."
+    "rule": "'શંકર ગાય' / 'શંકર ગાયો' (Shankar cow / Shankar gai) is a colloquial regional Gujarati label for a **specific local crossbred / improved breed cow** common in the Banaskantha-Patan-Mehsana belt. When used together with the noun 'ગાય' / 'ગાયો' specifically, keep the proper-noun form 'Shankar cow' / 'Shankar gai' in English and do NOT normalize the breed name to 'crossbred', 'Sahiwal', 'Holstein', 'HF', or 'Jersey'. NOTE: The bare word 'શંકર' / 'સંકર' on its own — or when paired with 'વાછરડી', 'જાનવર', 'પશુ' or in a question about breed STANDARDS / criteria / definitions — usually means the generic adjective 'crossbred'; in that case translate as 'crossbred'. The Shankar=proper-noun rule applies only when the surrounding sentence is asking about specific Shankar-type cows (e.g. buying / selling / characteristics of a Shankar cow)."
   }
 ]


### PR DESCRIPTION
Mirror of amul-oan-api v5 PR.

Same code fix (pretranslation passes include_ask=False) and same 2 glossary refinements (paho clarification, Shankar disambiguation).