### PR TITLE
fix(history): tolerate legacy null usage tokens when loading cached history

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -118,12 +118,60 @@ async def set_cache(key: str, value, ttl: int = DEFAULT_CACHE_TTL):
     return True
 
 
+# pydantic-ai usage integer fields. The 0.2.4 schema (request_tokens /
+# response_tokens / total_tokens / requests) and the 1.x schema (input_tokens /
+# output_tokens / cache_* tokens) both store these as ints, but legacy turns
+# where the model reported no usage (streamed / vLLM-gemma responses) persisted
+# them as null. The 1.x ModelMessagesTypeAdapter requires int, so loading that
+# history raises ValidationError. Coerce nulls to 0 on read.
+_USAGE_INT_FIELDS = (
+    "requests", "request_tokens", "response_tokens", "total_tokens",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+    "input_audio_tokens", "cache_audio_read_tokens", "output_audio_tokens",
+)
+
+
+def _sanitize_legacy_usage(message_history):
+    """Coerce null usage token counts in cached history to 0 so the pydantic-ai
+    1.x adapter can validate history written by older revisions. Mutates and
+    returns the same structure; best-effort and never raises."""
+    if not isinstance(message_history, list):
+        return message_history
+    for msg in message_history:
+        if not isinstance(msg, dict):
+            continue
+        usage = msg.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        for field in _USAGE_INT_FIELDS:
+            if field in usage and usage.get(field) is None:
+                usage[field] = 0
+        details = usage.get("details")
+        if isinstance(details, dict):
+            for key, value in list(details.items()):
+                if value is None:
+                    details[key] = 0
+        elif details is None and "details" in usage:
+            usage["details"] = {}
+    return message_history
+
+
 async def _get_message_history(session_id: str) -> List[ModelMessage]:
     """Get or initialize message history."""
     message_history = await get_cache(f"{session_id}_{HISTORY_SUFFIX}")
-    if message_history:
+    if not message_history:
+        return []
+    message_history = _sanitize_legacy_usage(message_history)
+    try:
         return ModelMessagesTypeAdapter.validate_python(message_history)
-    return []
+    except Exception as exc:
+        # Never 500 a live call on unreadable history (e.g. future format
+        # drift). Drop it and proceed as a fresh turn — degraded, not broken.
+        logger.warning(
+            "Discarding unreadable message history for session %s: %s",
+            session_id, exc,
+        )
+        return []
 
 async def update_message_history(session_id: str, all_messages: List[ModelMessage]):
     """Update message history."""


### PR DESCRIPTION
## INCIDENT FIX
Deploying the pydantic-ai 1.x release (#136) to prod **500'd ~58% of live voice calls**. Rolled back to `amul-prod-f0c0fc6` immediately; prod is stable.

### Root cause
`_get_message_history` validates Redis-cached history with the 1.x `ModelMessagesTypeAdapter`, which requires `usage.request_tokens` / `response_tokens` to be `int`. History written by older revisions stored these as `null` whenever the model reported no usage (streamed / vLLM-gemma turns) → `ValidationError` → 500 on any returning multi-turn session. New/empty sessions worked, so boot + health checks looked clean — which is why it slipped through.

### Fix
- `_sanitize_legacy_usage()`: coerce null usage token counts (both 0.2.4 `request_tokens/response_tokens/total_tokens/requests` and 1.x `input_tokens/output_tokens/cache_*` names) and null `details` entries to `0` before validation.
- Wrap `validate_python` in try/except that logs + returns `[]` on any residual failure — future format drift degrades to a fresh turn instead of a hard 500.

### Validation (against real prod data — the gap that caused the incident)
Tested against **707 real prod history values** pulled from Redis:
- **295/707 (42%) passed pre-fix** → 412 would 500
- **707/707 (100%) passed post-fix**, 0 hit the graceful fallback
- all 412 null-usage sessions now load
- full unit suite: 535 passed (same 5 pre-existing failures, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)