### PR TITLE
Remove pretranslation completeness/confidence rating

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -617,11 +617,11 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
         "- Your job is faithful pretranslation for safe routing, not correction, completion, or advice.\n"
         "- Preserve uncertainty from the original speech. Do not repair missing words, fill missing slots, or choose a clean interpretation when the audio transcript is ambiguous.\n"
         "- Words that look like human names (e.g. સલાદ, સરલા, ગંગા) are almost always ANIMAL NAMES (cow/buffalo names). Transliterate them as-is, do NOT translate literally.\n"
-        "- If a garbled token does not clearly map to a real medicine, feed, symptom, or service term, do NOT invent a meaning. Keep the translation conservative and set confidence to low.\n"
+        "- If a garbled token does not clearly map to a real medicine, feed, symptom, or service term, do NOT invent a meaning. Keep the translation conservative.\n"
         "- Kinship words like બેન, બહેન, ભાઈ are often address markers for Sarlaben or filler in phone speech. Do not turn them into the caller's gender. Use 'Sarlaben' only if the caller is clearly addressing the assistant; otherwise omit the address marker.\n"
-        "- 'ભાઈ' in livestock context may refer to a male animal (bull/ox), but mark confidence low if the word could also be an address marker.\n"
-        "- Prefer veterinary/agricultural meanings only when the term is clear in the original transcript. If choosing the agricultural meaning requires guessing, preserve the uncertain token and set confidence low.\n"
-        "- Do not infer animal species. If cow/buffalo/sheep/goat is unclear, write 'unclear animal' or keep the uncertain token, and set confidence low.\n"
+        "- 'ભાઈ' in livestock context may refer to a male animal (bull/ox); keep it generic if the word could also be an address marker.\n"
+        "- Prefer veterinary/agricultural meanings only when the term is clear in the original transcript. If choosing the agricultural meaning requires guessing, preserve the uncertain token.\n"
+        "- Do not infer animal species. If cow/buffalo/sheep/goat is unclear, write 'unclear animal' or keep the uncertain token.\n"
     )
 
     # -- Ambiguity hints from ambiguity_terms.json ---------------------
@@ -646,11 +646,9 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
     system_content = (
         f"{domain_preamble}\n"
         "Translate the user's message to faithful spoken English for an internal agent. "
-        "Respond with JSON: {\"translation\": \"...\", \"confidence\": \"high\" or \"low\"}.\n\n"
+        "Respond with JSON: {\"translation\": \"...\"}.\n\n"
         "Do not preserve markdown, bullets, bracketed duplicates, or other formatting clutter, but do preserve the meaning uncertainty.\n"
-        "Set confidence to \"high\" only when the core request is clear without guessing: animal or subject, problem or topic, and desired action are identifiable from the transcript.\n"
-        "Set confidence to \"low\" when the input is garbled noise, random syllables, fragmentary, contradictory, or when any key noun, animal species, medicine, feed, product, disease, symptom, or requested action is uncertain.\n"
-        "If confidence is low, still provide the most faithful translation possible, using markers such as 'unclear animal', 'unclear feed name', 'unclear symptom', or '[unclear token]' instead of inventing missing meaning.\n"
+        "When the input is garbled noise, random syllables, fragmentary, contradictory, or when any key noun, animal species, medicine, feed, product, disease, symptom, or requested action is uncertain, still provide the most faithful translation possible, using markers such as 'unclear animal', 'unclear feed name', 'unclear symptom', or '[unclear token]' instead of inventing missing meaning.\n"
         "Never convert a doubtful token into a specific medicine, feed, disease, animal species, or service term just because it would make a plausible livestock question."
     )
 
@@ -661,14 +659,14 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
 
 
 def _build_structured_pretranslation_prompt(source_name: str, source_code: str, text: str) -> str:
