### PR TITLE
promote: farmer cache SWR + API observability + tool-defs aligned with chat (dev → prod)

### DIFF
--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -33,7 +33,7 @@ FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days hard retention in Redis (deletion)
 FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record after 12h
 FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
-FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
+FARMER_COLD_FETCH_TIMEOUT = 4.0  # bounded blocking fetch for a cold/never-cached miss (cold ~3.1s observed)
 # Beyond this age a cached record is too stale to serve: the read blocks on a
 # bounded API call instead (falls back to the stale record only if that fails).
 FARMER_MAX_SERVE_STALE_SECONDS = settings.farmer_max_serve_stale_seconds
@@ -125,29 +125,48 @@ async def set_cached_farmer_data(phone: str, data: FarmerDataEnvelope) -> None:
 from agents.tools.farmer import fetch_farmer_info_raw
 
 
+async def _restamp_kept_record(phone: str, envelope: FarmerDataEnvelope) -> None:
+    """When don't-downgrade keeps a 'found' record on an empty upstream, refresh
+    its fetchedAt so reads stop block-fetching it every turn — while PRESERVING the
+    remaining 7d Redis TTL so a genuinely removed farmer still expires on schedule."""
+    envelope.fetchedAt = datetime.now(timezone.utc).isoformat()
+    key = _cache_key(phone)
+    try:
+        remaining = await redis_client.ttl(build_cache_key(key, namespace=FARMER_CACHE_NAMESPACE))
+        if remaining and remaining > 0:
+            await cache.set(key, envelope.model_dump(), ttl=remaining, namespace=FARMER_CACHE_NAMESPACE)
+    except Exception as e:
+        logger.warning("Failed to restamp kept farmer record (phone hash %s...): %s", key[:8], e)
+
+
 async def _await_inflight_refresh(
-    phone: str, lock_key: str, *, max_wait: float = 2.0, interval: float = 0.1
-) -> Optional[FarmerDataEnvelope]:
-    """Wait briefly for the in-flight refresh holding `lock_key` to finish, then
-    return the latest cached value. Lets a caller that lost the lock race get the
-    fresh result instead of a None it would misread as failure."""
+    phone: str, lock_key: str, *, timeout: float, interval: float = 0.1
+) -> tuple[Optional[FarmerDataEnvelope], bool]:
+    """Poll until the in-flight refresh holding `lock_key` finishes (lock gone),
+    bounded by `timeout`. Returns (latest cached value, cleared) — cleared is True
+    only if the lock actually released within the window. No cap below `timeout`:
+    the request path's outer asyncio.wait_for is the real limiter, and the worker
+    passes its own bound — so a slow (~3s) cold-fetch holder is awaited fully
+    instead of giving up early and serving stale."""
     loop = asyncio.get_event_loop()
-    deadline = loop.time() + max_wait
+    deadline = loop.time() + timeout
+    cleared = False
     while loop.time() < deadline:
         await asyncio.sleep(interval)
         try:
             if not await redis_client.exists(lock_key):
+                cleared = True
                 break
         except Exception:
             break
-    return await get_cached_farmer_data(phone)
+    return await get_cached_farmer_data(phone), cleared
 
 
 async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
     """
     Refresh farmer data from upstream APIs and update Redis.
     Returns the refreshed envelope, or the in-flight refresh's result when the
-    lock is busy, or None on actual failure.
+    lock is busy and clears in time, or None on actual failure / lock-still-busy.
     """
     lock_key = _refresh_lock_key(phone)
     acquired = False
@@ -158,7 +177,15 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             # rather than None — None would make max-serve-stale serve the ancient
             # record and would let the worker drop a queued phone as a no-op.
             logger.debug("Farmer refresh in flight for phone hash %s...; awaiting result", _cache_key(phone)[:8])
-            return await _await_inflight_refresh(phone, lock_key)
+            env, cleared = await _await_inflight_refresh(
+                phone, lock_key, timeout=FARMER_COLD_FETCH_TIMEOUT
+            )
+            if cleared:
+                return env
+            # Holder outlived our wait — re-queue so the refresh isn't lost
+            # (covers the worker path) and signal "not done" to the caller.
+            await enqueue_farmer_refresh(phone)
+            return None
 
         records = await fetch_farmer_info_raw(phone)
         if records:
@@ -179,6 +206,12 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
                 "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
                 _cache_key(phone)[:8],
             )
+            # If it had already aged past the serve ceiling, a persistently-empty
+            # upstream would otherwise force a blocking re-fetch on EVERY turn.
+            # Restamp fetchedAt so reads serve it without blocking, while
+            # PRESERVING the 7d hard TTL so a genuinely removed farmer still expires.
+            if exceeds_max_serve_stale(existing):
+                await _restamp_kept_record(phone, existing)
             return existing
 
         envelope = FarmerDataEnvelope.not_found(source="api")

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -17,10 +17,13 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.core.cache import cache, redis_client, build_cache_key
+from app.config import settings
+from app.observability import start_observation
 from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
 from agents.tools.farmer_animal_backends import (
     GetAITechniciansBySocietyQueryParams,
     get_ai_technicians_by_society_api,
+    fetch_reason,
 )
 from helpers.utils import get_logger
 
@@ -31,6 +34,9 @@ FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record 
 FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
 FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
+# Beyond this age a cached record is too stale to serve: the read blocks on a
+# bounded API call instead (falls back to the stale record only if that fails).
+FARMER_MAX_SERVE_STALE_SECONDS = settings.farmer_max_serve_stale_seconds
 FARMER_CACHE_NAMESPACE = "farmer"
 FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
 FARMER_REFRESH_QUEUE_NAMESPACE = "farmer-refresh-queue"
