### PR TITLE
feat(voice): farmer API observability + cache max-serve-stale, don't-downgrade, lock-await

### DIFF
--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -33,7 +33,7 @@ FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days hard retention in Redis (deletion)
 FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record after 12h
 FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
-FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
+FARMER_COLD_FETCH_TIMEOUT = 4.0  # bounded blocking fetch for a cold/never-cached miss (cold ~3.1s observed)
 # Beyond this age a cached record is too stale to serve: the read blocks on a
 # bounded API call instead (falls back to the stale record only if that fails).
 FARMER_MAX_SERVE_STALE_SECONDS = settings.farmer_max_serve_stale_seconds
@@ -125,29 +125,48 @@ async def set_cached_farmer_data(phone: str, data: FarmerDataEnvelope) -> None:
 from agents.tools.farmer import fetch_farmer_info_raw
 
 
+async def _restamp_kept_record(phone: str, envelope: FarmerDataEnvelope) -> None:
+    """When don't-downgrade keeps a 'found' record on an empty upstream, refresh
+    its fetchedAt so reads stop block-fetching it every turn — while PRESERVING the
+    remaining 7d Redis TTL so a genuinely removed farmer still expires on schedule."""
+    envelope.fetchedAt = datetime.now(timezone.utc).isoformat()
+    key = _cache_key(phone)
+    try:
+        remaining = await redis_client.ttl(build_cache_key(key, namespace=FARMER_CACHE_NAMESPACE))
+        if remaining and remaining > 0:
+            await cache.set(key, envelope.model_dump(), ttl=remaining, namespace=FARMER_CACHE_NAMESPACE)
+    except Exception as e:
+        logger.warning("Failed to restamp kept farmer record (phone hash %s...): %s", key[:8], e)
+
+
 async def _await_inflight_refresh(
-    phone: str, lock_key: str, *, max_wait: float = 2.0, interval: float = 0.1
-) -> Optional[FarmerDataEnvelope]:
-    """Wait briefly for the in-flight refresh holding `lock_key` to finish, then
-    return the latest cached value. Lets a caller that lost the lock race get the
-    fresh result instead of a None it would misread as failure."""
+    phone: str, lock_key: str, *, timeout: float, interval: float = 0.1
+) -> tuple[Optional[FarmerDataEnvelope], bool]:
+    """Poll until the in-flight refresh holding `lock_key` finishes (lock gone),
+    bounded by `timeout`. Returns (latest cached value, cleared) — cleared is True
+    only if the lock actually released within the window. No cap below `timeout`:
+    the request path's outer asyncio.wait_for is the real limiter, and the worker
+    passes its own bound — so a slow (~3s) cold-fetch holder is awaited fully
+    instead of giving up early and serving stale."""
     loop = asyncio.get_event_loop()
-    deadline = loop.time() + max_wait
+    deadline = loop.time() + timeout
+    cleared = False
     while loop.time() < deadline:
         await asyncio.sleep(interval)
         try:
             if not await redis_client.exists(lock_key):
+                cleared = True
                 break
         except Exception:
             break
-    return await get_cached_farmer_data(phone)
+    return await get_cached_farmer_data(phone), cleared
 
 
 async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
     """
     Refresh farmer data from upstream APIs and update Redis.
     Returns the refreshed envelope, or the in-flight refresh's result when the
-    lock is busy, or None on actual failure.
+    lock is busy and clears in time, or None on actual failure / lock-still-busy.
     """
     lock_key = _refresh_lock_key(phone)
     acquired = False
@@ -158,7 +177,15 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             # rather than None — None would make max-serve-stale serve the ancient
             # record and would let the worker drop a queued phone as a no-op.
             logger.debug("Farmer refresh in flight for phone hash %s...; awaiting result", _cache_key(phone)[:8])
-            return await _await_inflight_refresh(phone, lock_key)
+            env, cleared = await _await_inflight_refresh(
+                phone, lock_key, timeout=FARMER_COLD_FETCH_TIMEOUT
+            )
+            if cleared:
+                return env
+            # Holder outlived our wait — re-queue so the refresh isn't lost
+            # (covers the worker path) and signal "not done" to the caller.
+            await enqueue_farmer_refresh(phone)
+            return None
 
         records = await fetch_farmer_info_raw(phone)
         if records:
@@ -179,6 +206,12 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
                 "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
                 _cache_key(phone)[:8],
             )
+            # If it had already aged past the serve ceiling, a persistently-empty
+            # upstream would otherwise force a blocking re-fetch on EVERY turn.
+            # Restamp fetchedAt so reads serve it without blocking, while
+            # PRESERVING the 7d hard TTL so a genuinely removed farmer still expires.
+            if exceeds_max_serve_stale(existing):
+                await _restamp_kept_record(phone, existing)
             return existing
 
         envelope = FarmerDataEnvelope.not_found(source="api")

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -17,10 +17,13 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.core.cache import cache, redis_client, build_cache_key
+from app.config import settings
+from app.observability import start_observation
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
 from agents.tools.farmer_animal_backends import (
     GetAITechniciansBySocietyQueryParams,
     get_ai_technicians_by_society_api,
+    fetch_reason,
 )
 from helpers.utils import get_logger
 
