### PR TITLE
perf(voice): keep per-turn hints out of the cacheable prompt prefix

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -511,6 +511,12 @@ async def get_or_fetch_farmer_data(mobile: str):
 
 
 def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
+    """Stable per-call context (constant across a call's turns: date, farmer
+    profile, signed-in state, tool groups). Placed BEFORE history so the token
+    sequence [system][stable-context][history] stays a single growing prefix that
+    vLLM prefix caching can reuse across turns. Per-query content that changes
+    every turn lives in _build_query_hints_request() and is appended AFTER history
+    so it never breaks this prefix."""
     tool_groups = ["retrieval", "booking"]
     if deps.signed_in and deps.mobile:
         tool_groups.append("signed-in-farmer-data")
@@ -521,27 +527,40 @@ def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
         runtime_context.replace("Runtime context for this turn:\n", "", 1),
         f"- Tool groups in this run: {', '.join(tool_groups)}",
     ]
+    return ModelRequest(parts=[UserPromptPart(content="\n".join(context_lines))])
+
+
+def _build_query_hints_request(deps: FarmerContext) -> Optional[ModelRequest]:
+    """Per-query hints derived from the caller's current utterance: disambiguation
+    rules (for ambiguous terms) and the voice answer mode. Kept OUT of the stable
+    pre-history context — these change every turn, so placing them before history
+    would break the cacheable prefix. Appended right before the user message
+    instead, where the instructions also sit closest to the query they describe.
+    Returns None when the query triggers neither hint."""
+    hint_lines: list[str] = []
     # Inject ambiguity hints for the agent so it can decide to clarify vs. answer
     ambiguity_hints = get_ambiguity_hints_for_query(
         deps.query or "",
         threshold=settings.ambiguity_match_threshold,
     )
     if ambiguity_hints:
-        context_lines.append(f"- Disambiguation rules for terms in this query:\n{ambiguity_hints}")
+        hint_lines.append(f"- Disambiguation rules for terms in this query:\n{ambiguity_hints}")
     answer_mode = _voice_answer_mode_for_query(deps.query or "")
     if answer_mode == "compact_comparison":
-        context_lines.append(
+        hint_lines.append(
             "- Voice answer mode: compact comparison. Give one short contrast sentence, then at most one short practical takeaway. Do not enumerate. Do not use labels, colons, or list structure. Do not append an extra follow-up question unless required."
         )
     elif answer_mode == "compact_explainer":
-        context_lines.append(
+        hint_lines.append(
             "- Voice answer mode: compact explainer. Give one short plain-language definition or explanation, then at most one short practical takeaway. Do not teach the full topic. Do not enumerate. Do not use labels, colons, or list structure. Do not append an extra follow-up question unless required."
         )
     elif answer_mode == "action_first_symptom":
-        context_lines.append(
+        hint_lines.append(
             "- Voice answer mode: action-first symptom response. Start with the most useful immediate action in one short sentence. Add at most one short safety or escalation sentence. Do not give long background, multiple causes, or a symptom checklist unless asked."
         )
-    return ModelRequest(parts=[UserPromptPart(content="\n".join(context_lines))])
+    if not hint_lines:
+        return None
+    return ModelRequest(parts=[UserPromptPart(content="\n".join(["Hints for the current user query:", *hint_lines]))])
 
 
 def _extract_farmer_tags(records: list[FarmerRecord]) -> list[str]:
@@ -1449,7 +1468,13 @@ async def stream_voice_message(
             # attention to the actual runtime context. Keep only the runtime
             # context request, which carries the per-turn deps (today's date,
             # farmer profile, ambiguity hints, voice answer mode).
+            # Stable context first → [system][stable-context][history] is a single
+            # growing prefix vLLM can cache across turns. Per-query hints (if any)
+            # go last, right before the user message, so they never break it.
             model_input_history = [runtime_context_request, *trimmed_history]
+            query_hints_request = _build_query_hints_request(deps)
+            if query_hints_request is not None:
+                model_input_history.append(query_hints_request)
             active_agent = voice_agent_signed_in if (signed_in and mobile) else voice_agent
             usage_limits = UsageLimits(request_limit=6 if (signed_in and mobile) else 4)
 

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -33,6 +33,7 @@ from app.services.voice import (
     _build_ai_technician_summary,
     _build_compact_farmer_summary,
     _build_runtime_context_request,
+    _build_query_hints_request,
     _prepare_text_for_voice_translation,
     _has_meaningful_history,
     _is_bare_greeting,
@@ -440,7 +441,7 @@ class TestHelperCoverage:
 
     def test_runtime_context_adds_compact_comparison_mode(self):
         deps = FarmerContext(query="What is the difference between A2 milk and normal milk?")
-        request = _build_runtime_context_request(deps)
+        request = _build_query_hints_request(deps)
         content = request.parts[0].content
         assert "Voice answer mode: compact comparison." in content
         assert "Give one short contrast sentence" in content
@@ -448,14 +449,14 @@ class TestHelperCoverage:
 
     def test_runtime_context_adds_compact_explainer_mode(self):
         deps = FarmerContext(query="What is mastitis?")
-        request = _build_runtime_context_request(deps)
+        request = _build_query_hints_request(deps)
         content = request.parts[0].content
         assert "Voice answer mode: compact explainer." in content
         assert "Do not teach the full topic." in content
 
     def test_runtime_context_adds_action_first_symptom_mode(self):
         deps = FarmerContext(query="My cow has fever")
-        request = _build_runtime_context_request(deps)
+        request = _build_query_hints_request(deps)
         content = request.parts[0].content
         assert "Voice answer mode: action-first symptom response." in content
         assert "Start with the most useful immediate action" in content


### PR DESCRIPTION
The agent's per-turn context (`_build_runtime_context_request`) was injected **before** the conversation history, but it mixes:
- **stable per-call** content (today's date, farmer profile, signed-in state, tool groups), and
- **per-query** content recomputed every turn: disambiguation rules (`get_ambiguity_hints_for_query`) + the voice answer mode (`compact comparison/explainer/action-first`).

vLLM prefix caching matches the longest common **token** prefix. The per-query bits sitting before history broke the match right after the system prompt, so `[system][history]` was never reusable across turns — defeating prefix caching regardless of LB routing.

**Fix:** split the builder. Stable context stays before history → `[system][stable-context][history]` is one growing cacheable prefix. Per-query hints move to a new `_build_query_hints_request()` appended right before the user message (also the more natural spot for per-query instructions). The injected context isn't persisted (only `new_messages` is), so this is purely request ordering.

This is the **prerequisite** for prefix-cache reuse across turns; the full multi-turn win also needs session-affinity routing on the gemma LB (`:8020` is `least_conn` today) + an app-emitted session key — gated on the prod app deploy.

**Validation (UAT VM5):** fast unit suite = 262 passed / 23 failed, **identical to the amul-dev baseline** (the 23 are pre-existing 1.x test-maintenance debt — e.g. tests poking the renamed `Agent._function_tools`→`_function_toolset` internal — not introduced here). Answer-mode unit tests updated to the new builder and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)