### PR TITLE
feat(pipeline): Redis-sticky %-split between OSS and legacy voice pipelines

### DIFF
--- a/agents/models/__init__.py
+++ b/agents/models/__init__.py
@@ -144,3 +144,52 @@ else:
     raise ValueError(
         f"Invalid LLM_PROVIDER: {LLM_PROVIDER}. Must be one of: 'vllm', 'openai', 'azure-openai', 'anthropic'"
     )
+
+
+# --- OSS pipeline (open-source models via vLLM) ---------------------------------
+# Built additively alongside the legacy LLM_MODEL so a per-request sticky split can
+# route a configurable % of voice sessions to the OSS path (vLLM gemma agent +
+# vLLM gemma pretranslation; post-translation TranslateGemma is unchanged).
+#
+# This block must never raise at import: if OSS env is absent, OSS_LLM_MODEL stays
+# None and get_model_for_variant() transparently falls back to the legacy model, so
+# legacy behaviour is byte-identical when the split is disabled (OSS_PIPELINE_PCT=0).
+OSS_LLM_MODEL_NAME = os.getenv('OSS_LLM_MODEL_NAME', 'gemma-4-31b-it')
+OSS_INFERENCE_ENDPOINT_URL = os.getenv('OSS_INFERENCE_ENDPOINT_URL')
+OSS_INFERENCE_API_KEY = os.getenv('OSS_INFERENCE_API_KEY', 'dummy')
+
+OSS_LLM_MODEL = None
+if OSS_INFERENCE_ENDPOINT_URL:
+    try:
+        OSS_LLM_MODEL = BoundaryCaptureOpenAIModel(
+            OSS_LLM_MODEL_NAME,
+            provider=OpenAIProvider(
+                base_url=OSS_INFERENCE_ENDPOINT_URL,
+                api_key=OSS_INFERENCE_API_KEY,
+            ),
+        )
+    except Exception:  # pragma: no cover - never break startup on OSS misconfig
+        OSS_LLM_MODEL = None
+
+
+def oss_model_available() -> bool:
+    """True when an OSS vLLM model object was successfully constructed."""
+    return OSS_LLM_MODEL is not None
+
+
+def get_model_for_variant(variant: str):
+    """Return the pydantic-ai model object for a resolved pipeline variant.
+
+    'oss' -> the vLLM model when configured, else the legacy model (fail-safe).
+    anything else -> the legacy startup model (unchanged behaviour).
+    """
+    if variant == 'oss' and OSS_LLM_MODEL is not None:
+        return OSS_LLM_MODEL
+    return LLM_MODEL
+
+
+def provider_for_variant(variant: str) -> str:
+    """Effective provider for a resolved variant: OSS is OpenAI-compatible (vLLM)."""
+    if variant == 'oss' and OSS_LLM_MODEL is not None:
+        return 'vllm'
+    return LLM_PROVIDER

--- a/app/config.py
+++ b/app/config.py
@@ -78,6 +78,16 @@ class Settings(BaseSettings):
     voice_trace_preview_chars: int = int(os.getenv("VOICE_TRACE_PREVIEW_CHARS", "120"))
     voice_trace_log_summary: bool = _get_bool_env("VOICE_TRACE_LOG_SUMMARY", default=True)
 
+    # Sticky %-split between OSS (vLLM gemma + pretranslation) and legacy pipelines.
+    # A session is bucketed deterministically by session_id; OSS_PIPELINE_PCT
+    # controls what fraction lands on OSS. With OSS_PIPELINE_PCT=0 (default) or
+    # OSS_INFERENCE_ENDPOINT_URL unset, every session resolves to 'legacy' and
+    # behaviour is byte-identical to today.
+    oss_pipeline_pct: int = int(os.getenv("OSS_PIPELINE_PCT", "0"))
+    oss_inference_endpoint_url: Optional[str] = os.getenv("OSS_INFERENCE_ENDPOINT_URL")
+    oss_llm_model_name: Optional[str] = os.getenv("OSS_LLM_MODEL_NAME")
+    oss_variant_ttl: int = int(os.getenv("OSS_VARIANT_TTL", str(60 * 60 * 24 * 7)))  # 7d sticky
+
     # Voice pipeline behavioral flags
     # RETRIEVAL_AUDIT_LOG: log intent/retrieval_called/query per turn for replay analysis
     retrieval_audit_log: bool = _get_bool_env("RETRIEVAL_AUDIT_LOG", default=False)

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -4,6 +4,7 @@ from app.auth.jwt_auth import get_current_user
 from app.config import settings
 from app.services.voice_trace import create_voice_trace
 from app.services.voice import stream_voice_message