@@ -31,6 +34,9 @@ FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record 
 FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
 FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
+# Beyond this age a cached record is too stale to serve: the read blocks on a
+# bounded API call instead (falls back to the stale record only if that fails).
+FARMER_MAX_SERVE_STALE_SECONDS = settings.farmer_max_serve_stale_seconds
 FARMER_CACHE_NAMESPACE = "farmer"
 FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
 FARMER_REFRESH_QUEUE_NAMESPACE = "farmer-refresh-queue"
@@ -64,6 +70,26 @@ def _compute_freshness(envelope: FarmerDataEnvelope) -> tuple[bool, Optional[str
     refresh_after_iso = refresh_after.astimezone(timezone.utc).isoformat()
     is_stale = datetime.now(timezone.utc) >= refresh_after.astimezone(timezone.utc)
     return is_stale, ("expired" if is_stale else None), refresh_after_iso
+
+
+def _envelope_age_seconds(envelope: Optional[FarmerDataEnvelope]) -> Optional[float]:
+    if envelope is None or not envelope.fetchedAt:
+        return None
+    try:
+        fetched_at = datetime.fromisoformat(envelope.fetchedAt.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - fetched_at.astimezone(timezone.utc)).total_seconds()
+
+
+def exceeds_max_serve_stale(envelope: Optional[FarmerDataEnvelope]) -> bool:
+    """True when a cached record is too old to serve and the read should block
+    on a fresh API call (e.g. background refresh has been failing). Unknown age
+    counts as too stale."""
+    age = _envelope_age_seconds(envelope)
+    if age is None:
+        return True
+    return age > FARMER_MAX_SERVE_STALE_SECONDS
 
 
 async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
@@ -116,8 +142,25 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         if records:
             envelope = FarmerDataEnvelope.from_records(records, source="api", lookup_status="found")
             envelope.aiTechnicians = await _fetch_ai_technicians(records)
-        else:
-            envelope = FarmerDataEnvelope.not_found(source="api")
+            await set_cached_farmer_data(phone, envelope)
+            return envelope
+
+        # Upstream returned nothing. Guard against a transient empty response
+        # wiping known-good data: keep a still-serveable "found" record rather
+        # than downgrading it to not_found. It stays stale, so it is retried.
+        existing = await get_cached_farmer_data(phone)
+        if (
+            existing is not None
+            and existing.lookupStatus == "found"
+            and not exceeds_max_serve_stale(existing)
+        ):
+            logger.info(
+                "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
+                _cache_key(phone)[:8],
+            )
+            return existing
+
+        envelope = FarmerDataEnvelope.not_found(source="api")
         await set_cached_farmer_data(phone, envelope)
         return envelope
     except Exception as e:
@@ -176,7 +219,8 @@ async def refresh_farmer_data_bounded(
     the phone is queued, and the caller proceeds with no farmer data this turn.
     """
     try:
-        return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
+        with fetch_reason("cold_fetch"):
+            return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
     except asyncio.TimeoutError:
         logger.warning(
             "Cold farmer fetch exceeded %.1fs for phone hash %s...; deferring to worker",
@@ -201,7 +245,16 @@ async def drain_farmer_refresh_queue_once(batch: int = 20) -> int:
     processed = 0
     for phone in members:
         try:
-            await refresh_farmer_data(phone)
+            # Root span so the nested API-call observations have a parent and
+            # are queryable in Langfuse (background refreshes aren't tied to a
+            # voice session); fetch_reason tags them as background_refresh.
+            with start_observation(
+                "farmer_background_refresh",
+                input={"phone_hash": _cache_key(phone)[:12]},
+                metadata={"reason": "background_refresh"},
+            ):
+                with fetch_reason("background_refresh"):
+                    await refresh_farmer_data(phone)
             processed += 1
         except Exception:
             logger.exception("Background farmer refresh failed for a queued phone")

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -125,18 +125,40 @@ async def set_cached_farmer_data(phone: str, data: FarmerDataEnvelope) -> None:
 from agents.tools.farmer import fetch_farmer_info_raw
 
 
+async def _await_inflight_refresh(
+    phone: str, lock_key: str, *, max_wait: float = 2.0, interval: float = 0.1
+) -> Optional[FarmerDataEnvelope]:
+    """Wait briefly for the in-flight refresh holding `lock_key` to finish, then
+    return the latest cached value. Lets a caller that lost the lock race get the
+    fresh result instead of a None it would misread as failure."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + max_wait
+    while loop.time() < deadline:
+        await asyncio.sleep(interval)
+        try:
+            if not await redis_client.exists(lock_key):
+                break
+        except Exception:
+            break
+    return await get_cached_farmer_data(phone)
+
+
 async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
     """
     Refresh farmer data from upstream APIs and update Redis.
-    Returns the refreshed envelope or None on refresh failure.
+    Returns the refreshed envelope, or the in-flight refresh's result when the
+    lock is busy, or None on actual failure.
     """
     lock_key = _refresh_lock_key(phone)
     acquired = False
     try:
         acquired = await redis_client.set(lock_key, "1", ex=FARMER_REFRESH_LOCK_TTL, nx=True)
         if not acquired:
-            logger.debug("Farmer refresh already in flight for phone hash %s...", _cache_key(phone)[:8])
-            return None
+            # Another refresh is in-flight. Wait for its result and return that,
+            # rather than None — None would make max-serve-stale serve the ancient
+            # record and would let the worker drop a queued phone as a no-op.
+            logger.debug("Farmer refresh in flight for phone hash %s...; awaiting result", _cache_key(phone)[:8])
+            return await _await_inflight_refresh(phone, lock_key)
 
         records = await fetch_farmer_info_raw(phone)
         if records:
@@ -145,15 +167,14 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             await set_cached_farmer_data(phone, envelope)
             return envelope
 
-        # Upstream returned nothing. Guard against a transient empty response
-        # wiping known-good data: keep a still-serveable "found" record rather
-        # than downgrading it to not_found. It stays stale, so it is retried.
+        # Upstream returned nothing. Never let a transient empty response wipe
+        # known-good data — keep the "found" record regardless of age (it stays
+        # stale and is retried). We cannot distinguish a genuine "not found" from
+        # a transient failure here, so genuine removal is left to the 7d hard
+        # Redis TTL rather than an ambiguous empty response. (A confident
+        # not_found signal is a follow-up in the provider-interface PR.)
         existing = await get_cached_farmer_data(phone)
-        if (
-            existing is not None
-            and existing.lookupStatus == "found"
-            and not exceeds_max_serve_stale(existing)
-        ):
+        if existing is not None and existing.lookupStatus == "found":
             logger.info(
                 "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
                 _cache_key(phone)[:8],

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -82,6 +82,16 @@ def _safe_response_summary(body: str) -> dict:
     if isinstance(first, dict):
         out["keys"] = sorted(first.keys())
         out["null_keys"] = sorted(k for k, v in first.items() if v is None)
+        # Lengths of list-valued fields (no values) — surfaces empty/thin records
+        # (e.g. an empty animals/visits/technicians array) which signal a
+        # degraded "empty" response distinct from a populated one.
+        array_lens = {k: len(v) for k, v in first.items() if isinstance(v, list)}
+        if array_lens:
+            out["array_lens"] = array_lens
+        # Keys whose value is an empty string — another empty-response signal.
+        empty_str_keys = sorted(k for k, v in first.items() if v == "")
+        if empty_str_keys:
+            out["empty_str_keys"] = empty_str_keys
     return out
 
 

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -53,12 +53,44 @@ def current_fetch_reason() -> str:
     return _fetch_reason.get()
 
 
-def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
-    """Attach status code + response body + source to a Langfuse observation.
+def _safe_response_summary(body: str) -> dict:
+    """PII-safe shape of a response: record count + which keys are present/null,
+    WITHOUT any values. This is what proves an inconsistent return (e.g. a record
+    that came back missing `totalAnimals`) without shipping farmer PII to Langfuse.
+    """
+    out: dict[str, Any] = {"bytes": len(body)}
+    if not body.strip():
+        out["json"] = False
+        return out
+    try:
+        data = json.loads(body)
+    except Exception:
+        out["json"] = False
+        return out
+    out["json"] = True
+    if isinstance(data, dict) and isinstance(data.get("data"), list):
+        data = data["data"]
+    if isinstance(data, list):
+        out["records"] = len(data)
+        first = data[0] if data and isinstance(data[0], dict) else None
+    elif isinstance(data, dict):
+        out["records"] = 1
+        first = data
+    else:
+        out["records"] = 0
+        first = None
+    if isinstance(first, dict):
+        out["keys"] = sorted(first.keys())
+        out["null_keys"] = sorted(k for k, v in first.items() if v is None)
+    return out
 
-    This is how we prove inconsistent upstream returns. Span latency is recorded
-    by Langfuse from the observation duration, so we only enrich the output.
-    Wrapped in try/except: tracing must never break a read.
+
+def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
+    """Attach status + a PII-safe response structure + source to a Langfuse
+    observation. This is how we prove inconsistent upstream returns. Span latency
+    is recorded by Langfuse from the observation duration. Raw bodies are only
+    included when FARMER_API_TRACE_BODY is enabled (deep-debug). Wrapped in
+    try/except: tracing must never break a read.
     """
     if observation is None:
         return
@@ -67,16 +99,15 @@ def _record_api_trace(observation, response, *, provider: str, url: str) -> None
     except Exception:
         body = ""
     try:
-        observation.update(
-            output={
-                "status_code": response.status_code,
-                "ok": response.status_code == 200,
-                "bytes": len(body),
-                "body": body[: settings.farmer_api_trace_body_chars],
-                "fetch_reason": _fetch_reason.get(),
-            },
-            metadata={"provider": provider, "url": url},
-        )
+        output = {
+            "status_code": response.status_code,
+            "ok": 200 <= response.status_code < 300,
+            "fetch_reason": _fetch_reason.get(),
+            **_safe_response_summary(body),
+        }
+        if settings.farmer_api_trace_body and settings.farmer_api_trace_body_chars > 0:
+            output["body"] = body[: settings.farmer_api_trace_body_chars]
+        observation.update(output=output, metadata={"provider": provider, "url": url})
     except Exception:
         pass
 
@@ -308,12 +339,12 @@ async def create_ai_call_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
                 _logger.info(
                     "[CreateAICall(%s,%s,%s,%s)] :: Response received.",
                     request.union_code, request.society_code, request.farmer_code, request.species.value,
                 )
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -342,6 +373,7 @@ async def create_health_call_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
                 _logger.info(
                     "[CreateHealthCall(%s,%s,%s,%s,%s)] :: Response received.",
@@ -351,7 +383,6 @@ async def create_health_call_api(
                     request.species.value,
                     request.case_type.value,
                 )
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -398,8 +429,8 @@ async def get_ai_technicians_by_society_api(
                     params=query.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         response_json = response.json()
         if isinstance(response_json, dict) and isinstance(response_json.get("data"), list):
@@ -444,8 +475,8 @@ async def get_farmer_milk_collection_details_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         if response.status_code == 204 or not (response.text or "").strip():
             return None

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -8,6 +8,8 @@ Used by farmer.py and animal.py to provide cohesive tools with fallback and merg
 """
 import json
 import re
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -20,6 +22,7 @@ from app.models.milk_collection import (
     FarmerMilkCollectionRequestModel,
     FarmerMilkCollectionResponseModel,
 )
+from app.config import settings
 from app.observability import start_observation
 from helpers.utils import get_logger
 
@@ -27,6 +30,55 @@ _logger = get_logger(__name__)
 
 BASE_AMULPASHUDHAN = "https://api.amulpashudhan.com/configman/v1/PashuGPT"
 BASE_HERDMAN = "https://herdman.live/apis/api"
+
+
+# Why this read happened — tags every API observation so we can tell, in
+# Langfuse, a request-time cold fetch from a background-worker refresh. Reads
+# served straight from Redis never reach this layer, so a recorded API call
+# always means the cache was bypassed.
+_fetch_reason: ContextVar[str] = ContextVar("farmer_fetch_reason", default="request")
+
+
+@contextmanager
+def fetch_reason(reason: str):
+    """Tag all Amul API calls made within this block with `reason`."""
+    token = _fetch_reason.set(reason)
+    try:
+        yield
+    finally:
+        _fetch_reason.reset(token)
+
+
+def current_fetch_reason() -> str:
+    return _fetch_reason.get()
+
+
+def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
+    """Attach status code + response body + source to a Langfuse observation.
+
+    This is how we prove inconsistent upstream returns. Span latency is recorded
+    by Langfuse from the observation duration, so we only enrich the output.
+    Wrapped in try/except: tracing must never break a read.
+    """
+    if observation is None:
+        return
+    try:
+        body = response.text or ""
+    except Exception:
+        body = ""
+    try:
+        observation.update(
+            output={
+                "status_code": response.status_code,
+                "ok": response.status_code == 200,
+                "bytes": len(body),
+                "body": body[: settings.farmer_api_trace_body_chars],
+                "fetch_reason": _fetch_reason.get(),
+            },
+            metadata={"provider": provider, "url": url},
+        )
+    except Exception:
+        pass
 
 
 class GetAITechniciansBySocietyQueryParams(BaseModel):
@@ -78,8 +130,7 @@ async def fetch_farmer_amulpashudhan(mobile: str, token: str) -> Optional[List[D
                     url,
                     headers={"accept": "application/json", "Authorization": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "amulpashudhan", "url": url})
+            _record_api_trace(observation, r, provider="amulpashudhan", url=url)
         if r.status_code == 204 or not (r.text or "").strip():
             return None
         if r.status_code != 200:
@@ -109,8 +160,7 @@ async def fetch_farmer_herdman(mobile: str, token: str) -> Optional[List[Dict[st
                     params={"mobileno": mobile},
                     headers={"accept": "application/json", "api-token": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "herdman", "url": url})
+            _record_api_trace(observation, r, provider="herdman", url=url)
         if r.status_code != 200 or not (r.text or "").strip():
             return None
         data = json.loads(r.text)
@@ -160,8 +210,7 @@ async def fetch_animal_amulpashudhan(tag_no: str, token: str) -> Optional[Dict[s
                     url,
                     headers={"accept": "application/json", "Authorization": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "amulpashudhan", "url": url})
+            _record_api_trace(observation, r, provider="amulpashudhan", url=url)
         if r.status_code == 204 or not (r.text or "").strip():
             return None
         if r.status_code != 200:
@@ -212,8 +261,7 @@ async def fetch_animal_herdman(tag_no: str, token: str) -> Optional[Dict[str, An
                     params={"TagID": tag_no},
                     headers={"accept": "application/json", "api-token": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "herdman", "url": url})
+            _record_api_trace(observation, r, provider="herdman", url=url)
         if r.status_code != 200 or not (r.text or "").strip():
             return None
         data = json.loads(r.text)
@@ -265,8 +313,7 @@ async def create_ai_call_api(
                     "[CreateAICall(%s,%s,%s,%s)] :: Response received.",
                     request.union_code, request.society_code, request.farmer_code, request.species.value,
                 )
-            if observation is not None:
-                observation.update(output={"status_code": response.status_code}, metadata={"provider": "amulpashudhan", "url": api_url})
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -304,11 +351,7 @@ async def create_health_call_api(
                     request.species.value,
                     request.case_type.value,
                 )
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -356,11 +399,7 @@ async def get_ai_technicians_by_society_api(
                     headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         response_json = response.json()
         if isinstance(response_json, dict) and isinstance(response_json.get("data"), list):
@@ -406,11 +445,7 @@ async def get_farmer_milk_collection_details_api(
                     headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         if response.status_code == 204 or not (response.text or "").strip():
             return None

--- a/app/config.py
+++ b/app/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     # the read blocks on a bounded API call instead of serving it (falls back to
     # the stale record only if the API also fails). Backstop above the 12h/2h
     # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
-    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 48)))
+    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 24)))
     # Max chars of an upstream API response body recorded to Langfuse (to prove
     # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
     farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))

--- a/app/config.py
+++ b/app/config.py
@@ -66,8 +66,12 @@ class Settings(BaseSettings):
     # the stale record only if the API also fails). Backstop above the 12h/2h
     # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
     farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 24)))
