### PR TITLE
fix(voice): green the 1.x unit suite + restore dropped disambiguation data

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -114,14 +114,14 @@ def extract_complete_sentences(text: str):
     if inline_structural_match and inline_structural_match.start() > 0:
         split_at = inline_structural_match.start()
         head = text[:split_at]
-        tail = text[split_at:]
+        tail = text[split_at:].lstrip("\n")
         if head:
             return [head], tail
     structural_match = re.search(r"\n(?=(?:#{1,6}\s|[-*•]\s|\d+\.\s))", text)
     if structural_match:
         split_at = structural_match.start()
         head = text[:split_at]
-        tail = text[split_at:]
+        tail = text[split_at:].lstrip("\n")
         if head:
             return [head], tail
     sentences = sentence_segmenter(text)
@@ -157,6 +157,14 @@ def _split_voice_batch_text(text: str, max_chars: int = VOICE_TRANSLATION_BATCH_
                 if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
                     split_at = idx
                     break
+
+    if split_at < 0:
+        # Last resort: split at the latest word boundary so an unpunctuated
+        # run-on still flushes for voice delivery instead of stalling until
+        # the stream ends.
+        idx = window.rfind(" ")
+        if idx >= VOICE_TRANSLATION_SOFT_SPLIT_MIN_CHARS:
+            split_at = idx
 
     if split_at < 0:
         return text, ""
@@ -1367,12 +1375,9 @@ async def stream_voice_message(
             if (
                 requested_source_lang not in {"en", "english"}
                 and not (processing_query or "").strip()
-                and not (processing_query or "").strip()
             ):
                 trace.set_route("pretranslation_empty")
                 logger.info(
-                    "Pretranslation produced no usable text; asking to repeat - session_id=%s process_id=%s query=%r",
-                    session_id, process_id, query,
                     "Pretranslation produced no usable text; asking to repeat - session_id=%s process_id=%s query=%r",
                     session_id, process_id, query,
                 )

--- a/assets/ambiguity_terms.json
+++ b/assets/ambiguity_terms.json
@@ -171,7 +171,10 @@
       "જર",
       "જર પડવી",
       "retained placenta",
-      "afterbirth retention"
+      "afterbirth retention",
+      "માટી ન ખસવી",
+      "મેલી ન પડવી",
+      "mati na khasvi"
     ],
     "type": "hardcode",
     "rule": "કથીરી / kathiri / મેલી / જર refers to retained placenta (afterbirth retention) — the placenta failing to expel within 8-12 hours after calving, risking uterine infection (metritis). When translating to English, always render as 'retained placenta' or 'afterbirth retention'. NEVER translate as Coccidiosis, parasitic infection, or any unrelated condition. Treat as a postpartum reproductive issue requiring veterinary intervention."
@@ -442,5 +445,75 @@
     ],
     "type": "hardcode",
     "rule": "'રેલી' (and inflected forms 'રેલીને', 'રેલીની') is a colloquial term for a **heifer** — a young female cow or buffalo that has not yet calved. It is NOT a proper name. Translate as 'heifer'."
