### PR TITLE
fix(moderation): allow conceptual ભાવફેર / PD / dividend queries

### DIFF
--- a/assets/prompts/voice_moderation_en.md
+++ b/assets/prompts/voice_moderation_en.md
@@ -16,7 +16,7 @@ You are the content-moderation gate for Amul AI, a live phone helpline for India
 - Animal housing, hygiene, shelter, comfort
 - Cattle, buffalo, camels, goats, sheep, poultry care
 - Farmer's own profile, animal tag numbers, DCS / society / union records
-- Amul cooperative services: payment, passbook, society membership, AI (artificial insemination) booking
+- Amul cooperative services: payment, passbook, society membership, AI (artificial insemination) booking, cooperative payment concepts (milk price, rate, ભાવફેર / price differential, PD / price difference, બોનસ / bonus, ડિવિડન્ડ / dividend, rate adjustment) — **including explainer questions** like "ભાવફેર શું છે?" / "how is PD calculated?"
 - Government schemes relevant to agriculture, dairy, livestock, or rural development
 - Weather as it relates to animals, fodder, or farm operations
 - Market prices for milk, fodder, livestock


### PR DESCRIPTION
## Problem

Mirror of [openAgriNet/amul-oan-api#72](https://github.com/OpenAgriNet/amul-oan-api/pull/72). Conceptual queries about Amul cooperative payment terms (\"ભાવફેર શું છે?\", \"how is PD calculated?\") risk being classified as off-scope. On a live phone call a false reject ends a real farmer's call — far worse than the chat case.

## Change

One-line edit to `assets/prompts/voice_moderation_en.md`: the existing **Amul cooperative services** in-scope line is extended to explicitly list cooperative payment concepts (ભાવફેર / price differential, PD, બોનસ / bonus, ડિવિડન્ડ / dividend, rate adjustment) and their explainer questions.

Voice already has a strong scope-bias default (\"context uncertain → in_scope\") and explicit `Amul cooperative services` mention, so this is mostly an explicit-intent reinforcement to match the chat carve-out. Not stacking — single bullet edit.

## Validation

Recommend a dev smoke replay on the voice pipeline of:
- \"ભાવફેર શું છે ?\" → should classify `in_scope`
- \"PD કેવી રીતે ગણાય છે?\" → should classify `in_scope`

Paired chat PR: openAgriNet/amul-oan-api#72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)