-    # Max chars of an upstream API response body recorded to Langfuse (to prove
-    # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
+    # Farmer/animal API tracing records a PII-SAFE structure summary by default
+    # (status, record count, which keys are present/null) — enough to prove
+    # inconsistent returns without shipping farmer PII to Langfuse. Raw response
+    # bodies are only captured when FARMER_API_TRACE_BODY is explicitly enabled
+    # (temporary deep-debug), capped at FARMER_API_TRACE_BODY_CHARS.
+    farmer_api_trace_body: bool = _get_bool_env("FARMER_API_TRACE_BODY", default=False)
     farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))
 
     # Logging Configuration

--- a/app/config.py
+++ b/app/config.py
@@ -61,6 +61,14 @@ class Settings(BaseSettings):
     default_cache_ttl: int = 60 * 60 * 24  # 24 hours
     session_owner_ttl_seconds: int = int(os.getenv("SESSION_OWNER_TTL_SECONDS", "120"))
     session_owner_refresh_interval_seconds: int = int(os.getenv("SESSION_OWNER_REFRESH_INTERVAL_SECONDS", "15"))
+    # Farmer cache policy: beyond this age a cached record is too stale to serve —
+    # the read blocks on a bounded API call instead of serving it (falls back to
+    # the stale record only if the API also fails). Backstop above the 12h/2h
+    # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
+    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 48)))
+    # Max chars of an upstream API response body recorded to Langfuse (to prove
+    # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
+    farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))
 
     # Logging Configuration
     log_level: str = "INFO"

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -19,6 +19,7 @@ from agents.services.farmer_cache import (
     refresh_farmer_data_bounded,
     enqueue_farmer_refresh,
     should_refresh_farmer_data,
+    exceeds_max_serve_stale,
 )
 from app.models.union import UnionName
 from app.services.scheme_ingestion import (
@@ -524,6 +525,12 @@ async def get_or_fetch_farmer_data(mobile: str):
     """
     cached = await get_farmer_data_cached_only(mobile)
     if cached is not None:
+        if exceeds_max_serve_stale(cached):
+            # Too stale to serve (e.g. background refresh has been failing):
+            # block on a bounded API call, falling back to the stale record
+            # only if the API also fails.
+            fresh = await refresh_farmer_data_bounded(mobile)
+            return fresh if fresh is not None else cached
         return cached
     return await refresh_farmer_data_bounded(mobile)
 

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -44,6 +44,9 @@ class _Env:
         self.lookupStatus = lookup_status
         self.fetchedAt = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).isoformat()
 
+    def model_dump(self):
+        return {"lookupStatus": self.lookupStatus, "fetchedAt": self.fetchedAt}
+
 
 def test_freshness_intervals_found_vs_not_found():
     # found: soft expiry at 12h
@@ -208,6 +211,110 @@ def test_bounded_timeout_releases_lock_on_cancel():
         result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
     assert result is None
     fake_redis.delete.assert_awaited()  # lock released on cancellation
+
+
+def test_lock_busy_never_clears_reenqueues_not_stale():
+    """Residual #3/#4 fix: if the in-flight holder outlives the wait, return None
+    and RE-ENQUEUE — do not serve the stale record or silently drop the phone."""
+    old = _Env("found", 1000)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)   # lock busy
+    fake_redis.exists = AsyncMock(return_value=1)   # never clears within the wait
+    enqueue = AsyncMock()
+    with patch.object(fc, "FARMER_COLD_FETCH_TIMEOUT", 0.3), \
+         patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=old)), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is None                       # NOT the ancient cached record
+    enqueue.assert_awaited_once_with("111")     # re-queued, not dropped
+
+
+def test_lock_busy_held_then_released_returns_fresh():
+    """If the holder finishes within the (now cold-fetch-sized) wait, return its
+    fresh result and do not re-enqueue."""
+    fresh = _Env("found", 0)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)               # lock busy
+    fake_redis.exists = AsyncMock(side_effect=[1, 0])           # held, then released
+    enqueue = AsyncMock()
+    with patch.object(fc, "FARMER_COLD_FETCH_TIMEOUT", 2.0), \
+         patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=fresh)), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is fresh
+    enqueue.assert_not_called()
+
+
+def test_restamp_kept_record_preserves_ttl():
+    """Don't-downgrade past the ceiling restamps fetchedAt (to stop a per-turn
+    block) but PRESERVES the remaining 7d TTL."""
+    existing = _Env("found", 1000)  # >24h
+    orig_fetched = existing.fetchedAt
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)       # lock acquired
+    fake_redis.delete = AsyncMock()
+    fake_redis.ttl = AsyncMock(return_value=100000)     # remaining hard TTL
+    fake_cache = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "cache", fake_cache), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)):
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    assert existing.fetchedAt != orig_fetched           # restamped
+    fake_cache.set.assert_awaited()
+    assert fake_cache.set.call_args.kwargs.get("ttl") == 100000  # 7d TTL preserved, not reset
+
+
+def test_trace_recorded_before_raise_for_status_on_failure():
+    """A failing (5xx) booking response must still be traced — _record_api_trace
+    runs BEFORE response.raise_for_status()."""
+    import contextlib
+    from agents.tools import farmer_animal_backends as backends
+    from agents.models.ai_call import AICallRequestModel, AISpecies
+
+    captured = {}
+
+    class _Obs:
+        def update(self, output=None, metadata=None):
+            captured["output"] = output
+
+    @contextlib.contextmanager
+    def _fake_obs(*a, **k):
+        yield _Obs()
+
+    class _Resp:
+        status_code = 500
+        text = '{"error": "boom"}'
+
+        def raise_for_status(self):
+            raise Exception("HTTP 500")
+
+        def json(self):
+            return {}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            return _Resp()
+
+    req = AICallRequestModel(
+        unionCode="2021", societyCode="NA4310", farmerCode="NA0002",
+        userId="u1", species=AISpecies.COW,
+    )
+    with patch.object(backends, "start_observation", _fake_obs), \
+         patch.object(backends.httpx, "AsyncClient", lambda *a, **k: _Client()):
+        result = asyncio.run(backends.create_ai_call_api(req, "tok"))
+    assert result is None                                    # raised -> None
+    assert captured["output"]["status_code"] == 500          # but the 500 WAS traced
+    assert captured["output"]["ok"] is False
 
 
 def _capture_trace(backends, resp, reason="cold_fetch"):

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -115,12 +115,93 @@ def test_bounded_fetch_times_out_and_enqueues():
 
 
 def test_voice_read_returns_cached_without_blocking():
-    cached = object()
+    cached = _Env("found", 1)  # fresh, within max-serve-stale
     with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=cached)), \
          patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock()) as bounded:
         result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
     assert result is cached
     bounded.assert_not_called()
+
+
+def test_voice_read_blocks_when_too_stale():
+    stale = _Env("found", 1000)   # well beyond the 48h max-serve-stale
+    fresh = _Env("found", 0)
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fresh)) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is fresh
+    bounded.assert_awaited_once_with("111")
+
+
+def test_voice_read_too_stale_falls_back_to_stale_on_api_failure():
+    stale = _Env("found", 1000)
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=None)):
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is stale  # API also failed -> serve stale rather than nothing
+
+
+def test_exceeds_max_serve_stale():
+    assert fc.exceeds_max_serve_stale(_Env("found", 1)) is False
+    assert fc.exceeds_max_serve_stale(_Env("found", 1000)) is True
+    assert fc.exceeds_max_serve_stale(None) is True
+
+
+def test_refresh_keeps_found_on_transient_not_found():
+    """A transient empty upstream response must not wipe a still-fresh 'found' record."""
+    existing = _Env("found", 1)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)   # lock acquired
+    fake_redis.delete = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)), \
+         patch.object(fc, "set_cached_farmer_data", new=AsyncMock()) as set_cache:
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    set_cache.assert_not_called()  # did NOT downgrade to not_found
+
+
+def test_record_api_trace_captures_body_status_and_reason():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"totalAnimals": 5}'
+
+    captured = {}
+
+    class _Obs:
+        def update(self, output=None, metadata=None):
+            captured["output"] = output
+            captured["metadata"] = metadata
+
+    with backends.fetch_reason("cold_fetch"):
+        backends._record_api_trace(_Obs(), _Resp(), provider="amulpashudhan", url="http://x")
+    assert captured["output"]["status_code"] == 200
+    assert captured["output"]["ok"] is True
+    assert captured["output"]["body"] == '{"totalAnimals": 5}'
+    assert captured["output"]["fetch_reason"] == "cold_fetch"
+    assert captured["metadata"] == {"provider": "amulpashudhan", "url": "http://x"}
+
+
+def test_record_api_trace_none_observation_is_noop():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 500
+        text = "boom"
+
+    backends._record_api_trace(None, _Resp(), provider="x", url="y")  # must not raise
+
+
+def test_fetch_reason_contextvar_default_and_scope():
+    from agents.tools import farmer_animal_backends as backends
+
+    assert backends.current_fetch_reason() == "request"
+    with backends.fetch_reason("background_refresh"):
+        assert backends.current_fetch_reason() == "background_refresh"
+    assert backends.current_fetch_reason() == "request"
 
 
 def test_voice_read_cold_miss_does_bounded_fetch():

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -124,7 +124,7 @@ def test_voice_read_returns_cached_without_blocking():
 
 
 def test_voice_read_blocks_when_too_stale():
-    stale = _Env("found", 1000)   # well beyond the 48h max-serve-stale
+    stale = _Env("found", 1000)   # well beyond the 24h max-serve-stale
     fresh = _Env("found", 0)
     with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
          patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fresh)) as bounded:
@@ -162,13 +162,55 @@ def test_refresh_keeps_found_on_transient_not_found():
     set_cache.assert_not_called()  # did NOT downgrade to not_found
 
 
-def test_record_api_trace_captures_body_status_and_reason():
-    from agents.tools import farmer_animal_backends as backends
+def test_refresh_keeps_old_found_past_ceiling_on_transient_not_found():
+    """Even past max-serve-stale, a transient empty must not overwrite a 'found'
+    record (genuine removal is left to the 7d hard TTL)."""
+    existing = _Env("found", 1000)  # well past the 24h ceiling
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)), \
+         patch.object(fc, "set_cached_farmer_data", new=AsyncMock()) as set_cache:
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    set_cache.assert_not_called()
 
-    class _Resp:
-        status_code = 200
-        text = '{"totalAnimals": 5}'
 
+def test_refresh_lock_busy_awaits_inflight_value():
+    """A refresh that loses the NX-lock race returns the in-flight result, not
+    None (None would defeat max-serve-stale and drop queued refreshes)."""
+    sentinel = _Env("found", 0)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)   # lock busy
+    fake_redis.exists = AsyncMock(return_value=0)   # in-flight refresh already finished
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=sentinel)):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is sentinel
+
+
+def test_bounded_timeout_releases_lock_on_cancel():
+    """The design's key claim: when the bounded fetch times out and cancels the
+    in-flight refresh, the NX lock is released in refresh_farmer_data's finally."""
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)   # lock acquired
+    fake_redis.delete = AsyncMock()
+
+    async def _slow(_phone):
+        await asyncio.sleep(5)
+        return []
+
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=_slow), \
+         patch.object(fc, "enqueue_farmer_refresh", new=AsyncMock()):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
+    assert result is None
+    fake_redis.delete.assert_awaited()  # lock released on cancellation
+
+
+def _capture_trace(backends, resp, reason="cold_fetch"):
     captured = {}
 
     class _Obs:
