### PR TITLE
fix(voice): align farmer-data access with chat — drop brittle tools, strengthen context

### DIFF
--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -67,24 +67,35 @@ BASE_TOOLS = [
 ]
 
 SIGNED_IN_FARMER_TOOLS = [
-    Tool(
-        _with_nudge_signal(get_farmer_profile),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
-    Tool(
-        _with_nudge_signal(get_herd_summary),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
-    Tool(
-        _with_nudge_signal(list_animal_tags),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
+    # # Get Farmer Profile (disabled — redundant with _build_compact_farmer_summary
+    # # context; the brittle farmers[0]-only read returned "not available" when
+    # # the cached record was missing fields, while context already had them).
+    # Tool(
+    #     _with_nudge_signal(get_farmer_profile),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
+    # # Get Herd Summary (disabled — same cache as context; root of the Turn-A
+    # # "I don't have your herd info" failure. Counts now always surfaced in
+    # # the runtime context with len(tags) fallback, matching chat's pattern).
+    # Tool(
+    #     _with_nudge_signal(get_herd_summary),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
+    # # List Animal Tags (disabled — runtime context now lists all tags inline
+    # # (no truncation), so a tool round-trip is no longer needed).
+    # Tool(
+    #     _with_nudge_signal(list_animal_tags),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
     Tool(
         _with_nudge_signal(get_union_scheme_data),
         takes_ctx=True,

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -631,12 +631,28 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
         lines.append(f"- Society code: {society_code}")
     if first.farmerCode:
         lines.append(f"- Farmer code: {first.farmerCode}")
-    if first.totalAnimals is not None:
-        lines.append(f"- Total animals: {first.totalAnimals}")
+    # Herd counts: always surface what we have. The agent answers from this
+    # context (the brittle get_herd_summary / list_animal_tags / get_farmer_profile
+    # tools were dropped — they read the same cache and returned "not available"
+    # when the upstream record omitted totalAnimals even though tags were present).
+    first_data = first.model_dump()
+    total_animals = first.totalAnimals
+    if total_animals is None and tags:
+        total_animals = len(tags)  # fallback when upstream omits the count
+    if total_animals is not None:
+        lines.append(f"- Total animals: {total_animals}")
+    cow = first_data.get("cow") or first_data.get("Cow")
+    if cow is not None:
+        lines.append(f"- Cows: {cow}")
+    buffalo = first_data.get("buffalo") or first_data.get("Buffalo")
+    if buffalo is not None:
+        lines.append(f"- Buffaloes: {buffalo}")
+    milking = first_data.get("totalMilkingAnimals") or first_data.get("Milking Animal")
+    if milking is not None:
+        lines.append(f"- Milking animals: {milking}")
     if tags:
-        preview = ", ".join(tags[:8])
-        extra = f" (+{len(tags) - 8} more)" if len(tags) > 8 else ""
-        lines.append(f"- Known animal tags: {preview}{extra}")
+        # All tags inline — no truncation, since the list-tags tool was dropped.
+        lines.append(f"- Known animal tags: {', '.join(tags)}")
     if len(envelope.farmers) > 1:
         lines.append("- Multiple farmer records are registered on this mobile number.")
         lines.append("- For AI booking, first ask which farmer name the caller wants to use.")

--- a/tests/test_voice_farmer_context.py
+++ b/tests/test_voice_farmer_context.py
@@ -1,0 +1,73 @@
+"""Unit tests for the voice runtime context (compact farmer summary).
+
+Covers Fix-1: counts always surface (with len(tags) fallback), cow/buffalo/milking
+always surface, all tags inline — so the voice agent answers herd questions from
+context without needing the dropped get_herd_summary / list_animal_tags /
+get_farmer_profile tools.
+"""
+# Import the app entry first so the pre-existing tools<->farmer_cache cycle
+# resolves in the same order the running app establishes it.
+import app.services.voice as voice
+
+from agents.models.farmer import FarmerDataEnvelope
+from helpers.gujarati_numbers import mask_tag_identifier
+
+
+def _envelope(record: dict) -> FarmerDataEnvelope:
+    return FarmerDataEnvelope.from_records([record], source="api", lookup_status="found")
+
+
+def test_summary_falls_back_to_tag_count_when_totalanimals_null():
+    """Turn-A fix: a record missing totalAnimals (the incident shape) still
+    answers 'you have N animals' by deriving N from the tag list."""
+    record = {"farmerName": "X", "tagNo": "100000000001,100000000002,100000000003"}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "- Total animals: 3" in summary
+
+
+def test_summary_includes_cow_buffalo_milking():
+    record = {
+        "farmerName": "X",
+        "totalAnimals": 5,
+        "cow": 3,
+        "buffalo": 2,
+        "totalMilkingAnimals": 4,
+        "tagNo": "100000000001,100000000002,100000000003,100000000004,100000000005",
+    }
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "- Total animals: 5" in summary
+    assert "- Cows: 3" in summary
+    assert "- Buffaloes: 2" in summary
+    assert "- Milking animals: 4" in summary
+
+
+def test_summary_shows_all_tags_no_truncation():
+    """list_animal_tags tool dropped — context must list all tags inline."""
+    tags_csv = ",".join(f"10000000{i:04d}" for i in range(12))  # 12 tags
+    record = {"farmerName": "X", "totalAnimals": 12, "tagNo": tags_csv}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "more)" not in summary  # no truncation marker
+    # All 12 masked tag strings appear (distinct last-4-digit verbalizations)
+    masked_count = sum(
+        1 for i in range(12)
+        if mask_tag_identifier(f"10000000{i:04d}") in summary
+    )
+    assert masked_count == 12
+
+
+def test_summary_handles_record_with_no_count_and_no_tags():
+    """Edge case: a record with neither totalAnimals nor tags omits the line
+    rather than asserting a zero count we can't substantiate."""
+    record = {"farmerName": "X", "societyName": "S"}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "Total animals" not in summary
+
+
+def test_signed_in_farmer_tools_drops_brittle_three():
+    """The three brittle voice-only farmer tools are commented out; only the
+    union-scheme tool remains in SIGNED_IN_FARMER_TOOLS."""
+    from agents.tools import SIGNED_IN_FARMER_TOOLS
+
+    assert len(SIGNED_IN_FARMER_TOOLS) == 1, (
+        f"expected only get_union_scheme_data; got {len(SIGNED_IN_FARMER_TOOLS)} tools"
+    )


### PR DESCRIPTION
## What
Fixes the **chat-vs-voice "I don't have your herd info"** gap by aligning voice's farmer-data access path with chat's.

## Why
Voice and chat read the **same** farmer cache. But:
- **Chat** has its herd/profile/tag tools commented out and reads farmer data from the prompt context. Answers reliably.
- **Voice** exposed `get_herd_summary`/`list_animal_tags`/`get_farmer_profile` as live tools. The agent called `get_herd_summary` and got back the partial cache record (no \`totalAnimals\`) → "not available," even though tags were sitting in its context. That was the Turn-A failure.

The voice tools were **pure round-trips** — they read the same cache the context already exposes — but with a brittle `farmers[0]` + count-fields-only read.

## Changes
- **`_build_compact_farmer_summary`** now always surfaces what we know:
  - `Total animals` falls back to `len(tags)` when the upstream omits the count (the Turn-A shape).
  - `Cows` / `Buffaloes` / `Milking animals` emitted from the \`extra="allow"\` record fields.
  - All tags listed inline (was capped at 8 + "(+N more)" — the list-tags tool was the cap's escape hatch).
- **`SIGNED_IN_FARMER_TOOLS`**: `get_farmer_profile`, `get_herd_summary`, `list_animal_tags` commented out (chat-style). `get_union_scheme_data` stays.

Net: voice agent now answers herd/profile/tag questions from the prompt context — the same access path chat uses.

## Tests
+5 (34 total): tag-count fallback, cow/buffalo/milking surfaced, no tag truncation, no-data record omits the count line, `SIGNED_IN_FARMER_TOOLS` only contains `get_union_scheme_data`. Verified `import main` still boots.

## Not in scope
- Numbers ("Twenty Two → Two Two") — wontfix per Kanav.
- Provider-interface PR (per-field keep-best merge + union-gated backends) — follow-up.
- Booking PR (live `get_available_technicians`) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)