@@ -64,6 +70,26 @@ def _compute_freshness(envelope: FarmerDataEnvelope) -> tuple[bool, Optional[str
     refresh_after_iso = refresh_after.astimezone(timezone.utc).isoformat()
     is_stale = datetime.now(timezone.utc) >= refresh_after.astimezone(timezone.utc)
     return is_stale, ("expired" if is_stale else None), refresh_after_iso
+
+
+def _envelope_age_seconds(envelope: Optional[FarmerDataEnvelope]) -> Optional[float]:
+    if envelope is None or not envelope.fetchedAt:
+        return None
+    try:
+        fetched_at = datetime.fromisoformat(envelope.fetchedAt.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - fetched_at.astimezone(timezone.utc)).total_seconds()
+
+
+def exceeds_max_serve_stale(envelope: Optional[FarmerDataEnvelope]) -> bool:
+    """True when a cached record is too old to serve and the read should block
+    on a fresh API call (e.g. background refresh has been failing). Unknown age
+    counts as too stale."""
+    age = _envelope_age_seconds(envelope)
+    if age is None:
+        return True
+    return age > FARMER_MAX_SERVE_STALE_SECONDS
 
 
 async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
@@ -116,8 +142,25 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         if records:
             envelope = FarmerDataEnvelope.from_records(records, source="api", lookup_status="found")
             envelope.aiTechnicians = await _fetch_ai_technicians(records)
-        else:
-            envelope = FarmerDataEnvelope.not_found(source="api")
+            await set_cached_farmer_data(phone, envelope)
+            return envelope
+
+        # Upstream returned nothing. Guard against a transient empty response
+        # wiping known-good data: keep a still-serveable "found" record rather
+        # than downgrading it to not_found. It stays stale, so it is retried.
+        existing = await get_cached_farmer_data(phone)
+        if (
+            existing is not None
+            and existing.lookupStatus == "found"
+            and not exceeds_max_serve_stale(existing)
+        ):
+            logger.info(
+                "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
+                _cache_key(phone)[:8],
+            )
+            return existing
+
+        envelope = FarmerDataEnvelope.not_found(source="api")
         await set_cached_farmer_data(phone, envelope)
         return envelope
     except Exception as e:
@@ -176,7 +219,8 @@ async def refresh_farmer_data_bounded(
     the phone is queued, and the caller proceeds with no farmer data this turn.
     """
     try:
-        return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
+        with fetch_reason("cold_fetch"):
+            return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
     except asyncio.TimeoutError:
         logger.warning(
             "Cold farmer fetch exceeded %.1fs for phone hash %s...; deferring to worker",
@@ -201,7 +245,16 @@ async def drain_farmer_refresh_queue_once(batch: int = 20) -> int:
     processed = 0
     for phone in members:
         try:
-            await refresh_farmer_data(phone)
+            # Root span so the nested API-call observations have a parent and
+            # are queryable in Langfuse (background refreshes aren't tied to a
+            # voice session); fetch_reason tags them as background_refresh.
+            with start_observation(
+                "farmer_background_refresh",
+                input={"phone_hash": _cache_key(phone)[:12]},
+                metadata={"reason": "background_refresh"},
+            ):
+                with fetch_reason("background_refresh"):
+                    await refresh_farmer_data(phone)
             processed += 1
         except Exception:
             logger.exception("Background farmer refresh failed for a queued phone")

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -125,18 +125,40 @@ async def set_cached_farmer_data(phone: str, data: FarmerDataEnvelope) -> None:
 from agents.tools.farmer import fetch_farmer_info_raw
 
 
+async def _await_inflight_refresh(
+    phone: str, lock_key: str, *, max_wait: float = 2.0, interval: float = 0.1
+) -> Optional[FarmerDataEnvelope]:
+    """Wait briefly for the in-flight refresh holding `lock_key` to finish, then
+    return the latest cached value. Lets a caller that lost the lock race get the
+    fresh result instead of a None it would misread as failure."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + max_wait
+    while loop.time() < deadline:
+        await asyncio.sleep(interval)
+        try:
+            if not await redis_client.exists(lock_key):
+                break
+        except Exception:
+            break
+    return await get_cached_farmer_data(phone)
+
+
 async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
     """
     Refresh farmer data from upstream APIs and update Redis.
-    Returns the refreshed envelope or None on refresh failure.
+    Returns the refreshed envelope, or the in-flight refresh's result when the
+    lock is busy, or None on actual failure.
     """
     lock_key = _refresh_lock_key(phone)
     acquired = False
     try:
         acquired = await redis_client.set(lock_key, "1", ex=FARMER_REFRESH_LOCK_TTL, nx=True)
         if not acquired:
-            logger.debug("Farmer refresh already in flight for phone hash %s...", _cache_key(phone)[:8])
-            return None
+            # Another refresh is in-flight. Wait for its result and return that,
+            # rather than None — None would make max-serve-stale serve the ancient
+            # record and would let the worker drop a queued phone as a no-op.
+            logger.debug("Farmer refresh in flight for phone hash %s...; awaiting result", _cache_key(phone)[:8])
+            return await _await_inflight_refresh(phone, lock_key)
 
         records = await fetch_farmer_info_raw(phone)
         if records:
@@ -145,15 +167,14 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             await set_cached_farmer_data(phone, envelope)
             return envelope
 
-        # Upstream returned nothing. Guard against a transient empty response
-        # wiping known-good data: keep a still-serveable "found" record rather
-        # than downgrading it to not_found. It stays stale, so it is retried.
+        # Upstream returned nothing. Never let a transient empty response wipe
+        # known-good data — keep the "found" record regardless of age (it stays
+        # stale and is retried). We cannot distinguish a genuine "not found" from
+        # a transient failure here, so genuine removal is left to the 7d hard
+        # Redis TTL rather than an ambiguous empty response. (A confident
+        # not_found signal is a follow-up in the provider-interface PR.)
         existing = await get_cached_farmer_data(phone)
-        if (
-            existing is not None
-            and existing.lookupStatus == "found"
-            and not exceeds_max_serve_stale(existing)
-        ):
+        if existing is not None and existing.lookupStatus == "found":
             logger.info(
                 "Skipping not_found overwrite of good cached farmer data (phone hash %s...)",
                 _cache_key(phone)[:8],

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -3,11 +3,12 @@ Cache layer for farmer data fetched from PashuGPT APIs.
 
 Voice reads farmer context from Redis only. Freshness is controlled separately
 from key expiry:
-- refresh interval: 24h
-- cache retention: 7d
+- soft refresh interval: 12h for "found", 2h for "not_found"
+- cache retention (hard delete): 7d
 
 This lets the request path return cached data immediately, mark it stale in the
-read result, and schedule a background refresh without blocking the caller.
+read result, and schedule a background refresh (via a Redis queue drained by a
+worker) without blocking the caller.
 """
 import asyncio
 import hashlib

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -25,11 +25,16 @@ from helpers.utils import get_logger
 
 logger = get_logger(__name__)
 
-FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days retention in Redis
-FARMER_REFRESH_INTERVAL = 60 * 60 * 24  # refresh once a day
+FARMER_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days hard retention in Redis (deletion)
+FARMER_REFRESH_INTERVAL = 60 * 60 * 12  # soft expiry: refresh a "found" record after 12h
+FARMER_NEGATIVE_REFRESH_INTERVAL = 60 * 60 * 2  # not_found refreshes sooner (caller may newly register)
 FARMER_REFRESH_LOCK_TTL = 60 * 5  # dedupe concurrent refreshes for 5 minutes
+FARMER_COLD_FETCH_TIMEOUT = 3.0  # bounded blocking fetch for a cold/never-cached miss
 FARMER_CACHE_NAMESPACE = "farmer"
 FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
+FARMER_REFRESH_QUEUE_NAMESPACE = "farmer-refresh-queue"
+# Single Redis set holding raw phone numbers awaiting a background refresh.
+FARMER_REFRESH_QUEUE_KEY = build_cache_key("pending", namespace=FARMER_REFRESH_QUEUE_NAMESPACE)
 
 
 def _cache_key(phone: str) -> str:
@@ -49,7 +54,12 @@ def _compute_freshness(envelope: FarmerDataEnvelope) -> tuple[bool, Optional[str
     except ValueError:
         return True, "invalid_fetched_at", None
 
-    refresh_after = fetched_at + timedelta(seconds=FARMER_REFRESH_INTERVAL)
+    interval = (
+        FARMER_NEGATIVE_REFRESH_INTERVAL
+        if envelope.lookupStatus == "not_found"
+        else FARMER_REFRESH_INTERVAL
+    )
+    refresh_after = fetched_at + timedelta(seconds=interval)
     refresh_after_iso = refresh_after.astimezone(timezone.utc).isoformat()
     is_stale = datetime.now(timezone.utc) >= refresh_after.astimezone(timezone.utc)
     return is_stale, ("expired" if is_stale else None), refresh_after_iso
@@ -138,6 +148,63 @@ async def get_or_fetch_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         return cached
 
     return await refresh_farmer_data(phone)
+
+
+async def enqueue_farmer_refresh(phone: str) -> None:
+    """Queue a phone for background refresh (stale-while-revalidate).
+
+    Pushes the raw phone onto a Redis set so a dedicated worker can refresh it
+    off the request path. The set dedupes naturally, and refresh_farmer_data
+    self-dedupes via its NX lock, so enqueuing the same phone repeatedly is safe.
+    """
+    if not phone:
+        return
+    try:
+        await redis_client.sadd(FARMER_REFRESH_QUEUE_KEY, phone)
+    except Exception as e:
+        logger.warning("Failed to enqueue farmer refresh: %s", e)
+
+
+async def refresh_farmer_data_bounded(
+    phone: str, timeout: float = FARMER_COLD_FETCH_TIMEOUT
+) -> Optional[FarmerDataEnvelope]:
+    """Blocking refresh with a hard timeout, for a cold/never-cached miss.
+
+    On timeout we defer to the background worker rather than hanging the turn:
+    the in-flight refresh is cancelled (its NX lock is released in its finally),
+    the phone is queued, and the caller proceeds with no farmer data this turn.
+    """
+    try:
+        return await asyncio.wait_for(refresh_farmer_data(phone), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Cold farmer fetch exceeded %.1fs for phone hash %s...; deferring to worker",
+            timeout,
+            _cache_key(phone)[:8],
+        )
+        await enqueue_farmer_refresh(phone)
+        return None
+
+
+async def drain_farmer_refresh_queue_once(batch: int = 20) -> int:
+    """Pop up to `batch` queued phones and refresh each. Returns count processed."""
+    try:
+        members = await redis_client.spop(FARMER_REFRESH_QUEUE_KEY, batch)
+    except Exception as e:
+        logger.warning("Failed to read farmer refresh queue: %s", e)
+        return 0
+    if not members:
+        return 0
+    if isinstance(members, (str, bytes)):
+        members = [members]
+    processed = 0
+    for phone in members:
+        try:
+            await refresh_farmer_data(phone)
+            processed += 1
+        except Exception:
+            logger.exception("Background farmer refresh failed for a queued phone")
+    return processed
 
 
 async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:

--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -67,24 +67,35 @@ BASE_TOOLS = [
 ]
 
 SIGNED_IN_FARMER_TOOLS = [
-    Tool(
-        _with_nudge_signal(get_farmer_profile),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
-    Tool(
-        _with_nudge_signal(get_herd_summary),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
-    Tool(
-        _with_nudge_signal(list_animal_tags),
-        takes_ctx=True,
-        docstring_format='auto',
-        require_parameter_descriptions=False,
-    ),
+    # # Get Farmer Profile (disabled — redundant with _build_compact_farmer_summary
+    # # context; the brittle farmers[0]-only read returned "not available" when
+    # # the cached record was missing fields, while context already had them).
+    # Tool(
+    #     _with_nudge_signal(get_farmer_profile),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
+    # # Get Herd Summary (disabled — same cache as context; root of the Turn-A
+    # # "I don't have your herd info" failure. Counts now always surfaced in
+    # # the runtime context with len(tags) fallback, matching chat's pattern).
+    # Tool(
+    #     _with_nudge_signal(get_herd_summary),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
+    # # List Animal Tags (disabled — runtime context now lists all tags inline
+    # # (no truncation), so a tool round-trip is no longer needed).
+    # Tool(
+    #     _with_nudge_signal(list_animal_tags),
+    #     takes_ctx=True,
+    #     docstring_format='auto',
+    #     require_parameter_descriptions=False,
+    # ),
+
     Tool(
         _with_nudge_signal(get_union_scheme_data),
         takes_ctx=True,

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -82,6 +82,16 @@ def _safe_response_summary(body: str) -> dict:
     if isinstance(first, dict):
         out["keys"] = sorted(first.keys())
         out["null_keys"] = sorted(k for k, v in first.items() if v is None)
+        # Lengths of list-valued fields (no values) — surfaces empty/thin records
+        # (e.g. an empty animals/visits/technicians array) which signal a
+        # degraded "empty" response distinct from a populated one.
+        array_lens = {k: len(v) for k, v in first.items() if isinstance(v, list)}
+        if array_lens:
+            out["array_lens"] = array_lens
+        # Keys whose value is an empty string — another empty-response signal.
+        empty_str_keys = sorted(k for k, v in first.items() if v == "")
+        if empty_str_keys:
+            out["empty_str_keys"] = empty_str_keys
     return out
 
 

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -53,12 +53,44 @@ def current_fetch_reason() -> str:
     return _fetch_reason.get()
 
 
-def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
-    """Attach status code + response body + source to a Langfuse observation.
+def _safe_response_summary(body: str) -> dict:
+    """PII-safe shape of a response: record count + which keys are present/null,
+    WITHOUT any values. This is what proves an inconsistent return (e.g. a record
+    that came back missing `totalAnimals`) without shipping farmer PII to Langfuse.
+    """
+    out: dict[str, Any] = {"bytes": len(body)}
+    if not body.strip():
+        out["json"] = False
+        return out
+    try:
+        data = json.loads(body)
+    except Exception:
+        out["json"] = False
+        return out
+    out["json"] = True
+    if isinstance(data, dict) and isinstance(data.get("data"), list):
+        data = data["data"]
+    if isinstance(data, list):
+        out["records"] = len(data)
+        first = data[0] if data and isinstance(data[0], dict) else None
+    elif isinstance(data, dict):
+        out["records"] = 1
+        first = data
+    else:
+        out["records"] = 0
+        first = None
+    if isinstance(first, dict):
+        out["keys"] = sorted(first.keys())
+        out["null_keys"] = sorted(k for k, v in first.items() if v is None)
+    return out
 
-    This is how we prove inconsistent upstream returns. Span latency is recorded
-    by Langfuse from the observation duration, so we only enrich the output.
-    Wrapped in try/except: tracing must never break a read.
+
+def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
+    """Attach status + a PII-safe response structure + source to a Langfuse
+    observation. This is how we prove inconsistent upstream returns. Span latency
+    is recorded by Langfuse from the observation duration. Raw bodies are only
+    included when FARMER_API_TRACE_BODY is enabled (deep-debug). Wrapped in
+    try/except: tracing must never break a read.
     """
     if observation is None:
         return
@@ -67,16 +99,15 @@ def _record_api_trace(observation, response, *, provider: str, url: str) -> None
     except Exception:
         body = ""
     try:
-        observation.update(
-            output={
-                "status_code": response.status_code,
-                "ok": response.status_code == 200,
-                "bytes": len(body),
-                "body": body[: settings.farmer_api_trace_body_chars],
-                "fetch_reason": _fetch_reason.get(),
-            },
-            metadata={"provider": provider, "url": url},
-        )
+        output = {
+            "status_code": response.status_code,
+            "ok": 200 <= response.status_code < 300,
+            "fetch_reason": _fetch_reason.get(),
+            **_safe_response_summary(body),
+        }
+        if settings.farmer_api_trace_body and settings.farmer_api_trace_body_chars > 0:
+            output["body"] = body[: settings.farmer_api_trace_body_chars]
+        observation.update(output=output, metadata={"provider": provider, "url": url})
     except Exception:
         pass
 
@@ -308,12 +339,12 @@ async def create_ai_call_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
                 _logger.info(
                     "[CreateAICall(%s,%s,%s,%s)] :: Response received.",
                     request.union_code, request.society_code, request.farmer_code, request.species.value,
                 )
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -342,6 +373,7 @@ async def create_health_call_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
                 _logger.info(
                     "[CreateHealthCall(%s,%s,%s,%s,%s)] :: Response received.",
@@ -351,7 +383,6 @@ async def create_health_call_api(
                     request.species.value,
                     request.case_type.value,
                 )
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -398,8 +429,8 @@ async def get_ai_technicians_by_society_api(
                     params=query.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         response_json = response.json()
         if isinstance(response_json, dict) and isinstance(response_json.get("data"), list):
@@ -444,8 +475,8 @@ async def get_farmer_milk_collection_details_api(
                     params=request.to_query_params(),
                     headers={"Authorization": f"Bearer {token}"},
                 )
+                _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
                 response.raise_for_status()
-            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         if response.status_code == 204 or not (response.text or "").strip():
             return None

--- a/agents/tools/farmer_animal_backends.py
+++ b/agents/tools/farmer_animal_backends.py
@@ -8,6 +8,8 @@ Used by farmer.py and animal.py to provide cohesive tools with fallback and merg
 """
 import json
 import re
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -20,6 +22,7 @@ from app.models.milk_collection import (
     FarmerMilkCollectionRequestModel,
     FarmerMilkCollectionResponseModel,
 )
+from app.config import settings
 from app.observability import start_observation
 from helpers.utils import get_logger
 
@@ -27,6 +30,55 @@ _logger = get_logger(__name__)
 
 BASE_AMULPASHUDHAN = "https://api.amulpashudhan.com/configman/v1/PashuGPT"
 BASE_HERDMAN = "https://herdman.live/apis/api"
+
+
+# Why this read happened — tags every API observation so we can tell, in
+# Langfuse, a request-time cold fetch from a background-worker refresh. Reads
+# served straight from Redis never reach this layer, so a recorded API call
+# always means the cache was bypassed.
+_fetch_reason: ContextVar[str] = ContextVar("farmer_fetch_reason", default="request")
+
+
+@contextmanager
+def fetch_reason(reason: str):
+    """Tag all Amul API calls made within this block with `reason`."""
+    token = _fetch_reason.set(reason)
+    try:
+        yield
+    finally:
+        _fetch_reason.reset(token)
+
+
+def current_fetch_reason() -> str:
+    return _fetch_reason.get()
+
+
+def _record_api_trace(observation, response, *, provider: str, url: str) -> None:
+    """Attach status code + response body + source to a Langfuse observation.
+
+    This is how we prove inconsistent upstream returns. Span latency is recorded
+    by Langfuse from the observation duration, so we only enrich the output.
+    Wrapped in try/except: tracing must never break a read.
+    """
+    if observation is None:
+        return
+    try:
+        body = response.text or ""
+    except Exception:
+        body = ""
+    try:
+        observation.update(
+            output={
+                "status_code": response.status_code,
+                "ok": response.status_code == 200,
+                "bytes": len(body),
+                "body": body[: settings.farmer_api_trace_body_chars],
+                "fetch_reason": _fetch_reason.get(),
+            },
+            metadata={"provider": provider, "url": url},
+        )
+    except Exception:
+        pass
 
 
 class GetAITechniciansBySocietyQueryParams(BaseModel):
@@ -78,8 +130,7 @@ async def fetch_farmer_amulpashudhan(mobile: str, token: str) -> Optional[List[D
                     url,
                     headers={"accept": "application/json", "Authorization": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "amulpashudhan", "url": url})
+            _record_api_trace(observation, r, provider="amulpashudhan", url=url)
         if r.status_code == 204 or not (r.text or "").strip():
             return None
         if r.status_code != 200:
@@ -109,8 +160,7 @@ async def fetch_farmer_herdman(mobile: str, token: str) -> Optional[List[Dict[st
                     params={"mobileno": mobile},
                     headers={"accept": "application/json", "api-token": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "herdman", "url": url})
+            _record_api_trace(observation, r, provider="herdman", url=url)
         if r.status_code != 200 or not (r.text or "").strip():
             return None
         data = json.loads(r.text)
@@ -160,8 +210,7 @@ async def fetch_animal_amulpashudhan(tag_no: str, token: str) -> Optional[Dict[s
                     url,
                     headers={"accept": "application/json", "Authorization": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "amulpashudhan", "url": url})
+            _record_api_trace(observation, r, provider="amulpashudhan", url=url)
         if r.status_code == 204 or not (r.text or "").strip():
             return None
         if r.status_code != 200:
@@ -212,8 +261,7 @@ async def fetch_animal_herdman(tag_no: str, token: str) -> Optional[Dict[str, An
                     params={"TagID": tag_no},
                     headers={"accept": "application/json", "api-token": f"Bearer {token}"},
                 )
-            if observation is not None:
-                observation.update(output={"status_code": r.status_code}, metadata={"provider": "herdman", "url": url})
+            _record_api_trace(observation, r, provider="herdman", url=url)
         if r.status_code != 200 or not (r.text or "").strip():
             return None
         data = json.loads(r.text)
@@ -265,8 +313,7 @@ async def create_ai_call_api(
                     "[CreateAICall(%s,%s,%s,%s)] :: Response received.",
                     request.union_code, request.society_code, request.farmer_code, request.species.value,
                 )
-            if observation is not None:
-                observation.update(output={"status_code": response.status_code}, metadata={"provider": "amulpashudhan", "url": api_url})
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -304,11 +351,7 @@ async def create_health_call_api(
                     request.species.value,
                     request.case_type.value,
                 )
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
         response_json = response.json()
         if not isinstance(response_json, dict):
             raise Exception("Not a valid dict in response.")
@@ -356,11 +399,7 @@ async def get_ai_technicians_by_society_api(
                     headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         response_json = response.json()
         if isinstance(response_json, dict) and isinstance(response_json.get("data"), list):
@@ -406,11 +445,7 @@ async def get_farmer_milk_collection_details_api(
                     headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
-            if observation is not None:
-                observation.update(
-                    output={"status_code": response.status_code},
-                    metadata={"provider": "amulpashudhan", "url": api_url},
-                )
+            _record_api_trace(observation, response, provider="amulpashudhan", url=api_url)
 
         if response.status_code == 204 or not (response.text or "").strip():
             return None

--- a/agents/tools/farmer_cached.py
+++ b/agents/tools/farmer_cached.py
@@ -7,7 +7,6 @@ import json
 from pydantic_ai import RunContext
 
 from agents.deps import FarmerContext
-from agents.services.farmer_cache import get_or_fetch_farmer_data
 from helpers.gujarati_numbers import mask_tag_identifier
 
 
@@ -15,6 +14,12 @@ async def _get_envelope(ctx: RunContext[FarmerContext]):
     mobile = ctx.deps.mobile
     if not mobile:
         return None
+    # Lazy import: this module is pulled in by agents.tools/__init__, and
+    # farmer_cache imports back into agents.tools at module top — importing
+    # get_or_fetch_farmer_data here (not at module scope) breaks that cycle so
+    # farmer_cache can be imported cold (e.g. by the refresh worker at startup).
+    from agents.services.farmer_cache import get_or_fetch_farmer_data
+
     return await get_or_fetch_farmer_data(mobile)
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     # the read blocks on a bounded API call instead of serving it (falls back to
     # the stale record only if the API also fails). Backstop above the 12h/2h
     # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
-    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 48)))
+    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 24)))
     # Max chars of an upstream API response body recorded to Langfuse (to prove
     # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
     farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))

--- a/app/config.py
+++ b/app/config.py
@@ -66,8 +66,12 @@ class Settings(BaseSettings):
     # the stale record only if the API also fails). Backstop above the 12h/2h
     # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
     farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 24)))
-    # Max chars of an upstream API response body recorded to Langfuse (to prove
-    # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
+    # Farmer/animal API tracing records a PII-SAFE structure summary by default
+    # (status, record count, which keys are present/null) — enough to prove
+    # inconsistent returns without shipping farmer PII to Langfuse. Raw response
+    # bodies are only captured when FARMER_API_TRACE_BODY is explicitly enabled
+    # (temporary deep-debug), capped at FARMER_API_TRACE_BODY_CHARS.
+    farmer_api_trace_body: bool = _get_bool_env("FARMER_API_TRACE_BODY", default=False)
     farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))
 
     # Logging Configuration

--- a/app/config.py
+++ b/app/config.py
@@ -61,6 +61,14 @@ class Settings(BaseSettings):
     default_cache_ttl: int = 60 * 60 * 24  # 24 hours
     session_owner_ttl_seconds: int = int(os.getenv("SESSION_OWNER_TTL_SECONDS", "120"))
     session_owner_refresh_interval_seconds: int = int(os.getenv("SESSION_OWNER_REFRESH_INTERVAL_SECONDS", "15"))
+    # Farmer cache policy: beyond this age a cached record is too stale to serve —
+    # the read blocks on a bounded API call instead of serving it (falls back to
+    # the stale record only if the API also fails). Backstop above the 12h/2h
+    # soft-refresh; the 7d hard Redis TTL still deletes records entirely.
+    farmer_max_serve_stale_seconds: int = int(os.getenv("FARMER_MAX_SERVE_STALE_SECONDS", str(60 * 60 * 48)))
+    # Max chars of an upstream API response body recorded to Langfuse (to prove
+    # inconsistent returns). Responses are ~500 bytes; cap guards against blobs.
+    farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))
 
     # Logging Configuration
     log_level: str = "INFO"

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -16,7 +16,8 @@ from agents.voice import voice_agent, voice_agent_signed_in, STATIC_VOICE_SYSTEM
 from agents.tools.farmer import normalize_phone_to_mobile
 from agents.services.farmer_cache import (
     get_farmer_data_cached_only,
-    refresh_farmer_data,
+    refresh_farmer_data_bounded,
+    enqueue_farmer_refresh,
     should_refresh_farmer_data,
 )
 from app.models.union import UnionName
@@ -511,11 +512,20 @@ def _is_signed_in_session(user_info: Optional[dict], user_id: str) -> bool:
 
 
 async def get_or_fetch_farmer_data(mobile: str):
+    """Voice read policy (stale-while-revalidate).
+
+    Serve the cached envelope immediately when present (fresh or stale — the
+    caller enqueues a background refresh for stale records). On a cold/never-
+    cached (or hard-expired/deleted) miss, do a bounded blocking fetch so the
+    first turn has data, capped by FARMER_COLD_FETCH_TIMEOUT so a slow upstream
+    never hangs the call.
+
+    Still patchable by tests that stub this symbol.
     """
-    Backward-compatible alias for tests and callers that still patch the old symbol.
-    Voice request flow now uses Redis-only reads from this alias.
-    """
-    return await get_farmer_data_cached_only(mobile)
+    cached = await get_farmer_data_cached_only(mobile)
+    if cached is not None:
+        return cached
+    return await refresh_farmer_data_bounded(mobile)
 
 
 def _build_runtime_context_request(deps: FarmerContext) -> ModelRequest:
@@ -1421,7 +1431,7 @@ async def stream_voice_message(
                         len(ai_technician_info),
                     )
                     if mobile and should_refresh_farmer_data(envelope):
-                        asyncio.create_task(refresh_farmer_data(mobile))
+                        await enqueue_farmer_refresh(mobile)
                         logger.info(
                             "Farmer cache refresh scheduled in background for mobile %s stale=%s status=%s",
                             mobile,

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -19,6 +19,7 @@ from agents.services.farmer_cache import (
     refresh_farmer_data_bounded,
     enqueue_farmer_refresh,
     should_refresh_farmer_data,
+    exceeds_max_serve_stale,
 )
 from app.models.union import UnionName
 from app.services.scheme_ingestion import (
@@ -524,6 +525,12 @@ async def get_or_fetch_farmer_data(mobile: str):
     """
     cached = await get_farmer_data_cached_only(mobile)
     if cached is not None:
+        if exceeds_max_serve_stale(cached):
+            # Too stale to serve (e.g. background refresh has been failing):
+            # block on a bounded API call, falling back to the stale record
+            # only if the API also fails.
+            fresh = await refresh_farmer_data_bounded(mobile)
+            return fresh if fresh is not None else cached
         return cached
     return await refresh_farmer_data_bounded(mobile)
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -631,12 +631,28 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
         lines.append(f"- Society code: {society_code}")
     if first.farmerCode:
         lines.append(f"- Farmer code: {first.farmerCode}")
-    if first.totalAnimals is not None:
-        lines.append(f"- Total animals: {first.totalAnimals}")
+    # Herd counts: always surface what we have. The agent answers from this
+    # context (the brittle get_herd_summary / list_animal_tags / get_farmer_profile
+    # tools were dropped — they read the same cache and returned "not available"
+    # when the upstream record omitted totalAnimals even though tags were present).
+    first_data = first.model_dump()
+    total_animals = first.totalAnimals
+    if total_animals is None and tags:
+        total_animals = len(tags)  # fallback when upstream omits the count
+    if total_animals is not None:
+        lines.append(f"- Total animals: {total_animals}")
+    cow = first_data.get("cow") or first_data.get("Cow")
+    if cow is not None:
+        lines.append(f"- Cows: {cow}")
+    buffalo = first_data.get("buffalo") or first_data.get("Buffalo")
+    if buffalo is not None:
+        lines.append(f"- Buffaloes: {buffalo}")
+    milking = first_data.get("totalMilkingAnimals") or first_data.get("Milking Animal")
+    if milking is not None:
+        lines.append(f"- Milking animals: {milking}")
     if tags:
-        preview = ", ".join(tags[:8])
-        extra = f" (+{len(tags) - 8} more)" if len(tags) > 8 else ""
-        lines.append(f"- Known animal tags: {preview}{extra}")
+        # All tags inline — no truncation, since the list-tags tool was dropped.
+        lines.append(f"- Known animal tags: {', '.join(tags)}")
     if len(envelope.farmers) > 1:
         lines.append("- Multiple farmer records are registered on this mobile number.")
         lines.append("- For AI booking, first ask which farmer name the caller wants to use.")

--- a/app/tasks/farmer_refresh_worker.py
+++ b/app/tasks/farmer_refresh_worker.py
@@ -1,0 +1,62 @@
+"""Background worker that drains the farmer-data refresh queue.
+
+Stale-while-revalidate: the voice request path serves cached farmer data
+immediately and enqueues stale phones (see agents.services.farmer_cache.
+enqueue_farmer_refresh). This worker drains that Redis-backed queue off the
+request path and refreshes each record, so slow/unreliable upstream PashuGPT
+APIs never block a call. refresh_farmer_data self-dedupes via its NX lock, so
+running one worker per pod is safe.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from agents.services.farmer_cache import drain_farmer_refresh_queue_once
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Seconds to wait before re-polling when the queue is empty.
+IDLE_SLEEP_SECONDS = 5.0
+# Phones to refresh per drain iteration.
+DRAIN_BATCH = 20
+
+_worker_task: Optional[asyncio.Task] = None
+
+
+async def _run_loop() -> None:
+    logger.info("Farmer refresh worker started")
+    while True:
+        try:
+            processed = await drain_farmer_refresh_queue_once(batch=DRAIN_BATCH)
+            if processed == 0:
+                await asyncio.sleep(IDLE_SLEEP_SECONDS)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Farmer refresh worker iteration failed")
+            await asyncio.sleep(IDLE_SLEEP_SECONDS)
+
+
+async def start_farmer_refresh_worker() -> None:
+    global _worker_task
+    if _worker_task is not None and not _worker_task.done():
+        return
+    _worker_task = asyncio.create_task(_run_loop())
+
+
+async def stop_farmer_refresh_worker() -> None:
+    global _worker_task
+    if _worker_task is None:
+        return
+    _worker_task.cancel()
+    try:
+        await _worker_task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("Farmer refresh worker failed during shutdown")
+    finally:
+        _worker_task = None
+        logger.info("Farmer refresh worker stopped")

--- a/app/tasks/farmer_refresh_worker.py
+++ b/app/tasks/farmer_refresh_worker.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 from typing import Optional
 
-from agents.services.farmer_cache import drain_farmer_refresh_queue_once
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -26,6 +25,11 @@ _worker_task: Optional[asyncio.Task] = None
 
 
 async def _run_loop() -> None:
+    # Imported here (not at module scope) so importing this worker module is
+    # side-effect-free and never triggers the farmer_cache <-> tools import
+    # cycle at app startup (main.py imports the worker before the routers).
+    from agents.services.farmer_cache import drain_farmer_refresh_queue_once
+
     logger.info("Farmer refresh worker started")
     while True:
         try:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from contextlib import asynccontextmanager
 from app.tasks.scheme_scheduler import start_scheme_scheduler, stop_scheme_scheduler
+from app.tasks.farmer_refresh_worker import start_farmer_refresh_worker, stop_farmer_refresh_worker
 
 load_dotenv()
 
@@ -25,8 +26,10 @@ async def lifespan(app: FastAPI):
     from helpers.utils import load_prompt_templates
     load_prompt_templates(settings.base_dir / "assets" / "prompts")
     await start_scheme_scheduler()
+    await start_farmer_refresh_worker()
     yield
     # Shutdown
+    await stop_farmer_refresh_worker()
     await stop_scheme_scheduler()
     print(f"🛑 {settings.app_name} shutting down...")
 

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -44,6 +44,9 @@ class _Env:
         self.lookupStatus = lookup_status
         self.fetchedAt = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).isoformat()
 
+    def model_dump(self):
+        return {"lookupStatus": self.lookupStatus, "fetchedAt": self.fetchedAt}
+
 
 def test_freshness_intervals_found_vs_not_found():
     # found: soft expiry at 12h
@@ -208,6 +211,110 @@ def test_bounded_timeout_releases_lock_on_cancel():
         result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
     assert result is None
     fake_redis.delete.assert_awaited()  # lock released on cancellation
+
+
+def test_lock_busy_never_clears_reenqueues_not_stale():
+    """Residual #3/#4 fix: if the in-flight holder outlives the wait, return None
+    and RE-ENQUEUE — do not serve the stale record or silently drop the phone."""
+    old = _Env("found", 1000)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)   # lock busy
+    fake_redis.exists = AsyncMock(return_value=1)   # never clears within the wait
+    enqueue = AsyncMock()
+    with patch.object(fc, "FARMER_COLD_FETCH_TIMEOUT", 0.3), \
+         patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=old)), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is None                       # NOT the ancient cached record
+    enqueue.assert_awaited_once_with("111")     # re-queued, not dropped
+
+
+def test_lock_busy_held_then_released_returns_fresh():
+    """If the holder finishes within the (now cold-fetch-sized) wait, return its
+    fresh result and do not re-enqueue."""
+    fresh = _Env("found", 0)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)               # lock busy
+    fake_redis.exists = AsyncMock(side_effect=[1, 0])           # held, then released
+    enqueue = AsyncMock()
+    with patch.object(fc, "FARMER_COLD_FETCH_TIMEOUT", 2.0), \
+         patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=fresh)), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is fresh
+    enqueue.assert_not_called()
+
+
+def test_restamp_kept_record_preserves_ttl():
+    """Don't-downgrade past the ceiling restamps fetchedAt (to stop a per-turn
+    block) but PRESERVES the remaining 7d TTL."""
+    existing = _Env("found", 1000)  # >24h
+    orig_fetched = existing.fetchedAt
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)       # lock acquired
+    fake_redis.delete = AsyncMock()
+    fake_redis.ttl = AsyncMock(return_value=100000)     # remaining hard TTL
+    fake_cache = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "cache", fake_cache), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)):
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    assert existing.fetchedAt != orig_fetched           # restamped
+    fake_cache.set.assert_awaited()
+    assert fake_cache.set.call_args.kwargs.get("ttl") == 100000  # 7d TTL preserved, not reset
+
+
+def test_trace_recorded_before_raise_for_status_on_failure():
+    """A failing (5xx) booking response must still be traced — _record_api_trace
+    runs BEFORE response.raise_for_status()."""
+    import contextlib
+    from agents.tools import farmer_animal_backends as backends
+    from agents.models.ai_call import AICallRequestModel, AISpecies
+
+    captured = {}
+
+    class _Obs:
+        def update(self, output=None, metadata=None):
+            captured["output"] = output
+
+    @contextlib.contextmanager
+    def _fake_obs(*a, **k):
+        yield _Obs()
+
+    class _Resp:
+        status_code = 500
+        text = '{"error": "boom"}'
+
+        def raise_for_status(self):
+            raise Exception("HTTP 500")
+
+        def json(self):
+            return {}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            return _Resp()
+
+    req = AICallRequestModel(
+        unionCode="2021", societyCode="NA4310", farmerCode="NA0002",
+        userId="u1", species=AISpecies.COW,
+    )
+    with patch.object(backends, "start_observation", _fake_obs), \
+         patch.object(backends.httpx, "AsyncClient", lambda *a, **k: _Client()):
+        result = asyncio.run(backends.create_ai_call_api(req, "tok"))
+    assert result is None                                    # raised -> None
+    assert captured["output"]["status_code"] == 500          # but the 500 WAS traced
+    assert captured["output"]["ok"] is False
 
 
 def _capture_trace(backends, resp, reason="cold_fetch"):

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -5,13 +5,36 @@ Self-contained: uses asyncio.run + mocks, so it needs neither a live Redis nor
 pytest-asyncio.
 """
 import asyncio
+import os
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
-# Import the app entry first so the pre-existing tools<->farmer_cache import
-# cycle resolves in the same order the running app establishes it.
 import app.services.voice as voice
 import agents.services.farmer_cache as fc
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_cold_import_has_no_circular_import():
+    """Regression: `uvicorn main:app` imports the refresh worker before the
+    routers, so farmer_cache must be importable COLD (first touch) without
+    hitting the farmer_cache <-> agents.tools cycle. Run in a subprocess to get
+    a truly fresh interpreter, mirroring the app's startup import order."""
+    code = (
+        "import app.tasks.farmer_refresh_worker;"
+        "import agents.services.farmer_cache;"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"cold import failed:\n{result.stderr}"
+    assert "OK" in result.stdout
 
 
 class _Env:

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -115,12 +115,93 @@ def test_bounded_fetch_times_out_and_enqueues():
 
 
 def test_voice_read_returns_cached_without_blocking():
-    cached = object()
+    cached = _Env("found", 1)  # fresh, within max-serve-stale
     with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=cached)), \
          patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock()) as bounded:
         result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
     assert result is cached
     bounded.assert_not_called()