@@ -176,13 +218,69 @@ def test_record_api_trace_captures_body_status_and_reason():
             captured["output"] = output
             captured["metadata"] = metadata
 
-    with backends.fetch_reason("cold_fetch"):
-        backends._record_api_trace(_Obs(), _Resp(), provider="amulpashudhan", url="http://x")
-    assert captured["output"]["status_code"] == 200
-    assert captured["output"]["ok"] is True
-    assert captured["output"]["body"] == '{"totalAnimals": 5}'
-    assert captured["output"]["fetch_reason"] == "cold_fetch"
-    assert captured["metadata"] == {"provider": "amulpashudhan", "url": "http://x"}
+    with backends.fetch_reason(reason):
+        backends._record_api_trace(_Obs(), resp, provider="amulpashudhan", url="http://x")
+    return captured
+
+
+def test_record_api_trace_is_pii_safe_by_default():
+    """By default NO raw body is shipped — only status + structure (keys/null_keys
+    + record count), which still proves an inconsistent return."""
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"farmerName": "Ramesh", "totalAnimals": null, "tagNo": "1,2"}'
+
+    out = _capture_trace(backends, _Resp())["output"]
+    assert out["status_code"] == 200
+    assert out["ok"] is True
+    assert out["fetch_reason"] == "cold_fetch"
+    assert out["records"] == 1
+    assert out["keys"] == ["farmerName", "tagNo", "totalAnimals"]
+    assert out["null_keys"] == ["totalAnimals"]          # proves the Turn-A shape
+    assert "body" not in out                              # no PII value leaks
+    assert "Ramesh" not in str(out)
+
+
+def test_record_api_trace_ok_is_2xx():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _R204:
+        status_code = 204
+        text = ""
+
+    class _R500:
+        status_code = 500
+        text = "err"
+
+    assert _capture_trace(backends, _R204())["output"]["ok"] is True   # 204 is ok
+    assert _capture_trace(backends, _R500())["output"]["ok"] is False
+
+
+def test_record_api_trace_body_only_when_flag_enabled(monkeypatch):
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"totalAnimals": 5}'
+
+    monkeypatch.setattr(backends.settings, "farmer_api_trace_body", True)
+    out = _capture_trace(backends, _Resp())["output"]
+    assert out["body"] == '{"totalAnimals": 5}'
+
+
+def test_safe_response_summary_shapes():
+    from agents.tools.farmer_animal_backends import _safe_response_summary
+
+    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1"}]')
+    assert full["records"] == 1 and "totalAnimals" in full["keys"] and full["null_keys"] == []
+    missing = _safe_response_summary('[{"tagNo": "1"}]')   # totalAnimals absent
+    assert "totalAnimals" not in missing["keys"]
+    empty = _safe_response_summary("[]")
+    assert empty["records"] == 0
+    notjson = _safe_response_summary("<html>err</html>")
+    assert notjson["json"] is False
 
 
 def test_record_api_trace_none_observation_is_noop():

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -273,14 +273,23 @@ def test_record_api_trace_body_only_when_flag_enabled(monkeypatch):
 def test_safe_response_summary_shapes():
     from agents.tools.farmer_animal_backends import _safe_response_summary
 
