### PR TITLE
perf(voice): upgrade pydantic-ai 0.2.4→1.102 and restore agent token streaming

### DIFF
--- a/agents/models/__init__.py
+++ b/agents/models/__init__.py
@@ -1,113 +1,88 @@
+import json
+import logging
 import os
-from typing import Literal, cast
+from typing import Optional
 
-from openai import APIStatusError, AsyncAzureOpenAI, AsyncStream
-from pydantic_ai.models.openai import OpenAIModel
-from pydantic_ai.models.openai import (
-    NOT_GIVEN,
-    OpenAIModelSettings,
-    chat,
-    get_user_agent,
-    ModelRequestParameters,
-    ModelResponse,
-    ModelMessage,
-)
+import httpx
+from openai import AsyncAzureOpenAI
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from dotenv import load_dotenv
-from openai.types.chat import ChatCompletionChunk
 
-from pydantic_ai import ModelHTTPError
-
-from app.model_boundary_capture import capture_model_boundary_payload
+from app.model_boundary_capture import boundary_capture_enabled, capture_model_boundary_payload
 
 load_dotenv()
 
+logger = logging.getLogger(__name__)
 
-class BoundaryCaptureOpenAIModel(OpenAIModel):
-    async def _completions_create(
-        self,
-        messages: list[ModelMessage],
-        stream: bool,
-        model_settings: OpenAIModelSettings,
-        model_request_parameters: ModelRequestParameters,
-    ) -> chat.ChatCompletion | AsyncStream[ChatCompletionChunk]:
-        tools = self._get_tools(model_request_parameters)
 
-        if not tools:
-            tool_choice: Literal["none", "required", "auto"] | None = None
-        elif not model_request_parameters.allow_text_output:
-            tool_choice = "required"
-        else:
-            tool_choice = "auto"
+# ── Model-boundary capture ────────────────────────────────────────────────────
+# pydantic-ai 1.x no longer exposes the `_completions_create` override the old
+# BoundaryCaptureOpenAIModel subclass hooked. Capture the outgoing chat payload
+# at the HTTP layer instead, via an httpx request event-hook on a custom client
+# passed to OpenAIProvider. Gated by MODEL_BOUNDARY_CAPTURE_ENABLED; best-effort,
+# never raises (a failed capture must never drop a model request).
+async def _capture_request_hook(request: httpx.Request) -> None:
+    if not boundary_capture_enabled():
+        return
+    try:
+        if not request.url.path.endswith("/chat/completions"):
+            return
+        raw = request.content
+        if not raw:
+            return
+        body = json.loads(raw.decode("utf-8"))
+        capture_model_boundary_payload(
+            {
+                "model_name": body.get("model"),
+                "provider": "openai-compatible",
+                "stream": bool(body.get("stream", False)),
+                "tool_choice": body.get("tool_choice"),
+                "url": str(request.url),
+                "payload": body,
+            }
+        )
+    except Exception as exc:  # pragma: no cover - capture is best-effort
+        logger.debug("Model boundary capture hook failed: %s", exc)
 
-        openai_messages = await self._map_messages(messages)
-        extra_headers = model_settings.get("extra_headers", {})
-        extra_headers.setdefault("User-Agent", get_user_agent())
 
-        request_kwargs = {
-            "model": self._model_name,
-            "messages": openai_messages,
-            "n": 1,
-            "parallel_tool_calls": model_settings.get("parallel_tool_calls", NOT_GIVEN),
-            "tools": tools or NOT_GIVEN,
-            "tool_choice": tool_choice or NOT_GIVEN,
-            "stream": stream,
-            "stream_options": {"include_usage": True} if stream else NOT_GIVEN,
-            "stop": model_settings.get("stop_sequences", NOT_GIVEN),
-            "max_completion_tokens": model_settings.get("max_tokens", NOT_GIVEN),
-            "temperature": model_settings.get("temperature", NOT_GIVEN),
-            "top_p": model_settings.get("top_p", NOT_GIVEN),
-            "timeout": model_settings.get("timeout", NOT_GIVEN),
-            "seed": model_settings.get("seed", NOT_GIVEN),
-            "presence_penalty": model_settings.get("presence_penalty", NOT_GIVEN),
-            "frequency_penalty": model_settings.get("frequency_penalty", NOT_GIVEN),
-            "logit_bias": model_settings.get("logit_bias", NOT_GIVEN),
-            "reasoning_effort": model_settings.get("openai_reasoning_effort", NOT_GIVEN),
-            "user": model_settings.get("openai_user", NOT_GIVEN),
-            "extra_headers": extra_headers,
-            "extra_body": model_settings.get("extra_body"),
-        }
-        capture_payload = {
-            "model_name": self.model_name,
-            "provider": self.system,
-            "stream": stream,
-            "tool_choice": tool_choice,
-            "allow_text_output": model_request_parameters.allow_text_output,
-            "payload": {
-                key: value
-                for key, value in request_kwargs.items()
-                if value is not NOT_GIVEN and value is not None
-            },
-        }
-        capture_model_boundary_payload(capture_payload)
+def _capture_http_client() -> httpx.AsyncClient:
+    """Long-lived AsyncClient with the boundary-capture event hook attached."""
+    return httpx.AsyncClient(event_hooks={"request": [_capture_request_hook]})
 
