### PR TITLE
voice: tag Langfuse trace with pipeline variant (oss/legacy)

### DIFF
--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -247,7 +247,14 @@ class VoiceTrace:
                         "trace_id": self.trace_id,
                         "provider": str(self.provider or ""),
                     },
-                    tags=["voice", str(self.provider or "api")],
+                    tags=[
+                        "voice",
+                        str(self.provider or "api"),
+                        # Mirror chat's `variant:<oss|legacy>` trace tag so voice
+                        # sessions are sliceable by pipeline variant in Langfuse.
+                        # pipeline_variant is set on metadata before this opens.
+                        f"variant:{self.metadata.get('pipeline_variant') or 'legacy'}",
+                    ],
                     trace_name="voice_request",
                 )
             )


### PR DESCRIPTION
## What
Adds a `variant:oss` / `variant:legacy` tag to the `voice_request` Langfuse trace, mirroring chat (amul-oan-api `chat.py`: `tags=[f"pipeline:{...}", f"variant:{pipeline_variant}"]`).

## Why
Voice already records `pipeline_variant` in trace **metadata** and as a categorical **score**, but **not** as a trace **tag** — so voice sessions can't be filtered by variant in Langfuse the way chat can. This brings parity now that prod voice runs the 10% OSS split (`OSS_PIPELINE_PCT=10`).

## Change
Single edit in `app/services/voice_trace.py` `request_context()`: append `f"variant:{metadata['pipeline_variant'] or 'legacy'}"` to the trace tags. No signature/flow changes; `pipeline_variant` is already set on `metadata` (in `voice.py` `stream_voice_message`) before the root span opens.

## Deploy
After merge to `amul-prod`: trigger `run-voice-oan-api-build.sh` (Argo kaniko build → `kubectl set image` on `voice-oan-api`, rolling/PDB-respected). Verify new `voice-production` traces carry `variant:*` alongside `['RAYA','voice']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)