-    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1"}]')
+    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1", "visits": [1, 2, 3]}]')
     assert full["records"] == 1 and "totalAnimals" in full["keys"] and full["null_keys"] == []
+    assert full["array_lens"] == {"visits": 3}          # array metric, no values
     missing = _safe_response_summary('[{"tagNo": "1"}]')   # totalAnimals absent
     assert "totalAnimals" not in missing["keys"]
     empty = _safe_response_summary("[]")
     assert empty["records"] == 0
     notjson = _safe_response_summary("<html>err</html>")
     assert notjson["json"] is False
+
+
+def test_safe_response_summary_flags_empty_arrays_and_strings():
+    from agents.tools.farmer_animal_backends import _safe_response_summary
+
+    out = _safe_response_summary('[{"animals": [], "society": "", "tagNo": "1"}]')
+    assert out["array_lens"] == {"animals": 0}     # empty array surfaced
+    assert out["empty_str_keys"] == ["society"]    # empty string surfaced
 
 
 def test_record_api_trace_none_observation_is_noop():


### PR DESCRIPTION
Replaces #144, which GitHub auto-closed when its base (`feat/farmer-cache-swr`) was deleted on #143 merge. Same head branch (`03ea058`); diff is just the observability work since cache SWR is now in `amul-dev` via #143.