+  },
+  {
+    "gu_terms": [
+      "ફેટ",
+      "fat",
+      "fet",
+      "ફેટ ઓછ",
+      "fat ochi"
+    ],
+    "type": "hardcode",
+    "rule": "'ફેટ' in dairy context means milk fat content or percentage, NOT પેટ (stomach). When a farmer says 'ફેટ ઓછી' or 'fat is low', they mean their milk fat percentage is below expected — answer about milk fat improvement (feed quality, bypass fat, mineral mixture), NOT stomach or digestive issues."
+  },
+  {
+    "gu_terms": [
+      "સમુદ્રી દાણ",
+      "સમુદ્રી",
+      "samudri",
+      "samudri dan"
+    ],
+    "type": "hardcode",
+    "rule": "If ASR or translation yields 'સમુદ્રી' / samudri in a feed question about cows or buffaloes, do not drift into marine feed or seaweed advice by default. If the intended feed term is uncertain, ask the caller to repeat or clarify the word instead of assuming a brand or product."
+  },
+  {
+    "gu_terms": [
+      "વાડો",
+      "vado",
+      "vaado"
+    ],
+    "type": "hardcode",
+    "rule": "'વાડો' means cattle shed or animal enclosure, NOT પાડો (male buffalo calf). When a farmer asks about 'વાડો', they are asking about housing, shelter, or shed management — NOT about calves."
+  },
+  {
+    "gu_terms": [
+      "ભેંસ",
+      "ભેંસને",
+      "ભેંસો",
+      "ભેસ",
+      "ભેસને",
+      "ભેંશ",
+      "ભેંશને",
+      "ભૈંસ",
+      "ભૈંસને",
+      "ભૈસ",
+      "ભૈસને",
+      "ભેન્સ",
+      "ભેન્સને",
+      "ભેસ્ટ",
+      "ભેસ્ટને",
+      "ભંચ",
+      "ભંચને",
+      "ભેંચ",
+      "ભેંચને",
+      "ભેન્ચ",
+      "ભેન્ચને"
+    ],
+    "type": "hardcode",
+    "rule": "'ભેંસ' and ASR/spelling variants such as 'ભેસ્ટ', 'ભંચ', and 'ભેંચને' mean buffalo in Gujarati dairy context, NOT sheep or goat. Translate these as Buffalo. The suffix '-ને' is only the Gujarati object marker, not part of the animal name."
+  },
+  {
+    "gu_terms": [
+      "ગરમી",
+      "ગરમીમાં",
+      "ગરમીમાં આવવું",
+      "ગરમી નથી આવતી",
+      "heat",
+      "garmi",
+      "not coming in heat"
+    ],
+    "type": "hardcode",
+    "rule": "CRITICAL DOMAIN DISTINCTION — ગરમી (heat/estrus) and ગાભણ (pregnancy) are COMPLETELY DIFFERENT concepts. ગરમી means the animal is in heat (estrus cycle, ready for mating). ગાભણ means the animal is pregnant (carrying a calf). When a farmer says 'ગરમી નથી આવતી' or 'not coming in heat', they mean the animal is NOT showing estrus signs — do NOT use the word ગાભણ (pregnant) in your response. Say 'ગરમીમાં ન આવવું' NOT 'ગાભણ ન આવવું'. Say 'છેલ્લે ગરમીમાં ક્યારે આવ્યું?' NOT 'છેલ્લે ક્યારે ગાભણ આવ્યું?'. Anestrus (not coming in heat) is about missing estrus cycles. Pregnancy is about carrying offspring. Never confuse these."
   }
 ]

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -77,7 +77,7 @@ class _FakeResponseStream:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    def stream_text(self, delta: bool = True):
+    def stream_text(self, delta: bool = True, debounce_by: float | None = None, **kwargs):
         async def _gen():
             for chunk in self._chunks:
                 if self._delay:
@@ -318,8 +318,8 @@ class TestHelperCoverage:
         assert voice_agent_signed_in.model_settings["max_tokens"] == 3600
 
     def test_signed_in_agent_has_farmer_tools(self):
-        base_tool_names = set(voice_agent._function_tools.keys())
-        signed_in_tool_names = set(voice_agent_signed_in._function_tools.keys())
+        base_tool_names = set(voice_agent._function_toolset.tools.keys())
+        signed_in_tool_names = set(voice_agent_signed_in._function_toolset.tools.keys())
         assert {"search_terms", "search_documents", "get_farmer_milk_collection_details", "create_ai_call", "create_health_call"}.issubset(base_tool_names)
         assert {"get_farmer_profile", "get_herd_summary", "list_animal_tags"}.issubset(signed_in_tool_names)
         assert "get_farmer_profile" not in base_tool_names
@@ -538,7 +538,7 @@ class TestHelperCoverage:
         assert "Multiple farmer records are registered on this mobile number." in summary
         assert "For AI booking, first ask which farmer name the caller wants to use." in summary
         assert "Farmer code available: yes" in summary
-        assert "Known animal tags: 1001, 1002, 1003" in summary
+        assert "Known animal tags: one zero zero one, one zero zero two, one zero zero three" in summary
         assert "Farmer option 1: name=Rameshbhai, society_name=Anand Dairy Society, farmer_code=F123" in summary
         assert "Farmer option 2: name=Sureshbhai, society_name=Vidya Dairy Society, farmer_code=F456" in summary
         assert "AI technician option" not in summary
@@ -652,11 +652,12 @@ class TestHelperCoverage:
         prompt_path = Path(__file__).resolve().parents[1] / "assets" / "prompts" / "voice_moderation_en.md"
         prompt_text = prompt_path.read_text(encoding="utf-8")
         assert "When the context is uncertain, label `in_scope`" in prompt_text
-        assert "Pass through any mention of milk, dairy products, medicines, treatments, dosages" in prompt_text
+        assert "Pass through any mention of camel milk, camel-related care, milk, dairy products, medicines, treatments, dosages" in prompt_text
         assert "Amul, cooperative services, farmer records, animal records, DCS, society, union" in prompt_text
         assert "Do not reject medicine questions just because they might be human medical" in prompt_text
         assert "Reject as `irrelevant` only when the utterance is unambiguously about a human body" in prompt_text
