### PR TITLE
perf(voice): stale-while-revalidate farmer cache + background refresh worker

### DIFF
--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -3,11 +3,12 @@ Cache layer for farmer data fetched from PashuGPT APIs.
 
 Voice reads farmer context from Redis only. Freshness is controlled separately
 from key expiry:
-- refresh interval: 24h
-- cache retention: 7d
+- soft refresh interval: 12h for "found", 2h for "not_found"
+- cache retention (hard delete): 7d
 
 This lets the request path return cached data immediately, mark it stale in the
-read result, and schedule a background refresh without blocking the caller.
+read result, and schedule a background refresh (via a Redis queue drained by a
+worker) without blocking the caller.
 """
 import asyncio
 import hashlib

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -25,11 +25,16 @@ from helpers.utils import get_logger
 
 logger = get_logger(__name__)
 
-FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days retention in Redis
-FARMER_REFRESH_INTERVAL = 60 * 60 * 24  # refresh once a day
+FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days hard retention in Redis (deletion)
+FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record after 12h
+FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
+FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
 FARMER_CACHE_NAMESPACE = "farmer"
 FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
+FARMER_REFRESH_QUEUE_NAMESPACE = "farmer-refresh-queue"
+# Single Redis set holding raw phone numbers awaiting a background refresh.
+FARMER_REFRESH_QUEUE_KEY = build_cache_key("pending", namespace=FARMER_REFRESH_QUEUE_NAMESPACE)
 
 
 def _cache_key(phone: str) -> str:
@@ -49,7 +54,12 @@ def _compute_freshness(envelope: FarmerDataEnvelope) -> tuple[bool, Optional[str
     except ValueError:
         return True, "invalid_fetched_at", None
 
-    refresh_after = fetched_at + timedelta(seconds=FARMER_REFRESH_INTERVAL)
+    interval = (
+        FARMER_NEGATIVE_REFRESH_INTERVAL
+        if envelope.lookupStatus == "not_found"
+        else FARMER_REFRESH_INTERVAL
+    )
+    refresh_after = fetched_at + timedelta(seconds=interval)
     refresh_after_iso = refresh_after.astimezone(timezone.utc).isoformat()
     is_stale = datetime.now(timezone.utc) >= refresh_after.astimezone(timezone.utc)
     return is_stale, ("expired" if is_stale else None), refresh_after_iso
@@ -138,6 +148,63 @@ async def get_or_fetch_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         return cached
 
     return await refresh_farmer_data(phone)
+
+
+async def enqueue_farmer_refresh(phone: str) -> None:
+    """Queue a phone for background refresh (stale-while-revalidate).
+
+    Pushes the raw phone onto a Redis set so a dedicated worker can refresh it
+    off the request path. The set dedupes naturally, and refresh_farmer_data
+    self-dedupes via its NX lock, so enqueuing the same phone repeatedly is safe.
+    """
+    if not phone:
+        return
+    try:
+        await redis_client.sadd(FARMER_REFRESH_QUEUE_KEY, phone)
+    except Exception as e:
+        logger.warning("Failed to enqueue farmer refresh: %s", e)
+
+
+async def refresh_farmer_data_bounded(
+    phone: str, timeout: float = FARMER_COLD_FETCH_TIMEOUT
+) -> Optional[FarmerDataEnvelope]:
+    """Blocking refresh with a hard timeout, for a cold/never-cached miss.
+
+    On timeout we defer to the background worker rather than hanging the turn:
+    the in-flight refresh is cancelled (its NX lock is released in its finally),
+    the phone is queued, and the caller proceeds with no farmer data this turn.
+    """
+    try:
+        return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Cold farmer fetch exceeded %.1fs for phone hash %s...; deferring to worker",
+            timeout,
+            _cache_key(phone)[:8],
+        )
+        await enqueue_farmer_refresh(phone)
+        return None
+
+
+async def drain_farmer_refresh_queue_once(batch: int = 20) -> int:
+    """Pop up to `batch` queued phones and refresh each. Returns count processed."""
+    try:
+        members = await redis_client.spop(FARMER_REFRESH_QUEUE_KEY, batch)
+    except Exception as e:
+        logger.warning("Failed to read farmer refresh queue: %s", e)
+        return 0
+    if not members:
+        return 0
+    if isinstance(members, (str, bytes)):
+        members = [members]
+    processed = 0
+    for phone in members:
+        try:
+            await refresh_farmer_data(phone)
+            processed += 1
+        except Exception:
+            logger.exception("Background farmer refresh failed for a queued phone")
+    return processed
 
 
 async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:

--- a/agents/tools/farmer_cached.py
+++ b/agents/tools/farmer_cached.py
@@ -7,7 +7,6 @@ import json
 from pydantic_ai import RunContext
 
 from agents.deps import FarmerContext
-from agents.services.farmer_cache import get_or_fetch_farmer_data
 from helpers.gujarati_numbers import mask_tag_identifier
 
 
@@ -15,6 +14,12 @@ async def _get_envelope(ctx: RunContext[FarmerContext]):
     mobile = ctx.deps.mobile
     if not mobile:
         return None
+    # Lazy import: this module is pulled in by agents.tools/__init__, and
+    # farmer_cache imports back into agents.tools at module top — importing
+    # get_or_fetch_farmer_data here (not at module scope) breaks that cycle so
+    # farmer_cache can be imported cold (e.g. by the refresh worker at startup).
+    from agents.services.farmer_cache import get_or_fetch_farmer_data
+
     return await get_or_fetch_farmer_data(mobile)
 
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -16,7 +16,8 @@ from agents.voice import voice_agent, voice_agent_signed_in, STATIC_VOICE_SYSTEM
 from agents.tools.farmer import normalize_phone_to_mobile
 from agents.services.farmer_cache import (
     get_farmer_data_cached_only,
-    refresh_farmer_data,
+    refresh_farmer_data_bounded,
+    enqueue_farmer_refresh,
     should_refresh_farmer_data,
 )
 from app.models.union import UnionName
@@ -511,11 +512,20 @@ def _is_signed_in_session(user_info: Optional[dict], user_id: str) -> bool:
 
 
 async def get_or_fetch_farmer_data(mobile: str):
+    """Voice read policy (stale-while-revalidate).
+
+    Serve the cached envelope immediately when present (fresh or stale — the
+    caller enqueues a background refresh for stale records). On a cold/never-
+    cached (or hard-expired/deleted) miss, do a bounded blocking fetch so the
+    first turn has data, capped by FARMER_COLD_FETCH_TIMEOUT so a slow upstream
+    never hangs the call.
+
+    Still patchable by tests that stub this symbol.
     """
-    Backward-compatible alias for tests and callers that still patch the old symbol.
-    Voice request flow now uses Redis-only reads from this alias.
-    """
-    return await get_farmer_data_cached_only(mobile)
+    cached = await get_farmer_data_cached_only(mobile)
+    if cached is not None:
+        return cached
+    return await refresh_farmer_data_bounded(mobile)
 
 
 def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
