### PR TITLE
perf(voice): disable stream_text debounce for faster first token

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1482,7 +1482,11 @@ async def stream_voice_message(
                     usage_limits=usage_limits,
                     model=request_model,
                 ) as response_stream:
-                    stream_iter = response_stream.stream_text(delta=True)
+                    # debounce_by=0 disables pydantic-ai's default 100ms token
+                    # debounce so the first agent delta reaches the translation
+                    # stage immediately (every ms counts for phone TTFT). Our own
+                    # sentence batching downstream re-aggregates the smaller chunks.
+                    stream_iter = response_stream.stream_text(delta=True, debounce_by=0)
                     first_text_chunk_received = False
                     sentence_buffer = ""
                     translation_batch: list[str] = []


### PR DESCRIPTION
`response_stream.stream_text(delta=True)` used pydantic-ai's default `debounce_by=0.1`, delaying the first agent delta by ~100 ms before it reaches our translation/emit stage. Set `debounce_by=0`; downstream sentence batching still re-aggregates.

**Measured on UAT VM5 (OSS gemma):**
- en→en TTFT **2345 → 1288 ms** (and far more consistent)
- gu→gu marginal (~1686→1646; the first batch waits for a full English sentence anyway, so the 100 ms was already partly hidden)

Part of the voice latency pass. Also measured but **not pursued**: concurrent moderation (gate is only ~343 ms on gemma and pretranslation must precede the agent on the gu path anyway → ~50 ms upside, not worth the rejection-race complexity); `reasoning_effort` (no benefit, dropped earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)