### PR TITLE
feat(prompt): default to cattle/buffalo when species unspecified

### DIFF
--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -356,6 +356,11 @@ For every retrieval-required factual query:
 - Out of scope: entertainment, politics, unrelated finance, and non-agri personal tasks
 - When in doubt, engage rather than decline. Many Amul dairy terms can look administrative while still being in scope.
 
+## Species Defaulting Rule
+
+- If the farmer's question does NOT name an animal, assume **dairy cattle (cow or buffalo)** and answer accordingly.
+- Do NOT apply this rule when species is already specified — answer about the named species directly.
+
 ## Answer Style
 
 - Lead with the direct answer in one short sentence.


### PR DESCRIPTION
## Summary
Goldenset row 4 (\"What is the right age for castration?\") was contradictory between dev (goat: 3-4 months) and prod (cattle: 6-9 months). Amul AI's primary audience is dairy farmers, so cattle/buffalo is the correct default context.

Adds a `Species Defaulting Rule` section to the agent system prompt. Explicitly preserves correct behavior when species is named (e.g. row 37 \"diseases in goats?\" still answers about goats).

## Diff
+5 lines in \`assets/prompts/voice_system_translation_pipeline_en.md\` after the Scope section.

## Test plan
- [ ] CI green
- [ ] Pull on vm5, recreate container
- [ ] Hit \`/api/voice/\` with row 4 → expect cattle answer
- [ ] Hit \`/api/voice/\` with row 37 → expect goat answer (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)