@@ -1421,7 +1431,7 @@ async def stream_voice_message(
                         len(ai_technician_info),
                     )
                     if mobile and should_refresh_farmer_data(envelope):
-                        asyncio.create_task(refresh_farmer_data(mobile))
+                        await enqueue_farmer_refresh(mobile)
                         logger.info(
                             "Farmer cache refresh scheduled in background for mobile %s stale=%s status=%s",
                             mobile,

--- a/app/tasks/farmer_refresh_worker.py
+++ b/app/tasks/farmer_refresh_worker.py
@@ -1,0 +1,62 @@
+"""Background worker that drains the farmer-data refresh queue.
+
+Stale-while-revalidate: the voice request path serves cached farmer data
+immediately and enqueues stale phones (see agents.services.farmer_cache.
+enqueue_farmer_refresh). This worker drains that Redis-backed queue off the
+request path and refreshes each record, so slow/unreliable upstream PashuGPT
+APIs never block a call. refresh_farmer_data self-dedupes via its NX lock, so
+running one worker per pod is safe.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from agents.services.farmer_cache import drain_farmer_refresh_queue_once
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Seconds to wait before re-polling when the queue is empty.
+IDLE_SLEEP_SECONDS = 5.0
+# Phones to refresh per drain iteration.
+DRAIN_BATCH = 20
+
+_worker_task: Optional[asyncio.Task] = None
+
+
+async def _run_loop() -> None:
+    logger.info("Farmer refresh worker started")
+    while True:
+        try:
+            processed = await drain_farmer_refresh_queue_once(batch=DRAIN_BATCH)
+            if processed == 0:
+                await asyncio.sleep(IDLE_SLEEP_SECONDS)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Farmer refresh worker iteration failed")
+            await asyncio.sleep(IDLE_SLEEP_SECONDS)
+
+
+async def start_farmer_refresh_worker() -> None:
+    global _worker_task
+    if _worker_task is not None and not _worker_task.done():
+        return
+    _worker_task = asyncio.create_task(_run_loop())
+
+
+async def stop_farmer_refresh_worker() -> None:
+    global _worker_task
+    if _worker_task is None:
+        return
+    _worker_task.cancel()
+    try:
+        await _worker_task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("Farmer refresh worker failed during shutdown")
+    finally:
+        _worker_task = None
+        logger.info("Farmer refresh worker stopped")

--- a/app/tasks/farmer_refresh_worker.py
+++ b/app/tasks/farmer_refresh_worker.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 from typing import Optional
 
-from agents.services.farmer_cache import drain_farmer_refresh_queue_once
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -26,6 +25,11 @@ _worker_task: Optional[asyncio.Task] = None
 
 
 async def _run_loop() -> None:
+    # Imported here (not at module scope) so importing this worker module is
+    # side-effect-free and never triggers the farmer_cache <-> tools import
+    # cycle at app startup (main.py imports the worker before the routers).
+    from agents.services.farmer_cache import drain_farmer_refresh_queue_once
+
     logger.info("Farmer refresh worker started")
     while True:
         try:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from contextlib import asynccontextmanager
 from app.tasks.scheme_scheduler import start_scheme_scheduler, stop_scheme_scheduler
+from app.tasks.farmer_refresh_worker import start_farmer_refresh_worker, stop_farmer_refresh_worker
 
 load_dotenv()
 
@@ -25,8 +26,10 @@ async def lifespan(app: FastAPI):
     from helpers.utils import load_prompt_templates
     load_prompt_templates(settings.base_dir / "assets" / "prompts")
     await start_scheme_scheduler()
+    await start_farmer_refresh_worker()
     yield
     # Shutdown
+    await stop_farmer_refresh_worker()
     await stop_scheme_scheduler()
     print(f"🛑 {settings.app_name} shutting down...")
 

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -5,13 +5,36 @@ Self-contained: uses asyncio.run + mocks, so it needs neither a live Redis nor
 pytest-asyncio.
 """
 import asyncio
+import os
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
-# Import the app entry first so the pre-existing tools<->farmer_cache import
-# cycle resolves in the same order the running app establishes it.
 import app.services.voice as voice
 import agents.services.farmer_cache as fc
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_cold_import_has_no_circular_import():
+    """Regression: `uvicorn main:app` imports the refresh worker before the
+    routers, so farmer_cache must be importable COLD (first touch) without
+    hitting the farmer_cache <-> agents.tools cycle. Run in a subprocess to get
+    a truly fresh interpreter, mirroring the app's startup import order."""
+    code = (
+        "import app.tasks.farmer_refresh_worker;"
+        "import agents.services.farmer_cache;"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"cold import failed:\n{result.stderr}"
+    assert "OK" in result.stdout
 
 
 class _Env:

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -1,0 +1,109 @@
+"""Unit tests for the stale-while-revalidate farmer cache: freshness intervals,
+the Redis refresh queue, the bounded cold fetch, and the voice read policy.
+
+Self-contained: uses asyncio.run + mocks, so it needs neither a live Redis nor
+pytest-asyncio.
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+# Import the app entry first so the pre-existing tools<->farmer_cache import
+# cycle resolves in the same order the running app establishes it.
+import app.services.voice as voice
+import agents.services.farmer_cache as fc
+
+
+class _Env:
+    """Duck-typed stand-in for FarmerDataEnvelope (only fields _compute_freshness reads)."""
+
+    def __init__(self, lookup_status, age_hours):
+        self.lookupStatus = lookup_status
+        self.fetchedAt = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).isoformat()
+
+
+def test_freshness_intervals_found_vs_not_found():
+    # found: soft expiry at 12h
+    assert fc._compute_freshness(_Env("found", 6))[0] is False
+    assert fc._compute_freshness(_Env("found", 13))[0] is True
+    # not_found: shorter soft expiry at 2h
+    assert fc._compute_freshness(_Env("not_found", 1))[0] is False
+    assert fc._compute_freshness(_Env("not_found", 3))[0] is True
+
+
+def test_interval_constants():
+    assert fc.FARMER_REFRESH_INTERVAL == 60 * 60 * 12
+    assert fc.FARMER_NEGATIVE_REFRESH_INTERVAL == 60 * 60 * 2
+    assert fc.FARMER_CACHE_TTL == 60 * 60 * 24 * 7
+
+
+def test_enqueue_pushes_phone_to_redis_set():
+    fake_redis = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis):
+        asyncio.run(fc.enqueue_farmer_refresh("9999999999"))
+    fake_redis.sadd.assert_awaited_once_with(fc.FARMER_REFRESH_QUEUE_KEY, "9999999999")
+
+
+def test_enqueue_ignores_empty_phone():
+    fake_redis = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis):
+        asyncio.run(fc.enqueue_farmer_refresh(""))
+    fake_redis.sadd.assert_not_called()
+
+
+def test_drain_pops_batch_and_refreshes_each():
+    fake_redis = AsyncMock()
+    fake_redis.spop.return_value = ["111", "222", "333"]
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "refresh_farmer_data", new=AsyncMock()) as refresh:
+        processed = asyncio.run(fc.drain_farmer_refresh_queue_once(batch=10))
+    assert processed == 3
+    fake_redis.spop.assert_awaited_once_with(fc.FARMER_REFRESH_QUEUE_KEY, 10)
+    assert refresh.await_count == 3
+
+
+def test_drain_empty_queue_returns_zero():
+    fake_redis = AsyncMock()
+    fake_redis.spop.return_value = None
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "refresh_farmer_data", new=AsyncMock()) as refresh:
+        processed = asyncio.run(fc.drain_farmer_refresh_queue_once())
+    assert processed == 0
+    refresh.assert_not_called()
+
+
+def test_bounded_fetch_returns_envelope_on_success():
+    sentinel = object()
+    with patch.object(fc, "refresh_farmer_data", new=AsyncMock(return_value=sentinel)):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=1.0))
+    assert result is sentinel
+
+
+def test_bounded_fetch_times_out_and_enqueues():
+    async def _slow(_phone):
+        await asyncio.sleep(5)
+
+    enqueue = AsyncMock()
+    with patch.object(fc, "refresh_farmer_data", new=_slow), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
+    assert result is None
+    enqueue.assert_awaited_once_with("111")
+
+
+def test_voice_read_returns_cached_without_blocking():
+    cached = object()
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=cached)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock()) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is cached
+    bounded.assert_not_called()
+
+
+def test_voice_read_cold_miss_does_bounded_fetch():
+    fetched = object()
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=None)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fetched)) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is fetched
+    bounded.assert_awaited_once_with("111")


### PR DESCRIPTION
## What
Finishes the **stale-while-revalidate (SWR)** farmer-data cache on the voice path so calls never block on the slow/inconsistent Amul PashuGPT APIs (amulpashudhan + herdman fallback).

## Why
Amul API latency is inconsistent and can't be depended on in the request path. The SWR primitives already existed in `farmer_cache.py` but weren't wired: the voice path still blocked on cold misses and fired background refreshes via per-request `asyncio.create_task` (fragile — dies with the request scope).

## Changes
- **Read policy (`app/services/voice.py`):** cached-only read; cold/never-cached miss → bounded blocking fetch (3s cap); stale-but-present → enqueue a background refresh.
- **Background refresh (`agents/services/farmer_cache.py` + new `app/tasks/farmer_refresh_worker.py`):** stale phones pushed to a Redis set (`farmer:refresh:queue`); a dedicated worker (started/stopped in `main.py` lifespan) drains it. `refresh_farmer_data` self-dedups via its NX lock, so one worker per pod is safe.
- **Freshness:** 24h→12h soft refresh for `found`; **2h** for `not_found` so newly-registered callers are picked up fast; 7d hard Redis retention unchanged.
- **Cleanup:** removed the per-request `create_task(refresh)` and a now-unused `refresh_farmer_data` import.

## Tests
`tests/test_farmer_cache_swr.py` — 10 tests (freshness intervals, enqueue, batch drain, bounded-fetch success + timeout→enqueue, both read paths). Self-contained (`asyncio.run` + mocks; no Redis / pytest-asyncio). Existing tests that patch `get_or_fetch_farmer_data` are unaffected.

## Follow-ups (not in this PR)
- Cache-warm seed from distinct prod caller phones (blocked on a Langfuse prod outage).
- Unify amulpashudhan + herdman behind a single typed `FarmerDataProvider`/`AnimalDataProvider` (normalize to `FarmerRecord`/`AnimalRecord` once) — herdman is "the same data," yet 3 call sites re-implement the dual-backend merge/normalize today.
- Union-aware tool gating + corrected AI-booking flow (caller picks technician from a list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)