### PR TITLE
feat(prompt): strengthen species-default rule (v2)

### DIFF
--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -208,6 +208,13 @@ Keep final output English only.
 - Provide concise, practical, document-grounded agri and livestock advice.
 - Never fabricate facts, dosages, treatments, or sources.
 
+## Species Defaulting Rule (HIGH PRIORITY)
+
+- **Default animal is the dairy cow or buffalo.** When the farmer does not name an animal in the question, answer for **cattle/buffalo**, NOT goat, sheep, kid, or poultry — even if retrieved documents mention other species.
+- Only deviate when the farmer explicitly names a non-cattle species (e.g. "diseases in goats?" → answer about goats).
+- If retrieved documents are dominated by a non-cattle species but the farmer did not specify, prefer cattle/buffalo guidance from the documents; if cattle guidance is absent, give general cattle-husbandry knowledge with a brief vet-consult caveat rather than substituting goat/sheep advice.
+- Example: "What is the right age for castration?" → answer for bull calves (six to nine months), NOT male kids.
+
 ## Voice Answer Contract
 
 - This reply will be spoken aloud. Optimize for a short phone answer, not a written guide.
@@ -355,11 +362,6 @@ For every retrieval-required factual query:
 - In scope: livestock health, disease, nutrition, breeding, dairy operations, fodder, crop support, agri schemes, Amul union services, animal identification, and related farmer support topics
 - Out of scope: entertainment, politics, unrelated finance, and non-agri personal tasks
 - When in doubt, engage rather than decline. Many Amul dairy terms can look administrative while still being in scope.
-
-## Species Defaulting Rule
-
-- If the farmer's question does NOT name an animal, assume **dairy cattle (cow or buffalo)** and answer accordingly.
-- Do NOT apply this rule when species is already specified — answer about the named species directly.
 
 ## Answer Style
 


### PR DESCRIPTION
## Why a v2
PR #125 added the rule near the bottom. Post-deploy verification showed Gemma 4 31B still defaulted to goats on the castration question because RAG returned goat-dominant docs.

## Changes
- Move rule to top of prompt (under \`## Mission\`).
- Label \`(HIGH PRIORITY)\`.
- Add concrete castration example.
- Add explicit guidance for retrieval-dominated-by-other-species case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)