-    """Build the structured translation+confidence prompt for non-OpenAI fallback models."""
+    """Build the structured translation prompt for non-OpenAI fallback models."""
     messages = _build_openai_pretranslation_messages(source_name, source_code, text)
     system_content = messages[0]["content"]
     user_content = messages[1]["content"]
     return (
         "<bos><start_of_turn>user\n"
         f"{system_content}\n\nUser message:\n{user_content}\n\n"
-        'Respond only with valid JSON: {"translation": "...", "confidence": "high" or "low"}.'
+        'Respond only with valid JSON: {"translation": "..."}.'
         "<end_of_turn>\n"
         "<start_of_turn>model\n"
     )
@@ -727,27 +725,22 @@ def _raise_empty_pretranslation(
     raise ValueError("GPT pretranslation returned empty output")
 
 
-def _extract_translation_from_response(response) -> tuple[str, str]:
-    """Extract translation text and confidence from OpenAI JSON response.
-
-    Returns (translation, confidence) where confidence is "high", "low", or "unknown".
-    """
+def _extract_translation_from_response(response) -> str:
+    """Extract the translation string from an OpenAI JSON response."""
     raw = (response.choices[0].message.content or "").strip()
     return _extract_translation_from_raw(raw)
 
 
-def _extract_translation_from_raw(raw: str) -> tuple[str, str]:
-    """Extract translation text and confidence from raw model output."""
+def _extract_translation_from_raw(raw: str) -> str:
+    """Extract the translation string from raw model output."""
     if not raw:
-        return "", "unknown"
+        return ""
     try:
         data = json.loads(raw)
-        translation = (data.get("translation") or "").strip()
-        confidence = (data.get("confidence") or "unknown").strip().lower()
-        return translation, confidence
+        return (data.get("translation") or "").strip()
     except (json.JSONDecodeError, AttributeError):
         # Fallback: use raw content if JSON parsing fails
-        return raw, "unknown"
+        return raw
 
 
 async def translate_to_english_with_structured_fallback(
@@ -755,13 +748,16 @@ async def translate_to_english_with_structured_fallback(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
-    """Fallback pretranslation with the same structured contract as the OpenAI path."""
+) -> str:
+    """Fallback pretranslation with the same structured contract as the OpenAI path.
+
+    Returns the translated text, or an empty string on empty/failed output.
+    """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
     source_code = LANG_CODES.get(source_lang.lower(), source_lang.lower())
@@ -788,17 +784,17 @@ async def translate_to_english_with_structured_fallback(
 
             result = await response.json()
             raw_text = result["choices"][0]["text"].strip()
-            translated_text, confidence = _extract_translation_from_raw(raw_text)
+            translated_text = _extract_translation_from_raw(raw_text)
             translated_text = normalize_voice_output(translated_text, "english")
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             if not translated_text:
                 logger.warning(
-                    "Structured fallback pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "Structured fallback pretranslation returned empty - source_lang=%s query=%r",
                     source_lang,
                     (text or "")[:100],
                 )
-                return text, "low"
-            return translated_text, confidence
+                return text
+            return translated_text
 
 
 async def translate_to_english_with_gpt5_mini(
@@ -806,16 +802,16 @@ async def translate_to_english_with_gpt5_mini(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
+) -> str:
     """Translate input text to English using OpenAI for pipeline pre-translation.
 
-    Returns (translated_text, confidence) where confidence is "high", "low", or "unknown".
+    Returns the translated text, or an empty string on empty/failed output.
     """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     client = _get_openai_client()
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
@@ -832,15 +828,15 @@ async def translate_to_english_with_gpt5_mini(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OpenAI pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OpenAI pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                return text, "low"
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
-            return translated_text, confidence
+            return translated_text
 
         with langfuse.start_as_current_observation(
             name="query_pretranslation",
@@ -863,17 +859,17 @@ async def translate_to_english_with_gpt5_mini(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OpenAI pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OpenAI pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                observation.update(output="__EMPTY__", metadata={"confidence": "low"})
-                return text, "low"
+                observation.update(output="__EMPTY__")
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             observation.update(output=translated_text)
-            return translated_text, confidence
+            return translated_text
     except asyncio.TimeoutError as e:
         logger.error(
             "OpenAI pretranslation timed out - source_lang=%s model=%s timeout_seconds=%.2f query_chars=%s query_preview=%r",
@@ -911,20 +907,20 @@ async def translate_to_english_with_oss_vllm(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
+) -> str:
     """Pretranslate via the OSS vLLM endpoint (per-request, sticky 'oss' sessions).
 
-    Same return contract as translate_to_english_with_gpt5_mini:
-    (translated_text, confidence) where confidence is "high", "low", or "unknown".
+    Same return contract as translate_to_english_with_gpt5_mini: the translated
+    text, or an empty string on empty/failed output.
 
     Legacy sessions never hit this — the function is only called when the
     sticky pipeline router returns variant='oss'.
     """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     client = _get_oss_pretranslation_client()
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
@@ -941,15 +937,15 @@ async def translate_to_english_with_oss_vllm(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OSS vLLM pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                return text, "low"
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
-            return translated_text, confidence
+            return translated_text
 
         with langfuse.start_as_current_observation(
             name="query_pretranslation",
@@ -973,17 +969,17 @@ async def translate_to_english_with_oss_vllm(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OSS vLLM pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                observation.update(output="__EMPTY__", metadata={"confidence": "low"})
-                return text, "low"
+                observation.update(output="__EMPTY__")
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             observation.update(output=translated_text)
-            return translated_text, confidence
+            return translated_text
     except asyncio.TimeoutError as e:
         logger.error(
             "OSS vLLM pretranslation timed out - source_lang=%s model=%s timeout_seconds=%.2f query_chars=%s query_preview=%r",

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1205,7 +1205,6 @@ async def stream_voice_message(
 
             processing_query = query
             processing_lang = "en"
-            pretranslation_confidence = "unknown"
             history_user_text = query
             moderation_recent_history = "\n\n".join(format_message_pairs(history, 2))
             mobile = normalize_phone_to_mobile(user_id)
@@ -1256,18 +1255,17 @@ async def stream_voice_message(
                         model=_pretrans_model,
                     ):
                         if is_oss:
-                            processing_query, pretranslation_confidence = await translate_to_english_with_oss_vllm(
+                            processing_query = await translate_to_english_with_oss_vllm(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                         else:
-                            processing_query, pretranslation_confidence = await translate_to_english_with_gpt5_mini(
+                            processing_query = await translate_to_english_with_gpt5_mini(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                     trace.set_pretranslation(
                         text=processing_query,
-                        confidence=pretranslation_confidence,
                         provider=_pretrans_provider_label,
                         fallback_used=False,
                     )
@@ -1288,13 +1286,12 @@ async def stream_voice_message(
                             input=trace.metadata.get("query"),
                             metadata={"provider": "translategemma", "source_lang": requested_source_lang},
                         ):
-                            processing_query, pretranslation_confidence = await translate_to_english_with_structured_fallback(
+                            processing_query = await translate_to_english_with_structured_fallback(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                         trace.set_pretranslation(
                             text=processing_query,
-                            confidence=pretranslation_confidence,
                             provider="translategemma",
                             fallback_used=True,
                         )
@@ -1306,10 +1303,8 @@ async def stream_voice_message(
                             fallback_error,
                         )
                         processing_query = ""
-                        pretranslation_confidence = "low"
                         trace.set_pretranslation(
                             text=processing_query,
-                            confidence=pretranslation_confidence,
                             provider="failed",
                             fallback_used=True,
                         )
@@ -1319,7 +1314,6 @@ async def stream_voice_message(
                 history_user_text = query
                 trace.set_pretranslation(
                     text=query,
-                    confidence="high",
                     provider="none",
                     fallback_used=False,
                 )
@@ -1395,14 +1389,8 @@ async def stream_voice_message(
                 return
 
             # ── Empty-pretranslation guard ───────────────────────────────
-            # The model's own `confidence: low` verdict was previously a
-            # gate here, but it was over-rejecting clear short follow-ups
-            # ("where do I apply online?", "any medicine for this?") because
-            # the pretranslation prompt instructs the model to flag low
-            # whenever any key noun is missing — which is normal for
-            # pronominal turns in a multi-turn conversation. We now only
-            # short-circuit when pretranslation produced no usable text at
-            # all (i.e. both primary and fallback failed). True noise still
+            # Only short-circuit when pretranslation produced no usable text
+            # at all (i.e. both primary and fallback failed). True noise still
             # routes to the agent, which is better at asking for
             # clarification in context than a canned global retry.
             if (

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -303,13 +303,11 @@ class VoiceTrace:
         self,
         *,
         text: str,
-        confidence: str,
         provider: str,
         fallback_used: bool,
     ) -> None:
         self.metadata["pretranslation"] = {
             "text": sanitize_text(text),
-            "confidence": confidence,
             "provider": provider,
             "fallback_used": fallback_used,
         }

--- a/tests/test_pretranslation_ai_technician_booking_regression.py
+++ b/tests/test_pretranslation_ai_technician_booking_regression.py
@@ -57,7 +57,6 @@ if INTEGRATION_ENABLED:
             pytrace=False,
         )
 
-VALID_CONFIDENCE = {"high", "low", "unknown"}
 MATCHER_VERSION = "ai-booking-semantic-v1"
 MATCH_STOPWORDS = {
     "a",
@@ -118,7 +117,6 @@ class PretranslationBookingResult(BaseModel):
     source_lang: str
     source_text: str
     translation: str
-    confidence: str
     matched_groups: tuple[str, ...]
 
 
@@ -133,7 +131,6 @@ class BookingFailureLedgerEntry(BaseModel):
     forbidden_any: tuple[str, ...]
     optional_any: tuple[str, ...]
     translation: str
-    confidence: str
     notes: str = ""
 
 
@@ -239,7 +236,7 @@ def _validate_booking_translation(case: BookingQueryCase, translation: str) -> t
     return True, tuple(matched), ""
 
 
-def _failure_ledger(case: BookingQueryCase, translation: str, confidence: str, reason: str) -> str:
+def _failure_ledger(case: BookingQueryCase, translation: str, reason: str) -> str:
     entry = BookingFailureLedgerEntry(
         matcher_version=MATCHER_VERSION,
         case_id=case.case_id,
@@ -249,7 +246,6 @@ def _failure_ledger(case: BookingQueryCase, translation: str, confidence: str, r
         forbidden_any=case.forbidden_any,
         optional_any=case.optional_any,
         translation=translation,
-        confidence=confidence,
         notes=reason or case.notes,
     )
     return json.dumps(entry.model_dump(), ensure_ascii=False, sort_keys=True)
@@ -739,11 +735,10 @@ def test_negative_translations_are_not_full_booking_intent(case_id: str, transla
     ids=[case.case_id for case in ENGLISH_BOOKING_TURN1_CASES],
 )
 def test_english_queries_passthrough_pretranslation_unchanged(english_query: str):
-    translated, confidence = asyncio.run(
+    translated = asyncio.run(
         translate_to_english_with_gpt5_mini(english_query, "en")
     )
     assert translated == english_query
-    assert confidence == "high"
 
 
 def test_gujarati_glossary_transliteration_does_not_corrupt_other_topic_bija():
@@ -766,20 +761,18 @@ def test_vllm_pretranslation_gujarati_booking_turn1(case: BookingQueryCase):
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
     hints = _get_glossary_hints_for_gu_query(case.source_text, max_results=20)
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     ok, matched, reason = _validate_booking_translation(case, translation)
-    ledger = _failure_ledger(case, translation, confidence, reason)
+    ledger = _failure_ledger(case, translation, reason)
     assert ok, (
         f"Gujarati booking pretranslation failed semantic checks.\n"
         f"case_id={case.case_id}\n"
         f"source_text={case.source_text!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"hints={hints!r}\n"
         f"matched={matched!r}\n"
         f"failure_ledger_json={ledger}"
@@ -790,7 +783,6 @@ def test_vllm_pretranslation_gujarati_booking_turn1(case: BookingQueryCase):
         source_lang=case.source_lang,
         source_text=case.source_text,
         translation=translation,
-        confidence=confidence,
         matched_groups=matched,
     )
 
@@ -801,20 +793,18 @@ def test_vllm_pretranslation_gujarati_technician_selection(case: BookingQueryCas
     if not INTEGRATION_ENABLED:
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     ok, matched, reason = _validate_booking_translation(case, translation)
-    ledger = _failure_ledger(case, translation, confidence, reason)
+    ledger = _failure_ledger(case, translation, reason)
     assert ok, (
         f"Gujarati technician-selection pretranslation failed semantic checks.\n"
         f"case_id={case.case_id}\n"
         f"source_text={case.source_text!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"matched={matched!r}\n"
         f"failure_ledger_json={ledger}"
     )
@@ -826,11 +816,10 @@ def test_vllm_pretranslation_negative_fodder_seed_not_insemination_booking():
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
     case = next(c for c in NEGATIVE_NON_BOOKING_CASES if c.case_id == "neg-gu-fodder-seed")
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip()
-    assert confidence in VALID_CONFIDENCE
 
     booking_probe = BookingQueryCase(
         case_id="probe-full-booking",
@@ -842,8 +831,7 @@ def test_vllm_pretranslation_negative_fodder_seed_not_insemination_booking():
     ok_booking, _, _ = _validate_booking_translation(booking_probe, translation)
     assert not ok_booking, (
         f"Fodder-seed query was misread as AI booking.\n"
-        f"translation={translation!r}\n"
-        f"confidence={confidence!r}"
+        f"translation={translation!r}"
     )
 
 
@@ -854,11 +842,10 @@ def test_english_booking_queries_remain_valid_after_passthrough(case: BookingQue
     if not INTEGRATION_ENABLED:
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 to run integration suite marker")
 
-    translated, confidence = asyncio.run(
+    translated = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "en")
     )
     assert translated == case.source_text
-    assert confidence == "high"
 
     ok, matched, reason = _validate_booking_translation(case, translated)
     assert ok, (

--- a/tests/test_pretranslation_glossary_vllm_integration.py
+++ b/tests/test_pretranslation_glossary_vllm_integration.py
@@ -61,7 +61,6 @@ from app.services.translation import (
 )
 
 
-VALID_CONFIDENCE = {"high", "low", "unknown"}
 MATCHER_VERSION = "semantic-alias-v2"
 MATCH_STOPWORDS = {
     "a",
@@ -167,7 +166,6 @@ class PretranslationRegressionResult(BaseModel):
 
     case_id: str = Field(min_length=1)
     translation: str = Field(min_length=1)
-    confidence: str = Field(pattern="^(high|low|unknown)$")
     matched_expected: str = Field(min_length=1)
 
 
@@ -181,7 +179,6 @@ class GlossaryFailureLedgerEntry(BaseModel):
     glossary_gu: str = Field(min_length=1)
     expected_any: tuple[str, ...] = Field(min_length=1)
     translation: str = Field(min_length=1)
-    confidence: str = Field(pattern="^(high|low|unknown)$")
     hints: str
 
 
@@ -302,7 +299,6 @@ def _failure_ledger(
     case: GlossaryRegressionCase,
     hints: str,
     translation: str,
-    confidence: str,
 ) -> str:
     entry = GlossaryFailureLedgerEntry(
         matcher_version=MATCHER_VERSION,
@@ -312,7 +308,6 @@ def _failure_ledger(
         glossary_gu=case.glossary_gu,
         expected_any=case.expected_any,
         translation=translation,
-        confidence=confidence,
         hints=hints,
     )
     return json.dumps(
@@ -391,16 +386,14 @@ def test_vllm_pretranslation_uses_glossary_term(case: GlossaryRegressionCase):
         f"hints={hints!r}"
     )
 
-    translation, confidence = asyncio.run(translate_to_english_with_gpt5_mini(case.source_text, "gu"))
+    translation = asyncio.run(translate_to_english_with_gpt5_mini(case.source_text, "gu"))
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     matched_expected = _contains_expected_alias(translation, case.expected_any)
     failure_ledger = _failure_ledger(
         case=case,
         hints=hints,
         translation=translation,
-        confidence=confidence,
     )
     assert matched_expected is not None, (
         f"Pretranslation did not contain the expected glossary term or alias.\n"
@@ -408,13 +401,11 @@ def test_vllm_pretranslation_uses_glossary_term(case: GlossaryRegressionCase):
         f"source_text={case.source_text!r}\n"
         f"expected_any={case.expected_any!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"failure_ledger_json={failure_ledger}"
     )
 
     PretranslationRegressionResult(
         case_id=case.case_id,
         translation=translation,
-        confidence=confidence,
         matched_expected=matched_expected,
     )

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -340,7 +340,6 @@ class TestHelperCoverage:
         assert "faithful pretranslation" in prompt
         assert "Preserve uncertainty" in prompt
         assert "Do not infer animal species" in prompt
-        assert "Set confidence to \"high\" only when the core request is clear without guessing" in prompt
         assert "unclear animal" in prompt
         assert "Never convert a doubtful token into a specific medicine, feed, disease, animal species, or service term" in prompt
 
@@ -350,7 +349,6 @@ class TestHelperCoverage:
         assert "Kinship words" in prompt
         assert "Do not turn them into the caller's gender" in prompt
         assert "address marker" in prompt
-        assert "mark confidence low if the word could also be an address marker" in prompt
 
     @pytest.mark.parametrize("query", [
         "મારી ભેસ્ટને તાવ છે",
@@ -723,18 +721,17 @@ class TestHelperCoverage:
         assert "તાવ" in result
 
     def test_extract_translation_from_raw_json(self):
-        translated, confidence = _extract_translation_from_raw(
+        translated = _extract_translation_from_raw(
             '{"translation": "the cow has fever", "confidence": "low"}'
         )
         assert translated == "the cow has fever"
-        assert confidence == "low"
 
     def test_empty_fallback_pretranslation_short_circuits_with_repeat_prompt(self, monkeypatch):
         # Contract (see df9985f): the short-circuit now fires only when
         # pretranslation produces NO usable text at all (primary raised and
-        # fallback returned empty). A merely low-confidence-but-non-empty
-        # pretranslation routes to the agent instead, which clarifies in
-        # context. Here both primary and fallback fail to yield text.
+        # fallback returned empty). A non-empty pretranslation routes to the
+        # agent instead, which clarifies in context. Here both primary and
+        # fallback fail to yield text.
         from app.services import voice as voice_module
         from agents import voice as voice_agent_module
 
@@ -742,7 +739,7 @@ class TestHelperCoverage:
             raise TimeoutError("primary pretranslation failed")
 
         async def _fallback_pretranslation(*args, **kwargs):
-            return "", "low"
+            return ""
 
         agent_called = False
         history_store: dict[str, list] = {}
@@ -807,7 +804,7 @@ class TestMultiTurnFlows:
             agent_called["value"] = True
 
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever", "high"
+            return "My cow has fever"
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -839,7 +836,7 @@ class TestMultiTurnFlows:
             agent_called["value"] = True
 
         async def _pretranslate(*args, **kwargs):
-            return "yes", "high"
+            return "yes"
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -912,7 +909,7 @@ class TestMultiTurnFlows:
             )
 
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever.", "high"
+            return "My cow has fever."
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -990,7 +987,7 @@ class TestMultiTurnFlows:
 
         monkeypatch.setattr(voice_module, "get_or_fetch_farmer_data", _fake_farmer_data)
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever.", "high"
+            return "My cow has fever."
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
         from agents import voice as voice_agent_module
         monkeypatch.setattr(voice_agent_module.voice_agent, "run_stream", _unexpected_base_run_stream)

--- a/tests/test_voice_regressions_apr11_12_integration.py
+++ b/tests/test_voice_regressions_apr11_12_integration.py
@@ -208,17 +208,15 @@ def test_fixture_contains_integration_scenarios():
     assert {"feedback_removed", "stt_retry_ceiling", "voice_text_cleanup"}.issubset(scenario_ids)
 
 
-def test_real_openai_pretranslation_confidence_for_clear_and_garbled_inputs():
+def test_real_openai_pretranslation_for_clear_and_garbled_inputs():
     if not os.getenv("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY is required for this integration test")
 
-    clear_text, clear_confidence = asyncio.run(translate_to_english_with_gpt5_mini("ગાયને તાવ છે", "gu"))
-    noisy_text, noisy_confidence = asyncio.run(translate_to_english_with_gpt5_mini("કાળજ (વેચાવ)", "gu"))
+    clear_text = asyncio.run(translate_to_english_with_gpt5_mini("ગાયને તાવ છે", "gu"))
+    noisy_text = asyncio.run(translate_to_english_with_gpt5_mini("કાળજ (વેચાવ)", "gu"))
 
     assert clear_text
-    assert clear_confidence == "high"
     assert noisy_text
-    assert noisy_confidence in {"low", "high", "unknown"}
 
 
 def test_real_translategemma_output_is_speakable():


### PR DESCRIPTION
## What

The translation pretranslation step no longer **rates whether a farmer's utterance is complete vs incomplete/garbled**. The `high`/`low`/`unknown` confidence verdict the translation prompt produced is removed end-to-end. This is the surgical removal of that rating and nothing else.

## Changes (7 files: 3 code + 4 tests)

- **`translation.py`** — `translate_to_english_with_gpt5_mini`, `translate_to_english_with_oss_vllm`, and `translate_to_english_with_structured_fallback` now return just the translated `str` instead of `(text, confidence)`; the `confidence` ask is dropped from the prompt builders and the confidence parsing from `_extract_translation_from_*`. Conservative-translation guidance (preserve uncertain tokens, don't infer species, `unclear animal` markers) is kept, reworded to stand alone.
- **`voice.py`** — dropped `pretranslation_confidence` and the `confidence=` args to `trace.set_pretranslation`.
- **`voice_trace.py`** — dropped the `confidence` field from `set_pretranslation`.
- **tests** — updated the affected signatures to the new `str` return; dropped confidence-only assertions and the confidence model fields.

## Deliberately NOT changed

- **Moderation** and the **translation pipeline** itself.
- The **empty-pretranslation guard** in `voice.py` — it short-circuits only when translation yields *no usable text at all* (keyed on empty text, never on a confidence value), so it is unaffected and stays as a total-failure backstop.
- **All agent system prompts** — the clarification behaviour there is the agent's own conduct, not the translation-prompt confidence rating, so it is out of scope.

## Testing (repo `.venv`, python 3.10)

- All 7 changed files `py_compile` clean.
- `confidence` removed from `translation.py` / `voice.py` / `voice_trace.py` (grep: 0); empty-pretranslation guard still present.
- Non-integration suite shows **no new failures vs `amul-dev`**: the same 3 pre-existing/environmental failures appear on both branches (farmer-tool registration, a moved `farmer_cached` attribute, a technician matcher on raw Gujarati); one translation-endpoint test is flaky under load but **passes in isolation on both** base and this branch.
- Integration tests (live OpenAI/vLLM/booking endpoints) were not run locally — should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)