+from app.services.pipeline_router import resolve_pipeline_variant
 from app.utils import _get_message_history, claim_session_request_ownership
 from app.models.requests import ChatRequest
 from helpers.utils import get_logger
@@ -64,6 +65,10 @@ async def voice_endpoint(
     )
     logger.debug(f"Retrieved message history for session {session_id} - length: {len(history)}")
 
+    # Sticky per-session OSS/legacy routing (no-op while OSS_PIPELINE_PCT=0
+    # or OSS_INFERENCE_ENDPOINT_URL unset — resolver returns 'legacy').
+    pipeline_variant = await resolve_pipeline_variant(session_id)
+
     return StreamingResponse(
         stream_voice_message(
             query=request.query,
@@ -78,6 +83,7 @@ async def voice_endpoint(
             owner=owner,
             http_request=http_request,
             trace=trace,
+            pipeline_variant=pipeline_variant,
         ),
         media_type='text/event-stream'
-    ) 
+    )

--- a/app/services/pipeline_router.py
+++ b/app/services/pipeline_router.py
@@ -1,0 +1,70 @@
+"""Sticky per-session pipeline-variant router (voice).
+
+Routes a configurable percentage of voice sessions to the OSS pipeline
+(vLLM gemma agent + vLLM gemma pretranslation; post-translation
+TranslateGemma is unchanged regardless of variant) while the rest stay
+on the legacy pipeline. The assignment is:
+
+* deterministic   - bucketed from a stable hash of session_id, so the same
+                     session always lands the same way even without Redis;
+* sticky          - the resolved variant is persisted in the shared Redis
+                     cache, so a session keeps its variant for its lifetime
+                     even if OSS_PIPELINE_PCT is changed afterwards;
+* shared          - all API instances read the same Redis state;
+* fail-safe       - any Redis error degrades to the deterministic hash, never
+                     raising into the request path. With OSS_PIPELINE_PCT=0 (or
+                     OSS model unconfigured) every session resolves to
+                     ``legacy`` and behaviour is identical to today.
+
+Mirror of amul-oan-api's app/services/pipeline_router.py (#66).
+"""
+from __future__ import annotations
+
+import hashlib
+
+from app.config import settings
+from app.core.cache import cache
+from agents.models import oss_model_available
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+LEGACY = "legacy"
+OSS = "oss"
+
+_KEY_PREFIX = "voice_pipeline_variant:"
+
+
+def _deterministic_variant(session_id: str) -> str:
+    """Stable 0-99 bucket from session_id; OSS when bucket < configured pct."""
+    pct = max(0, min(100, settings.oss_pipeline_pct))
+    if pct <= 0 or not oss_model_available():
+        return LEGACY
+    digest = hashlib.sha256((session_id or "").encode("utf-8")).hexdigest()
+    bucket = int(digest[:8], 16) % 100
+    return OSS if bucket < pct else LEGACY
+
+
+async def resolve_pipeline_variant(session_id: str) -> str:
+    """Return the sticky pipeline variant ('oss' | 'legacy') for a session."""
+    if not session_id:
+        return _deterministic_variant(session_id)
+
+    key = f"{_KEY_PREFIX}{session_id}"
+
+    try:
+        stored = await cache.get(key)
+        if stored in (OSS, LEGACY):
+            return stored
+    except Exception as e:  # Redis down / timeout -> deterministic fallback
+        logger.warning("voice pipeline_router: cache read failed for %s: %s", session_id, e)
+        return _deterministic_variant(session_id)
+
+    variant = _deterministic_variant(session_id)
+
+    try:
+        await cache.set(key, variant, ttl=settings.oss_variant_ttl)
+    except Exception as e:  # persistence is best-effort; assignment still stable
+        logger.warning("voice pipeline_router: cache write failed for %s: %s", session_id, e)
+
+    return variant

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -45,6 +45,30 @@ OPENAI_PRETRANSLATION_MODEL = os.getenv(
 )
 _openai_client: Optional[AsyncOpenAI] = None
 