## What
Stacked observability + cache-policy work on top of the cache SWR (#143).

- **Trace every farmer/animal API call PII-safely.** `_record_api_trace` records `status_code` + `ok` (2xx) + `fetch_reason` (`request` / `cold_fetch` / `background_refresh`) + a structure summary (`records`, `keys`, `null_keys`, `array_lens`, `empty_str_keys`) on all 8 amulpashudhan/herdman observations. No values by default → no PII. Raw bodies only behind `FARMER_API_TRACE_BODY=true` (default off), capped at `FARMER_API_TRACE_BODY_CHARS`. `_record_api_trace` runs **before** `raise_for_status()` on booking/technician/milk endpoints so failing 4xx/5xx bodies are captured.
- **`fetch_reason` contextvar** + background-worker root span (`farmer_background_refresh`) so refreshes are queryable in Langfuse even without a session.
- **Max-serve-stale ceiling** `FARMER_MAX_SERVE_STALE_SECONDS=24h`: read blocks on a bounded API call when the record is too old, falling back to stale only if the API also fails. Ladder: fresh ≤12h, stale+bg-refresh 12-24h, block >24h, 7d hard delete.
- **Don't-downgrade** guard: a transient empty upstream never overwrites a `found` record (at any age). When the kept record is already past the ceiling, `fetchedAt` is restamped while the remaining 7d TTL is preserved, so a persistently-empty farmer doesn't pay a per-turn block.
- **Lock-contention fix:** `_await_inflight_refresh` returns `(envelope, cleared)` bounded by `FARMER_COLD_FETCH_TIMEOUT` (3s→4s to outlast a ~3.1s cold fetch). On lock-busy-not-cleared, `refresh_farmer_data` re-enqueues and returns `None` — so max-serve-stale doesn't serve ancient data and the worker doesn't drop the queued phone.

## Tests
29 — incl. PII-safe default, ok=2xx, body-behind-flag, safe-summary shapes, downgrade-past-ceiling, lock-busy never-clears reenqueue, lock-busy held-then-released, lock-release-on-cancel, restamp-preserves-TTL, trace-recorded-before-raise on 5xx.

## Follow-ups (not in this PR)
- Voice tool defs: align voice farmer-data access with chat (chat reads context; voice's brittle `get_herd_summary` is the chat-vs-voice gap).
- Provider-interface PR: per-field keep-best merge + union-gated backend selection.
- Booking PR: live `get_available_technicians` (stop caching technicians).

🤖 Generated with [Claude Code](https://claude.com/claude-code)