-        assert "Ambiguous medicine, treatment, dosage, pharmacy, product, or brand mentions" in prompt_text
+        assert "Ambiguous medicine, treatment, dosage, pharmacy" in prompt_text
+        assert "product, or brand mentions" in prompt_text
         assert "camel milk questions" in prompt_text
         assert "Cattle, buffalo, camels, goats, sheep, poultry care" in prompt_text
         assert "homeopathic/homepatheic, ayurvedic/aurvedic, Amul medicine" in prompt_text
@@ -728,7 +729,12 @@ class TestHelperCoverage:
         assert translated == "the cow has fever"
         assert confidence == "low"
 
-    def test_low_confidence_fallback_pretranslation_still_short_circuits(self, monkeypatch):
+    def test_empty_fallback_pretranslation_short_circuits_with_repeat_prompt(self, monkeypatch):
+        # Contract (see df9985f): the short-circuit now fires only when
+        # pretranslation produces NO usable text at all (primary raised and
+        # fallback returned empty). A merely low-confidence-but-non-empty
+        # pretranslation routes to the agent instead, which clarifies in
+        # context. Here both primary and fallback fail to yield text.
         from app.services import voice as voice_module
         from agents import voice as voice_agent_module
 
@@ -736,7 +742,7 @@ class TestHelperCoverage:
             raise TimeoutError("primary pretranslation failed")
 
         async def _fallback_pretranslation(*args, **kwargs):
-            return "unclear livestock query", "low"
+            return "", "low"
 
         agent_called = False
         history_store: dict[str, list] = {}


### PR DESCRIPTION
## Summary
Brings the voice unit suite back to green after the pydantic-ai 1.x upgrade. The **fast suite went 23 failed → 0 (285 passed)**. Triage showed only ~8 failures were actually 1.x / streaming-lever fallout — the rest were **pre-existing amul-dev debt** the upgrade work happened to surface.

## What changed (3 files)

### Data restore — a live prod bug, not test rot
`e01315a` (May 12) regenerated `ambiguity_terms.json` from a stale chat-repo base and **silently dropped ~7 voice-specific `hardcode` entries**. Restored verbatim from `e01315a~1`:
- ફેટ (milk fat ≠ stomach), સમુદ્રી (marine feed), વાડો (shed ≠ calf), ગરમી (estrus ≠ pregnancy)
- buffalo ASR variants ભેસ્ટ/ભંચ/ભેંચ → buffalo (not sheep/goat)
- retained-placenta triggers માટી ન ખસવી / મેલી ન પડવી

These feed both `get_ambiguity_hints_for_query` and the pretranslation prompt, so voice has been mis-disambiguating these since May 12.

### Real bugs fixed in `voice.py`
- **Latent crash:** the `pretranslation_empty` short-circuit had a duplicated `logger.info` format-string + args → `TypeError` every time it fires, crashing the graceful "please repeat" reply on the degraded-translation path.
- **Streaming stall:** `_split_voice_batch_text` now force-splits an unpunctuated run-on at the last word boundary instead of waiting for stream end (latency-positive).
- `extract_complete_sentences` now strips the leading newline from the tail at structural-header breaks.

### Test maintenance
- `_function_tools` → `_function_toolset.tools` (pydantic-ai 1.x rename)
- `_FakeResponseStream.stream_text` accepts `debounce_by` (#137 lever)
- Realigned stale assertions: moderation prompt reword, TTS-spelled tag format, the `df9985f` low-conf gate (only *empty* pretranslation short-circuits now)

## Validation
`pytest tests/test_voice_fixes.py tests/test_translation_vocabulary.py tests/test_voice_regressions_apr11_12.py` → **285 passed** (was 23 failed / 262 passed) in the VM5 pyupgrade container.

## Known pre-existing failures (NOT touched here — tracked separately)
In files this PR doesn't modify, predating the upgrade:
- `test_pretranslation_ai_technician_booking_regression` (3 gu cases): matcher fed raw Gujarati `source_text` vs English-name patterns — gu test-data bug
- `test_strict_rule_block_present_in_en_prompt`: active EN prompt's vague-query block lost its "(STRICT RULE)" wording — **possible prompt regression, needs product review**
- `verbose_answer_test`: stale fixture self-check
- Test env declares no `pytest`/`pytest-asyncio` deps (3 `nudge_race` async tests need the plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)