### PR TITLE
fix(translation): stop stripping 'સર'; preserves Sarlaben self-name

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -131,9 +131,8 @@ GU_POST_REPLACEMENTS = GU_POST_REPLACEMENTS_BASE + GU_POLICY_REPLACEMENTS
 
 # ── Gender-neutral caller-address guard ─────────────────────────────────────
 # Replace gendered address terms directed at the *caller* with neutral forms.
-# Patterns are boundary-aware: they must NOT match inside "સરલાબેન" or livestock
-# compound terms (e.g. "ભૂખ ભાઈ" is a common animal-behaviour phrase, but
-# "ભાઈ," at the start of a greeting is a caller address).
+# Patterns are boundary-aware (e.g. "ભૂખ ભાઈ" is a common animal-behaviour
+# phrase, but "ભાઈ," at the start of a greeting is a caller address).
 # Each tuple: (compiled pattern, replacement).
 GU_GENDER_NEUTRAL_POST: list[tuple[re.Pattern, str]] = [
     # "ભાઈ" or "ભૈ" as caller address (preceded by start-of-string, comma, space, or period)
@@ -144,8 +143,6 @@ GU_GENDER_NEUTRAL_POST: list[tuple[re.Pattern, str]] = [
     (re.compile(r"(?<![^\s,।.!?])સ(?:ા)?હ(?:ે)?બ(?=\s*[,।!?]|\s|$)"), ""),
     # "મેડમ" / "મૅડમ" / "મૅડ" as caller address
     (re.compile(r"(?<![^\s,।.!?])મ(?:ે|ૅ|ૅ)ડ(?:મ|)(?=\s*[,।!?]|\s|$)"), ""),
-    # "સર" as standalone caller address (not part of "સરલાબેન")
-    (re.compile(r"(?<![^\s,।.!?])સર(?!લ)(?=\s*[,।!?]|\s|$)"), ""),
 ]
 
 GU_WORD_BOUNDARY_START = r"(?<![\u0A80-\u0AFF])"


### PR DESCRIPTION
## Summary
- Removes the `સર` caller-address strip from `GU_GENDER_NEUTRAL_POST` in `app/services/translation.py`.
- The rule's `(?!લ)` guard against the bot's own name `સરલાબેન` only held when the two syllables were contiguous. TranslateGemma routinely transliterates the proper noun with a space/comma/newline between them (`સર લાબેન`), and once a non-`લ` character intervenes the lookahead passes, `સર` is stripped, and TTS speaks only **લાબેન**.
- Other four honorific strips (ભાઈ, બહેન, સાહેબ, મેડમ) are unchanged. The upstream `GU_PREFERRED_TRANSLATION_RULES` already instructs the translator not to use `સર` as a caller label, so the regex was load-bearing only as a belt-and-braces — and the brace was clobbering the bot's identity.

## Repros (prod, voice-production)
- `14e68d5c-f185-4fdd-99ba-d0b3e25b35bc`
- `33c29088-a22e-4d98-8670-6f23c599006e`
- `718a92a6-371c-4af9-8fa4-fec611fbbc21`

## Test plan
- [ ] Trigger a fresh voice call in Gujarati; first turn should now have Sarlaben fully audible (`સરલાબેન`) in TTS, not `લાબેન`.
- [ ] Spot-check the next ~10 prod sessions after rollout to confirm no regression where Translategemma starts emitting `સર` as a literal vocative directed at the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)