+
+
+def test_voice_read_blocks_when_too_stale():
+    stale = _Env("found", 1000)   # well beyond the 48h max-serve-stale
+    fresh = _Env("found", 0)
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fresh)) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is fresh
+    bounded.assert_awaited_once_with("111")
+
+
+def test_voice_read_too_stale_falls_back_to_stale_on_api_failure():
+    stale = _Env("found", 1000)
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=None)):
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is stale  # API also failed -> serve stale rather than nothing
+
+
+def test_exceeds_max_serve_stale():
+    assert fc.exceeds_max_serve_stale(_Env("found", 1)) is False
+    assert fc.exceeds_max_serve_stale(_Env("found", 1000)) is True
+    assert fc.exceeds_max_serve_stale(None) is True
+
+
+def test_refresh_keeps_found_on_transient_not_found():
+    """A transient empty upstream response must not wipe a still-fresh 'found' record."""
+    existing = _Env("found", 1)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)   # lock acquired
+    fake_redis.delete = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)), \
+         patch.object(fc, "set_cached_farmer_data", new=AsyncMock()) as set_cache:
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    set_cache.assert_not_called()  # did NOT downgrade to not_found
+
+
+def test_record_api_trace_captures_body_status_and_reason():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"totalAnimals": 5}'
+
+    captured = {}
+
+    class _Obs:
+        def update(self, output=None, metadata=None):
+            captured["output"] = output
+            captured["metadata"] = metadata
+
+    with backends.fetch_reason("cold_fetch"):
+        backends._record_api_trace(_Obs(), _Resp(), provider="amulpashudhan", url="http://x")
+    assert captured["output"]["status_code"] == 200
+    assert captured["output"]["ok"] is True
+    assert captured["output"]["body"] == '{"totalAnimals": 5}'
+    assert captured["output"]["fetch_reason"] == "cold_fetch"
+    assert captured["metadata"] == {"provider": "amulpashudhan", "url": "http://x"}
+
+
+def test_record_api_trace_none_observation_is_noop():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 500
+        text = "boom"
+
+    backends._record_api_trace(None, _Resp(), provider="x", url="y")  # must not raise
+
+
+def test_fetch_reason_contextvar_default_and_scope():
+    from agents.tools import farmer_animal_backends as backends
+
+    assert backends.current_fetch_reason() == "request"
+    with backends.fetch_reason("background_refresh"):
+        assert backends.current_fetch_reason() == "background_refresh"
+    assert backends.current_fetch_reason() == "request"
 
 
 def test_voice_read_cold_miss_does_bounded_fetch():

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -124,7 +124,7 @@ def test_voice_read_returns_cached_without_blocking():
 
 
 def test_voice_read_blocks_when_too_stale():
