### PR TITLE
fix(models): pin explicit 600s timeout on boundary-capture httpx client

### DIFF
--- a/agents/models/__init__.py
+++ b/agents/models/__init__.py
@@ -48,8 +48,17 @@ async def _capture_request_hook(request: httpx.Request) -> None:
 
 
 def _capture_http_client() -> httpx.AsyncClient:
-    """Long-lived AsyncClient with the boundary-capture event hook attached."""
-    return httpx.AsyncClient(event_hooks={"request": [_capture_request_hook]})
+    """Long-lived AsyncClient with the boundary-capture event hook attached.
+
+    Pin an explicit 600s read/write/pool timeout (5s connect) to match the
+    OpenAI SDK default and pydantic-ai's cached_async_http_client. A bare
+    AsyncClient inherits httpx's 5s default, which would abort long streaming
+    agent runs (multi-second generation + tool round-trips) under load.
+    """
+    return httpx.AsyncClient(
+        event_hooks={"request": [_capture_request_hook]},
+        timeout=httpx.Timeout(600.0, connect=5.0),
+    )
 
 
 def _build_openai_compatible_model(


### PR DESCRIPTION
## Summary
The custom `httpx.AsyncClient` we wire for model-boundary capture (`agents/models/__init__.py`) had no explicit timeout, inheriting httpx's **5s default**. The prior pydantic-ai path (`cached_async_http_client`) and the OpenAI SDK both default to **600s read/write/pool + 5s connect**.

The OpenAI SDK normally applies its own per-request 600s timeout (overriding the client default), so streaming likely wasn't hitting the 5s cap in practice — but relying on that implicitly is a footgun under load. A 5s read cap would abort long streaming agent runs (multi-second generation + tool round-trips). This pins the timeout explicitly to restore the prior safety margin.

```python
return httpx.AsyncClient(
    event_hooks={"request": [_capture_request_hook]},
    timeout=httpx.Timeout(600.0, connect=5.0),
)
```

Applies to `LLM_MODEL`, `OSS_LLM_MODEL`, and the Azure client (all use `_capture_http_client()`).

## Validation
- `_capture_http_client().timeout` → `Timeout(connect=5.0, read=600.0, write=600.0, pool=600.0)` ✓
- Full suite on the merge commit + this fix: **535 passed**, 116 skipped, 7 xfailed (same 5 pre-existing failures, all in files untouched by the release).

## Context
Found during a risk review of the pydantic-ai 1.x upgrade (#136). The other reviewed risks (boundary-capture payload shape, agent observation shape, `trim_history` 80k→32k, partial-turn-on-break) were confirmed **non-issues** — debug-only/off-by-default, intentional design, or already guarded by the monotonic `before_history_write` staleness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)