+# OSS pretranslation (vLLM) — used per-request only for sticky 'oss' sessions,
+# independent of the startup PRETRANSLATION_PROVIDER so legacy sessions are
+# completely unaffected. Mirrors amul-oan-api's OSS pretranslation path.
+OSS_INFERENCE_ENDPOINT_URL = (os.getenv("OSS_INFERENCE_ENDPOINT_URL", "") or "").rstrip("/")
+OSS_INFERENCE_API_KEY = os.getenv("OSS_INFERENCE_API_KEY") or "dummy"
+OSS_PRETRANSLATION_MODEL = os.getenv(
+    "OSS_PRETRANSLATION_MODEL", os.getenv("OSS_LLM_MODEL_NAME", "gemma-4-31b-it")
+)
+_oss_pretrans_client: Optional[AsyncOpenAI] = None
+
+
+def _get_oss_pretranslation_client() -> AsyncOpenAI:
+    """OpenAI-compatible client pinned to the OSS vLLM endpoint."""
+    global _oss_pretrans_client
+    if _oss_pretrans_client is None:
+        if not OSS_INFERENCE_ENDPOINT_URL:
+            raise ValueError(
+                "OSS_INFERENCE_ENDPOINT_URL is required for OSS pretranslation"
+            )
+        _oss_pretrans_client = AsyncOpenAI(
+            api_key=OSS_INFERENCE_API_KEY, base_url=OSS_INFERENCE_ENDPOINT_URL
+        )
+    return _oss_pretrans_client
+
 
 GU_PREFERRED_TRANSLATION_RULES = [
     "Use farmer-preferred Gujarati livestock terms.",
@@ -860,6 +884,116 @@ async def translate_to_english_with_gpt5_mini(
             (text or "")[:160],
         )
         raise TimeoutError("OpenAI pretranslation timed out") from e
+
+
+async def _create_oss_pretranslation_response(
+    client: AsyncOpenAI,
+    *,
+    source_name: str,
+    source_code: str,
+    text: str,
+    max_tokens: int,
+):
+    """Mirror of _create_openai_pretranslation_response, pinned to the OSS vLLM endpoint."""
+    return await asyncio.wait_for(
+        client.chat.completions.create(
+            model=OSS_PRETRANSLATION_MODEL,
+            messages=_build_openai_pretranslation_messages(source_name, source_code, text),
+            max_completion_tokens=max_tokens,
+            response_format={"type": "json_object"},
+        ),
+        timeout=settings.openai_pretranslation_timeout_seconds,
+    )
+
+
+async def translate_to_english_with_oss_vllm(
+    text: str,
+    source_lang: str,
+    *,
+    max_tokens: int = 1024,
+) -> tuple[str, str]:
+    """Pretranslate via the OSS vLLM endpoint (per-request, sticky 'oss' sessions).
+
+    Same return contract as translate_to_english_with_gpt5_mini:
+    (translated_text, confidence) where confidence is "high", "low", or "unknown".
+
+    Legacy sessions never hit this — the function is only called when the
+    sticky pipeline router returns variant='oss'.
+    """
+    if not text or not text.strip():
+        return text, "unknown"
+
+    if source_lang.lower() in {"english", "en"}:
+        return text, "high"
+
+    client = _get_oss_pretranslation_client()
+    source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
+    source_code = LANG_CODES.get(source_lang.lower(), source_lang.lower())
+
+    langfuse = _get_langfuse()
+
+    try:
+        if not langfuse:
+            response = await _create_oss_pretranslation_response(
+                client,
+                source_name=source_name,
+                source_code=source_code,
+                text=text,
+                max_tokens=max_tokens,
+            )
+            translated_text, confidence = _extract_translation_from_response(response)
+            if not translated_text:
+                logger.warning(
+                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    source_lang, (text or "")[:100],
+                )
+                return text, "low"
+            translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
+            return translated_text, confidence
+
+        with langfuse.start_as_current_observation(
+            name="query_pretranslation",
+            as_type="generation",
+            input={
+                "source_lang": source_lang,
+                "target_lang": "english",
+                "text": text,
+            },
+            model=OSS_PRETRANSLATION_MODEL,
+            metadata={
+                "translation_provider": "vllm",
+                "pipeline_stage": "query_pretranslation",
+                "pipeline_variant": "oss",
+            },
+        ) as observation:
+            response = await _create_oss_pretranslation_response(
+                client,
+                source_name=source_name,
+                source_code=source_code,
+                text=text,
+                max_tokens=max_tokens,
+            )
+            translated_text, confidence = _extract_translation_from_response(response)
+            if not translated_text:
+                logger.warning(
+                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    source_lang, (text or "")[:100],
+                )
+                observation.update(output="__EMPTY__", metadata={"confidence": "low"})
+                return text, "low"
+            translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
+            observation.update(output=translated_text)
+            return translated_text, confidence
+    except asyncio.TimeoutError as e:
+        logger.error(
+            "OSS vLLM pretranslation timed out - source_lang=%s model=%s timeout_seconds=%.2f query_chars=%s query_preview=%r",
+            source_lang,
+            OSS_PRETRANSLATION_MODEL,
+            settings.openai_pretranslation_timeout_seconds,
+            len(text or ""),
+            (text or "")[:160],
+        )
+        raise TimeoutError("OSS vLLM pretranslation timed out") from e
 
 
 async def translate_text_stream_fast(

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -56,16 +56,28 @@ from app.services.moderation import ModerationVerdict, check_moderation
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
+    OSS_PRETRANSLATION_MODEL,
     translate_text,
     translate_text_stream_fast,
     translate_to_english_with_gpt5_mini,
+    translate_to_english_with_oss_vllm,
     translate_to_english_with_structured_fallback,
 )
 from app.services.voice_trace import VoiceTrace, create_voice_trace
 # NOTE: Removing telemetry for now.
 # from app.tasks.telemetry import send_telemetry
 from agents.deps import FarmerContext
+from agents.models import (
+    LLM_MODEL_NAME,
+    OSS_LLM_MODEL_NAME,
+    get_model_for_variant,
+    provider_for_variant,
+)
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
+try:  # Langfuse is optional at import time
+    from langfuse import get_client as _get_langfuse_client
+except ImportError:  # pragma: no cover
+    _get_langfuse_client = None
 
 logger = get_logger(__name__)
 
@@ -770,11 +782,19 @@ async def stream_voice_message(
     owner: Optional[SessionRequestOwner] = None,
     http_request: Optional[Request] = None,
     trace: Optional[VoiceTrace] = None,
+    pipeline_variant: str = "legacy",
 #    background_tasks: BackgroundTasks,
-    
+
 ) -> AsyncGenerator[str, None]:
     """Async generator for streaming chat messages."""
     request_started_at = time.monotonic()
+    # OSS sticky variant => run the dev OSS path (vLLM gemma agent + vLLM
+    # gemma pretranslation). 'legacy' keeps current prod behaviour byte-for-byte;
+    # with OSS_PIPELINE_PCT=0 (or OSS endpoint unset) every session is 'legacy'.
+    is_oss = pipeline_variant == "oss"
+    request_model = get_model_for_variant(pipeline_variant)
+    request_provider = provider_for_variant(pipeline_variant)
+    request_model_name = OSS_LLM_MODEL_NAME if is_oss else LLM_MODEL_NAME
     last_owner_refresh_at = 0.0
     last_emitted_sig_char: str | None = None
     trace = trace or create_voice_trace(
@@ -785,6 +805,37 @@ async def stream_voice_message(
         target_lang=target_lang,
         provider=provider,
         process_id=process_id,
+    )
+    # Tag the trace with the resolved pipeline variant so Langfuse dashboards
+    # can filter sessions by variant. The categorical score is emitted lazily
+    # (once a Langfuse trace context is active) below.
+    try:
+        trace.metadata["pipeline_variant"] = pipeline_variant
+        trace.metadata["request_model"] = request_model_name
+        trace.metadata["request_provider"] = request_provider
+    except Exception:  # pragma: no cover - never break the call
+        pass
+    if _get_langfuse_client is not None:
+        try:
+            _lf = _get_langfuse_client()
+            # Score the current trace once a trace context is active. The
+            # score_id is deterministic per session so subsequent turns in the
+            # same session upsert the same score (no duplicates).
+            _lf.score_current_trace(
+                name="pipeline_variant",
+                value=pipeline_variant,
+                data_type="CATEGORICAL",
+                score_id=f"voice-variant-{(session_id or '')[:180]}",
+                comment="Sticky pipeline variant for this voice session",
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("Langfuse: voice pipeline_variant score failed: %s", e)
+    logger.info(
+        "voice request_variant session_id=%s variant=%s model=%s provider=%s",
+        session_id,
+        pipeline_variant,
+        request_model_name,
+        request_provider,
     )
 
     async def _request_is_stale(reason: str) -> bool:
@@ -1107,10 +1158,13 @@ async def stream_voice_message(
             )
 
             if requested_source_lang not in {"en", "english"}:
+                _pretrans_provider_label = "vllm" if is_oss else "openai"
+                _pretrans_model = OSS_PRETRANSLATION_MODEL if is_oss else OPENAI_PRETRANSLATION_MODEL
                 logger.info(
-                    "Translation pipeline enabled; pretranslating %s -> en with %s",
+                    "Translation pipeline enabled; pretranslating %s -> en with %s (variant=%s)",
                     requested_source_lang,
-                    OPENAI_PRETRANSLATION_MODEL,
+                    _pretrans_model,
+                    pipeline_variant,
                 )
                 if await _request_is_stale("before_query_pretranslation"):
                     moderation_task.cancel()
@@ -1120,17 +1174,27 @@ async def stream_voice_message(
                         "pretranslation",
                         as_type="generation",
                         input=trace.metadata.get("query"),
-                        metadata={"provider": "openai", "source_lang": requested_source_lang},
-                        model=OPENAI_PRETRANSLATION_MODEL,
+                        metadata={
+                            "provider": _pretrans_provider_label,
+                            "source_lang": requested_source_lang,
+                            "pipeline_variant": pipeline_variant,
+                        },
+                        model=_pretrans_model,
                     ):
-                        processing_query, pretranslation_confidence = await translate_to_english_with_gpt5_mini(
-                            text=query,
-                            source_lang=requested_source_lang,
-                        )
+                        if is_oss:
+                            processing_query, pretranslation_confidence = await translate_to_english_with_oss_vllm(
+                                text=query,
+                                source_lang=requested_source_lang,
+                            )
+                        else:
+                            processing_query, pretranslation_confidence = await translate_to_english_with_gpt5_mini(
+                                text=query,
+                                source_lang=requested_source_lang,
+                            )
                     trace.set_pretranslation(
                         text=processing_query,
                         confidence=pretranslation_confidence,
-                        provider="openai",
+                        provider=_pretrans_provider_label,
                         fallback_used=False,
                     )
                     history_user_text = processing_query or _canonical_history_user_text("low_confidence")
@@ -1403,6 +1467,9 @@ async def stream_voice_message(
                     metadata={
                         "signed_in": bool(signed_in and mobile),
                         "request_limit": usage_limits.request_limit,
+                        "pipeline_variant": pipeline_variant,
+                        "model": request_model_name,
+                        "provider": request_provider,
                     },
                 ):
                     agent_result = await active_agent.run(
@@ -1410,6 +1477,7 @@ async def stream_voice_message(
                         message_history=model_input_history,
                         deps=deps,
                         usage_limits=usage_limits,
+                        model=request_model,
                     )
                 _agent_output = (
                     getattr(agent_result, "output", None)


### PR DESCRIPTION
Mirrors openAgriNet/amul-oan-api#66 onto voice.

## What it does

Adds a per-session sticky router that sends `OSS_PIPELINE_PCT%` of voice sessions to the OSS pipeline (**vLLM gemma agent + vLLM gemma pretranslation**) while the rest stay on the legacy pipeline (**OpenAI GPT-5.1 agent + OpenAI pretranslation** — current prod). Post-translation (TranslateGemma) is unchanged for both variants.

- **Deterministic**: SHA256(session_id) → 0-99 bucket → `oss` if `bucket < pct`.
- **Sticky**: assignment persisted in Redis (`voice_pipeline_variant:<sid>` key, 7-day TTL); same session always lands the same way.
- **Shared**: all API instances read the same Redis state.
- **Fail-safe**: any Redis error degrades to the deterministic hash, never raises into the request path. With `OSS_PIPELINE_PCT=0` (default) or `OSS_INFERENCE_ENDPOINT_URL` unset, every session resolves to `legacy` and behaviour is byte-identical to today.

**Prompt selection deliberately untouched.** Both variants use whatever `VOICE_AGENT_PROMPT_VERSION` resolves to (default `mixed`). Tying the prompt to the variant (e.g. `oss → gemma4`) is a separate decision once we have real OSS traffic to A/B against — keeps this PR additive and reduces variables changing at once.

## Files

- **`agents/models/__init__.py`** — additive OSS model factory (`get_model_for_variant`, `provider_for_variant`) using `BoundaryCaptureOpenAIModel` to preserve voice's boundary-capture path. Never raises at import if OSS env absent.
- **`app/services/pipeline_router.py`** (new) — sticky variant resolver. Key prefix `voice_pipeline_variant:` to avoid colliding with the chat router's keys in shared Redis.
- **`app/routers/voice.py`** — resolves variant before streaming, passes through.
- **`app/services/voice.py`** — per-request model + provider branch; Langfuse categorical `pipeline_variant` score + variant-tagged trace metadata; `agent.run(..., model=request_model)` override; pretranslation branches to `translate_to_english_with_oss_vllm` when `is_oss`.
- **`app/services/translation.py`** — OSS vLLM pretranslation client + `translate_to_english_with_oss_vllm` with the same return contract as `translate_to_english_with_gpt5_mini`. Legacy pretranslation path untouched.
- **`app/config.py`** — `OSS_PIPELINE_PCT` (default 0), `OSS_INFERENCE_ENDPOINT_URL`, `OSS_LLM_MODEL_NAME`, `OSS_VARIANT_TTL` (7d).

## Validation plan (next)

After merge, on dev VM (amul-vm5-ai-backend):

1. Set `OSS_INFERENCE_ENDPOINT_URL=http://10.185.25.198:8020/v1` + `OSS_PIPELINE_PCT=50` in `~/voice-oan-api/.env`, restart `amul_voice_app` (network-fix if needed).
2. Generate ~60 voice requests with distinct random `session_id`s; expect ~50% `oss`, ~50% `legacy` (within hashing variance).
3. Repeat the same `session_id` 3× — variant must be identical (Redis stickiness).
4. Check Langfuse: every voice trace tagged with `pipeline_variant` categorical score; pretranslation observation metadata shows `provider: vllm` for OSS / `provider: openai` for legacy; agent stage metadata shows correct model+provider per variant.
5. Negative test: unset `OSS_INFERENCE_ENDPOINT_URL`, restart — `oss_model_available()` returns False, all sessions land `legacy` regardless of pct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)