-    stale = _Env("found", 1000)   # well beyond the 48h max-serve-stale
+    stale = _Env("found", 1000)   # well beyond the 24h max-serve-stale
     fresh = _Env("found", 0)
     with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=stale)), \
          patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fresh)) as bounded:
@@ -162,13 +162,55 @@ def test_refresh_keeps_found_on_transient_not_found():
     set_cache.assert_not_called()  # did NOT downgrade to not_found
 
 
-def test_record_api_trace_captures_body_status_and_reason():
-    from agents.tools import farmer_animal_backends as backends
+def test_refresh_keeps_old_found_past_ceiling_on_transient_not_found():
+    """Even past max-serve-stale, a transient empty must not overwrite a 'found'
+    record (genuine removal is left to the 7d hard TTL)."""
+    existing = _Env("found", 1000)  # well past the 24h ceiling
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=AsyncMock(return_value=[])), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=existing)), \
+         patch.object(fc, "set_cached_farmer_data", new=AsyncMock()) as set_cache:
+        result = asyncio.run(fc.refresh_farmer_data("9999999999"))
+    assert result is existing
+    set_cache.assert_not_called()
 
-    class _Resp:
-        status_code = 200
-        text = '{"totalAnimals": 5}'
 
+def test_refresh_lock_busy_awaits_inflight_value():
+    """A refresh that loses the NX-lock race returns the in-flight result, not
+    None (None would defeat max-serve-stale and drop queued refreshes)."""
+    sentinel = _Env("found", 0)
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)   # lock busy
+    fake_redis.exists = AsyncMock(return_value=0)   # in-flight refresh already finished
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "get_cached_farmer_data", new=AsyncMock(return_value=sentinel)):
+        result = asyncio.run(fc.refresh_farmer_data("111"))
+    assert result is sentinel
+
+
+def test_bounded_timeout_releases_lock_on_cancel():
+    """The design's key claim: when the bounded fetch times out and cancels the
+    in-flight refresh, the NX lock is released in refresh_farmer_data's finally."""
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)   # lock acquired
+    fake_redis.delete = AsyncMock()
+
+    async def _slow(_phone):
+        await asyncio.sleep(5)
+        return []
+
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "fetch_farmer_info_raw", new=_slow), \
+         patch.object(fc, "enqueue_farmer_refresh", new=AsyncMock()):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
+    assert result is None
+    fake_redis.delete.assert_awaited()  # lock released on cancellation
+
+
+def _capture_trace(backends, resp, reason="cold_fetch"):
     captured = {}
 
     class _Obs:
@@ -176,13 +218,69 @@ def test_record_api_trace_captures_body_status_and_reason():
             captured["output"] = output
             captured["metadata"] = metadata
 
-    with backends.fetch_reason("cold_fetch"):
-        backends._record_api_trace(_Obs(), _Resp(), provider="amulpashudhan", url="http://x")
-    assert captured["output"]["status_code"] == 200
-    assert captured["output"]["ok"] is True
-    assert captured["output"]["body"] == '{"totalAnimals": 5}'
-    assert captured["output"]["fetch_reason"] == "cold_fetch"
-    assert captured["metadata"] == {"provider": "amulpashudhan", "url": "http://x"}
+    with backends.fetch_reason(reason):
+        backends._record_api_trace(_Obs(), resp, provider="amulpashudhan", url="http://x")
+    return captured
+
+
+def test_record_api_trace_is_pii_safe_by_default():
+    """By default NO raw body is shipped — only status + structure (keys/null_keys
+    + record count), which still proves an inconsistent return."""
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"farmerName": "Ramesh", "totalAnimals": null, "tagNo": "1,2"}'
+
+    out = _capture_trace(backends, _Resp())["output"]
+    assert out["status_code"] == 200
+    assert out["ok"] is True
+    assert out["fetch_reason"] == "cold_fetch"
+    assert out["records"] == 1
+    assert out["keys"] == ["farmerName", "tagNo", "totalAnimals"]
+    assert out["null_keys"] == ["totalAnimals"]          # proves the Turn-A shape
+    assert "body" not in out                              # no PII value leaks
+    assert "Ramesh" not in str(out)
+
+
+def test_record_api_trace_ok_is_2xx():
+    from agents.tools import farmer_animal_backends as backends
+
+    class _R204:
+        status_code = 204
+        text = ""
+
+    class _R500:
+        status_code = 500
+        text = "err"
+
+    assert _capture_trace(backends, _R204())["output"]["ok"] is True   # 204 is ok
+    assert _capture_trace(backends, _R500())["output"]["ok"] is False
+
+
+def test_record_api_trace_body_only_when_flag_enabled(monkeypatch):
+    from agents.tools import farmer_animal_backends as backends
+
+    class _Resp:
+        status_code = 200
+        text = '{"totalAnimals": 5}'
+
+    monkeypatch.setattr(backends.settings, "farmer_api_trace_body", True)
+    out = _capture_trace(backends, _Resp())["output"]
+    assert out["body"] == '{"totalAnimals": 5}'
+
+
+def test_safe_response_summary_shapes():
+    from agents.tools.farmer_animal_backends import _safe_response_summary
+
+    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1"}]')
+    assert full["records"] == 1 and "totalAnimals" in full["keys"] and full["null_keys"] == []
+    missing = _safe_response_summary('[{"tagNo": "1"}]')   # totalAnimals absent
+    assert "totalAnimals" not in missing["keys"]
+    empty = _safe_response_summary("[]")
+    assert empty["records"] == 0
+    notjson = _safe_response_summary("<html>err</html>")
+    assert notjson["json"] is False
 
 
 def test_record_api_trace_none_observation_is_noop():

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -1,0 +1,109 @@
+"""Unit tests for the stale-while-revalidate farmer cache: freshness intervals,
+the Redis refresh queue, the bounded cold fetch, and the voice read policy.
+
+Self-contained: uses asyncio.run + mocks, so it needs neither a live Redis nor
+pytest-asyncio.
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+# Import the app entry first so the pre-existing tools<->farmer_cache import
+# cycle resolves in the same order the running app establishes it.
+import app.services.voice as voice
+import agents.services.farmer_cache as fc
+
+
+class _Env:
+    """Duck-typed stand-in for FarmerDataEnvelope (only fields _compute_freshness reads)."""
+
+    def __init__(self, lookup_status, age_hours):
+        self.lookupStatus = lookup_status
+        self.fetchedAt = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).isoformat()
+
+
+def test_freshness_intervals_found_vs_not_found():
+    # found: soft expiry at 12h
+    assert fc._compute_freshness(_Env("found", 6))[0] is False
+    assert fc._compute_freshness(_Env("found", 13))[0] is True
+    # not_found: shorter soft expiry at 2h
+    assert fc._compute_freshness(_Env("not_found", 1))[0] is False
+    assert fc._compute_freshness(_Env("not_found", 3))[0] is True
+
+
+def test_interval_constants():
+    assert fc.FARMER_REFRESH_INTERVAL == 60 * 60 * 12
+    assert fc.FARMER_NEGATIVE_REFRESH_INTERVAL == 60 * 60 * 2
+    assert fc.FARMER_CACHE_TTL == 60 * 60 * 24 * 7
+
+
+def test_enqueue_pushes_phone_to_redis_set():
+    fake_redis = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis):
+        asyncio.run(fc.enqueue_farmer_refresh("9999999999"))
+    fake_redis.sadd.assert_awaited_once_with(fc.FARMER_REFRESH_QUEUE_KEY, "9999999999")
+
+
+def test_enqueue_ignores_empty_phone():
+    fake_redis = AsyncMock()
+    with patch.object(fc, "redis_client", fake_redis):
+        asyncio.run(fc.enqueue_farmer_refresh(""))
+    fake_redis.sadd.assert_not_called()
+
+
+def test_drain_pops_batch_and_refreshes_each():
+    fake_redis = AsyncMock()
+    fake_redis.spop.return_value = ["111", "222", "333"]
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "refresh_farmer_data", new=AsyncMock()) as refresh:
+        processed = asyncio.run(fc.drain_farmer_refresh_queue_once(batch=10))
+    assert processed == 3
+    fake_redis.spop.assert_awaited_once_with(fc.FARMER_REFRESH_QUEUE_KEY, 10)
+    assert refresh.await_count == 3
+
+
+def test_drain_empty_queue_returns_zero():
+    fake_redis = AsyncMock()
+    fake_redis.spop.return_value = None
+    with patch.object(fc, "redis_client", fake_redis), \
+         patch.object(fc, "refresh_farmer_data", new=AsyncMock()) as refresh:
+        processed = asyncio.run(fc.drain_farmer_refresh_queue_once())
+    assert processed == 0
+    refresh.assert_not_called()
+
+
+def test_bounded_fetch_returns_envelope_on_success():
+    sentinel = object()
+    with patch.object(fc, "refresh_farmer_data", new=AsyncMock(return_value=sentinel)):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=1.0))
+    assert result is sentinel
+
+
+def test_bounded_fetch_times_out_and_enqueues():
+    async def _slow(_phone):
+        await asyncio.sleep(5)
+
+    enqueue = AsyncMock()
+    with patch.object(fc, "refresh_farmer_data", new=_slow), \
+         patch.object(fc, "enqueue_farmer_refresh", new=enqueue):
+        result = asyncio.run(fc.refresh_farmer_data_bounded("111", timeout=0.05))
+    assert result is None
+    enqueue.assert_awaited_once_with("111")
+
+
+def test_voice_read_returns_cached_without_blocking():
+    cached = object()
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=cached)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock()) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is cached
+    bounded.assert_not_called()
+
+
+def test_voice_read_cold_miss_does_bounded_fetch():
+    fetched = object()
+    with patch.object(voice, "get_farmer_data_cached_only", new=AsyncMock(return_value=None)), \
+         patch.object(voice, "refresh_farmer_data_bounded", new=AsyncMock(return_value=fetched)) as bounded:
+        result = asyncio.run(voice.get_or_fetch_farmer_data("111"))
+    assert result is fetched
+    bounded.assert_awaited_once_with("111")

--- a/tests/test_farmer_cache_swr.py
+++ b/tests/test_farmer_cache_swr.py
@@ -273,14 +273,23 @@ def test_record_api_trace_body_only_when_flag_enabled(monkeypatch):
 def test_safe_response_summary_shapes():
     from agents.tools.farmer_animal_backends import _safe_response_summary
 
-    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1"}]')
+    full = _safe_response_summary('[{"totalAnimals": 5, "tagNo": "1", "visits": [1, 2, 3]}]')
     assert full["records"] == 1 and "totalAnimals" in full["keys"] and full["null_keys"] == []
+    assert full["array_lens"] == {"visits": 3}          # array metric, no values
     missing = _safe_response_summary('[{"tagNo": "1"}]')   # totalAnimals absent
     assert "totalAnimals" not in missing["keys"]
     empty = _safe_response_summary("[]")
     assert empty["records"] == 0
     notjson = _safe_response_summary("<html>err</html>")
     assert notjson["json"] is False
+
+
+def test_safe_response_summary_flags_empty_arrays_and_strings():
+    from agents.tools.farmer_animal_backends import _safe_response_summary
+
+    out = _safe_response_summary('[{"animals": [], "society": "", "tagNo": "1"}]')
+    assert out["array_lens"] == {"animals": 0}     # empty array surfaced
+    assert out["empty_str_keys"] == ["society"]    # empty string surfaced
 
 
 def test_record_api_trace_none_observation_is_noop():

--- a/tests/test_voice_farmer_context.py
+++ b/tests/test_voice_farmer_context.py
@@ -1,0 +1,73 @@
+"""Unit tests for the voice runtime context (compact farmer summary).
+
+Covers Fix-1: counts always surface (with len(tags) fallback), cow/buffalo/milking
+always surface, all tags inline — so the voice agent answers herd questions from
+context without needing the dropped get_herd_summary / list_animal_tags /
+get_farmer_profile tools.
+"""
+# Import the app entry first so the pre-existing tools<->farmer_cache cycle
+# resolves in the same order the running app establishes it.
+import app.services.voice as voice
+
+from agents.models.farmer import FarmerDataEnvelope
+from helpers.gujarati_numbers import mask_tag_identifier
+
+
+def _envelope(record: dict) -> FarmerDataEnvelope:
+    return FarmerDataEnvelope.from_records([record], source="api", lookup_status="found")
+
+
+def test_summary_falls_back_to_tag_count_when_totalanimals_null():
+    """Turn-A fix: a record missing totalAnimals (the incident shape) still
+    answers 'you have N animals' by deriving N from the tag list."""
+    record = {"farmerName": "X", "tagNo": "100000000001,100000000002,100000000003"}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "- Total animals: 3" in summary
+
+
+def test_summary_includes_cow_buffalo_milking():
+    record = {
+        "farmerName": "X",
+        "totalAnimals": 5,
+        "cow": 3,
+        "buffalo": 2,
+        "totalMilkingAnimals": 4,
+        "tagNo": "100000000001,100000000002,100000000003,100000000004,100000000005",
+    }
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "- Total animals: 5" in summary
+    assert "- Cows: 3" in summary
+    assert "- Buffaloes: 2" in summary
+    assert "- Milking animals: 4" in summary
+
+
+def test_summary_shows_all_tags_no_truncation():
+    """list_animal_tags tool dropped — context must list all tags inline."""
+    tags_csv = ",".join(f"10000000{i:04d}" for i in range(12))  # 12 tags
+    record = {"farmerName": "X", "totalAnimals": 12, "tagNo": tags_csv}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "more)" not in summary  # no truncation marker
+    # All 12 masked tag strings appear (distinct last-4-digit verbalizations)
+    masked_count = sum(
+        1 for i in range(12)
+        if mask_tag_identifier(f"10000000{i:04d}") in summary
+    )
+    assert masked_count == 12
+
+
+def test_summary_handles_record_with_no_count_and_no_tags():
+    """Edge case: a record with neither totalAnimals nor tags omits the line
+    rather than asserting a zero count we can't substantiate."""
+    record = {"farmerName": "X", "societyName": "S"}
+    summary = voice._build_compact_farmer_summary(_envelope(record))
+    assert "Total animals" not in summary
+
+
+def test_signed_in_farmer_tools_drops_brittle_three():
+    """The three brittle voice-only farmer tools are commented out; only the
+    union-scheme tool remains in SIGNED_IN_FARMER_TOOLS."""
+    from agents.tools import SIGNED_IN_FARMER_TOOLS
+
+    assert len(SIGNED_IN_FARMER_TOOLS) == 1, (
+        f"expected only get_union_scheme_data; got {len(SIGNED_IN_FARMER_TOOLS)} tools"
+    )