-        try:
-            return await self.client.chat.completions.create(**request_kwargs)
-        except APIStatusError as e:
-            if (status_code := e.status_code) >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise
+
+def _build_openai_compatible_model(
+    model_name: str,
+    *,
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> OpenAIChatModel:
+    return OpenAIChatModel(
+        model_name,
+        provider=OpenAIProvider(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=_capture_http_client(),
+        ),
+    )
 
 
 # Get configurations from environment variables
-LLM_PROVIDER    = os.getenv('LLM_PROVIDER', 'openai').lower()
+LLM_PROVIDER = os.getenv('LLM_PROVIDER', 'openai').lower()
 LLM_MODEL_NAME = os.getenv('LLM_MODEL_NAME')
 
 if LLM_PROVIDER == 'vllm':
-    LLM_MODEL = BoundaryCaptureOpenAIModel(
+    LLM_MODEL = _build_openai_compatible_model(
         LLM_MODEL_NAME,
-        provider=OpenAIProvider(
-            base_url=os.getenv('INFERENCE_ENDPOINT_URL'), 
-            api_key=os.getenv('INFERENCE_API_KEY'),  
-        ),
+        base_url=os.getenv('INFERENCE_ENDPOINT_URL'),
+        api_key=os.getenv('INFERENCE_API_KEY'),
     )
 elif LLM_PROVIDER == 'openai':
-    LLM_MODEL = BoundaryCaptureOpenAIModel(
+    LLM_MODEL = _build_openai_compatible_model(
         LLM_MODEL_NAME,
-        provider=OpenAIProvider(
-            api_key=os.getenv('OPENAI_API_KEY'),
-        ),
+        base_url=None,
+        api_key=os.getenv('OPENAI_API_KEY'),
     )
 elif LLM_PROVIDER == 'anthropic':
     # AnthropicModel reads ANTHROPIC_API_KEY from the environment
@@ -120,7 +95,7 @@ elif LLM_PROVIDER == 'azure-openai':
     azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
     azure_api_version = os.getenv('AZURE_OPENAI_API_VERSION')
     azure_deployment_name = os.getenv('AZURE_OPENAI_DEPLOYMENT_NAME')
-    
+
     if not azure_endpoint:
         raise ValueError("AZURE_OPENAI_ENDPOINT environment variable is required")
     if not azure_api_key:
@@ -129,14 +104,15 @@ elif LLM_PROVIDER == 'azure-openai':
         raise ValueError("AZURE_OPENAI_API_VERSION environment variable is required")
     if not azure_deployment_name:
         raise ValueError("AZURE_OPENAI_DEPLOYMENT_NAME environment variable is required")
-    
+
     azure_client = AsyncAzureOpenAI(
         azure_endpoint=azure_endpoint.rstrip('/'),
         api_version=azure_api_version,
         api_key=azure_api_key,
+        http_client=_capture_http_client(),
     )
-    
-    LLM_MODEL = BoundaryCaptureOpenAIModel(
+
+    LLM_MODEL = OpenAIChatModel(
         azure_deployment_name,
         provider=OpenAIProvider(openai_client=azure_client),
     )
@@ -161,12 +137,10 @@ OSS_INFERENCE_API_KEY = os.getenv('OSS_INFERENCE_API_KEY', 'dummy')
 OSS_LLM_MODEL = None
 if OSS_INFERENCE_ENDPOINT_URL:
     try:
-        OSS_LLM_MODEL = BoundaryCaptureOpenAIModel(
+        OSS_LLM_MODEL = _build_openai_compatible_model(
             OSS_LLM_MODEL_NAME,
-            provider=OpenAIProvider(
-                base_url=OSS_INFERENCE_ENDPOINT_URL,
-                api_key=OSS_INFERENCE_API_KEY,
-            ),
+            base_url=OSS_INFERENCE_ENDPOINT_URL,
+            api_key=OSS_INFERENCE_API_KEY,
         )
     except Exception:  # pragma: no cover - never break startup on OSS misconfig
         OSS_LLM_MODEL = None

--- a/agents/voice.py
+++ b/agents/voice.py
@@ -44,9 +44,8 @@ def _build_voice_agent(name: str, tools):
     return Agent(
         model=LLM_MODEL,
         name=name,
-        instrument=True,
         output_type=str,
-        deps=FarmerContext,
+        deps_type=FarmerContext,
         retries=3,
         tools=tools,
         instructions=STATIC_VOICE_SYSTEM_PROMPT,

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1457,72 +1457,21 @@ async def stream_voice_message(
                 process_id=process_id,
                 user_query=processing_query,
             ):
-                # pydantic-ai 0.2.4's run_stream + stream_text(delta=True) does not
-                # drive the agent loop past a tool-call-only first response — Gemma 4
-                # frequently emits tool_calls without text, after which the streamed
-                # iterator yields zero chunks and the run never completes. Switching
-                # to the non-streaming `run()` forces the full tool-call/response loop
-                # and reliably returns the final en text; we then stream the en→gu
-                # translation downstream via translate_text_stream_fast so the
-                # external response contract (gu chunks to the caller) is preserved.
-                with trace.stage(
-                    "agent",
-                    as_type="agent",
-                    metadata={
-                        "signed_in": bool(signed_in and mobile),
-                        "request_limit": usage_limits.request_limit,
-                        "pipeline_variant": pipeline_variant,
-                        "model": request_model_name,
-                        "provider": request_provider,
-                    },
-                ):
-                    agent_result = await active_agent.run(
-                        user_prompt=user_message,
-                        message_history=model_input_history,
-                        deps=deps,
-                        usage_limits=usage_limits,
-                        model=request_model,
-                    )
-                _agent_output = (
-                    getattr(agent_result, "output", None)
-                    or getattr(agent_result, "data", None)
-                    or ""
-                )
-                if not isinstance(_agent_output, str):
-                    _agent_output = str(_agent_output)
-                _agent_output = _agent_output.strip()
-                if _agent_output:
-                    trace.mark("first_agent_text_ms")
-
-                class _AgentRunResultStreamShim:
-                    """Adapter so the downstream batching/translation logic keeps
-                    working unchanged: yields the full en text as a single chunk
-                    and exposes the same `new_messages()` accessor."""
-
-                    def __init__(self, result, text: str) -> None:
-                        self._result = result
-                        self._text = text
-
-                    def stream_text(self, *, delta: bool = True):  # noqa: ARG002
-                        text = self._text
-                        async def _gen():
-                            if text:
-                                yield text
-                        return _gen()
-
-                    def new_messages(self):
-                        return self._result.new_messages()
-
-                response_stream = _AgentRunResultStreamShim(agent_result, _agent_output)
-                # Run the rest of the original flow within a no-op async context so
-                # the indentation and finally-clauses below stay structurally intact.
-                from contextlib import asynccontextmanager as _asynccontextmanager
-
-                @_asynccontextmanager
-                async def _noop_async():
-                    yield response_stream
-
-                async with _noop_async() as response_stream:
+                # Restored token streaming on pydantic-ai 1.x. run_stream now drives
+                # the full tool-call loop past a tool-call-only first response (the
+                # 0.2.4 stall that previously forced a blocking run()), then streams
+                # the final English text. We pipe those en deltas straight into the
+                # en->gu batch translator below, so agent generation and output
+                # translation overlap instead of running strictly back-to-back.
+                agent_started_at = time.monotonic()
+                _agent_output = ""
+                async with active_agent.run_stream(
+                    user_prompt=user_message,
+                    message_history=model_input_history,
+                    deps=deps,
+                    usage_limits=usage_limits,
+                    model=request_model,
+                ) as response_stream:
                     stream_iter = response_stream.stream_text(delta=True)
                     first_text_chunk_received = False
                     sentence_buffer = ""
@@ -1571,6 +1520,11 @@ async def stream_voice_message(
                         async for chunk in stream_iter:
                             if await _request_is_stale("during_agent_stream"):
                                 break
+
+                            if isinstance(chunk, str) and chunk:
+                                if not _agent_output and chunk.strip():
+                                    trace.mark("first_agent_text_ms")
+                                _agent_output += chunk
 
                             if not needs_output_translation:
                                 if (
@@ -1735,7 +1689,17 @@ async def stream_voice_message(
                                 pass
 
                     logger.info(f"Streaming complete for session {session_id}")
+                    _agent_output = _agent_output.strip()
                     new_messages = response_stream.new_messages()
+                    trace.attach_stage_timing(
+                        "agent",
+                        (time.monotonic() - agent_started_at) * 1000.0,
+                        signed_in=bool(signed_in and mobile),
+                        request_limit=usage_limits.request_limit,
+                        pipeline_variant=pipeline_variant,
+                        model=request_model_name,
+                        provider=request_provider,
+                    )
                     trace.set_agent(
                         signed_in=bool(signed_in and mobile),
                         output=_agent_output,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ requests
 # LLM
 openai
 anthropic
-pydantic==2.11.4
+pydantic==2.13.4
 tiktoken
 tenacity
 
@@ -38,7 +38,7 @@ python-decouple
 openpyxl
 
 ### Pydantic AI (Updated to resolve conflicts)
-pydantic-ai-slim[openai,anthropic,vertexai]==0.2.4
+pydantic-ai-slim[openai,anthropic,vertexai]==1.102.0
 asgiref
 
 # Web Server


### PR DESCRIPTION
## Why

The voice agent was switched from streaming `run_stream()` to a blocking `run()` in 548f581 to work around a **pydantic-ai 0.2.4** bug: `run_stream()` stalled on Gemma's tool-call-only first response (empty content + tool_calls), yielding zero chunks. That removed all token streaming and forced agent generation and en→gu output translation to run strictly back-to-back.

**pydantic-ai 1.102** drives the full tool loop past that turn, so we can restore streaming — and overlap agent generation with output translation.

## Changes

- **requirements**: `pydantic-ai-slim` 0.2.4→1.102.0, `pydantic` 2.11.4→2.13.4 (marqo 3.18 only needs pydantic≥2.0 — no conflict).
- **agents/models/__init__.py**: drop the `BoundaryCaptureOpenAIModel(OpenAIModel)` subclass — the `_completions_create` override point is gone in 1.x. Boundary capture (debug-only, `MODEL_BOUNDARY_CAPTURE_ENABLED`) is re-implemented as an **httpx request event-hook** on a custom client passed to `OpenAIProvider`. Applies to both `LLM_MODEL` and `OSS_LLM_MODEL`.
- **agents/voice.py**: `deps=` → `deps_type=` (the old kwarg was silently swallowed by `**_deprecated_kwargs` — a latent no-op); drop per-agent `instrument=` (handled by `Agent.instrument_all()`).
- **app/services/voice.py**: restore `async with active_agent.run_stream(...)`, accumulate agent output from streamed deltas, record agent-stage timing via `attach_stage_timing` (kept the downstream batch/translation consumer unchanged).

## Validation

Built and run e2e on an isolated UAT VM5 container (`:8013`, live `:8003` untouched) against the **real OSS gemma + TranslateGemma** stack via `scripts/measure_voice_ttft.py` (drives `stream_voice_message` directly, no JWT). Tool loop completes; real token streaming confirmed.

| Scenario | Metric | Before (blocking) | After (streaming) | Δ |
|---|---|---|---|---|
| gu→gu (prod path) | TTFT p50 | 2760 ms | **1686 ms** | **−39%** |
| gu→gu | total p50 | 4301 ms | 3229 ms | −25% |
| en→en | TTFT p50 | 2664 ms | 2345 ms | −12% |

(Warm runs; first audio reaches the caller ~1.1s sooner on the Gujarati path.)

## Notes / risk

- Major version bump (0.x→1.x) — surfaces touched: Agent/Tool/UsageLimits/ModelSettings (all kwargs verified against 1.102), message types + `ModelMessagesTypeAdapter` (Redis history; low blast radius — per-call sessions, 24h TTL).
- If Gemma ever emits text-then-more-tools, `run_stream` could end early; fallback is `agent.iter()` node streaming. Not observed in testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)