### PR DESCRIPTION
Promotes #143 + #147 + #148 (cumulative) from \`amul-dev\` to \`amul-prod\`. **All three are already merged on \`amul-dev\` and live in dev (VM5 \`amul_voice_app\`).** Merging this triggers the prod kaniko build + \`kubectl set image\` rollout.

## What's bundled

### 1. Cache SWR (#143)
- Voice farmer-data read path is **cache-only**; slow PashuGPT APIs are off the request path.
- Background refresh worker drains a Redis set (\`farmer:refresh:queue\`) — survives request lifecycle, dedups via the existing NX lock.
- Cold/never-cached miss does a bounded blocking fetch (4s cap, observed cold ~3.1s) so first-turn has data.
- Soft refresh **12h** for \`found\`, **2h** for \`not_found\`; **7d** hard Redis TTL unchanged.
- Boot blocker fix: lazy-imported \`get_or_fetch_farmer_data\` inside \`farmer_cached._get_envelope\` and \`drain_…\` inside the worker run loop — broke the pre-existing \`farmer_cache ⇄ agents.tools\` import cycle that would otherwise crash \`uvicorn main:app\`. Subprocess cold-import regression test added.

### 2. API observability + cache policy (#147)
- **PII-safe trace summary** on all 8 amulpashudhan/herdman API observations: \`status_code\`, \`ok\` (2xx), \`fetch_reason\` (\`request\` / \`cold_fetch\` / \`background_refresh\`), record count, present/null keys, list-field lengths, empty-string keys — *no values*. Raw bodies only behind \`FARMER_API_TRACE_BODY=true\` (default off). \`_record_api_trace\` runs **before** \`raise_for_status()\` on booking/technician/milk endpoints so 4xx/5xx bodies are captured. This is the instrument to finally prove the intermittent partial-payload upstream behavior.
- Background-worker refreshes get a \`farmer_background_refresh\` root span so their API calls are queryable per phone.
- **Max-serve-stale** ceiling \`FARMER_MAX_SERVE_STALE_SECONDS=24h\`: read blocks on a bounded API call when the record is too old, falling back to the stale record only if the API also fails.
- **Don't-downgrade**: a transient empty upstream never overwrites a \`found\` record (genuine removal left to the 7d TTL). When the kept record is already past 24h, fetchedAt is restamped while the 7d TTL is preserved (avoids per-turn block).
- Lock-contention fix: \`_await_inflight_refresh\` returns \`(env, cleared)\` bounded by the cold-fetch timeout (no internal 2s cap); on lock-busy-not-cleared, \`refresh_farmer_data\` re-enqueues and returns None, so max-serve-stale never serves the ancient record and the worker never drops the queued phone.

### 3. Voice tool defs aligned with chat (#148) — closes Fix-1
The chat-vs-voice "I don't have your herd info" gap. Both backends read the same farmer cache, but voice routed herd questions through \`get_herd_summary\` (brittle: returned "not available" on a partial payload) while chat reads from prompt context.

- \`_build_compact_farmer_summary\` now always surfaces what we have:
  - \`Total animals\` falls back to \`len(tags)\` when upstream omits it (the Turn-A shape).
  - \`Cows\` / \`Buffaloes\` / \`Milking animals\` emitted from the extra="allow" record fields.
  - All tags listed inline (was capped at 8 + "(+N more)").
- \`SIGNED_IN_FARMER_TOOLS\`: \`get_farmer_profile\`, \`get_herd_summary\`, \`list_animal_tags\` **commented out** (chat-style). Only \`get_union_scheme_data\` remains. Voice agent now answers herd/profile/tag questions from prompt context — exactly chat's access path.

## Verification on dev (VM5)
- Local test suite: **34/34 green**.
- VM5 \`amul_voice_app\` running \`adf3855\` (#148 merge), pydantic-ai 1.102 installed inside the container.
- Live inside the running container for the real complaint caller \`8128715393\`:
  - \`SIGNED_IN_FARMER_TOOLS = ['get_union_scheme_data']\`
  - Compact summary shows \`Total animals: 5\`, \`Cows: 5\`, \`Milking animals: 2\`, all 5 tags inline.
  - Worker queue+drain plumbing exercised end-to-end (enqueue + drain = 1 processed).

## Operational notes
- Numbers ("Twenty Two → Two Two") = **wontfix** per Kanav.
- Open follow-ups (not blocking prod promotion): the provider-interface PR (per-field keep-best merge + union-gated backend selection); the booking PR (live \`get_available_technicians\`).
- Reviewer-flagged nit on #143 (prefetch task cancel on aborted turns, LOW) still deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)