### PR TITLE
Promote to prod: confidence removal + Amul AI intro fix + faster/concurrent moderation

### DIFF
--- a/agents/deps.py
+++ b/agents/deps.py
@@ -1,5 +1,6 @@
+import asyncio
 from typing import Optional, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 
 class FarmerContext(BaseModel):
@@ -26,6 +27,33 @@ class FarmerContext(BaseModel):
     ai_technician_info: str = Field(default="", description="Pre-built internal AI technician context string.")
     signed_in: bool = Field(default=False, description="Whether the session is signed in/authenticated for farmer-specific tools.")
     mobile: Optional[str] = Field(default=None, description="Normalized mobile number when available.")
+
+    # Handle to the per-turn content-moderation task, which now runs concurrently
+    # with the agent (see app.services.voice). Side-effecting tools await it via
+    # ensure_in_scope() so a rejected query can never produce a write, even though
+    # the agent executes optimistically before the verdict is known.
+    _moderation_task: Optional["asyncio.Task"] = PrivateAttr(default=None)
+
+    def set_moderation_task(self, task: Optional["asyncio.Task"]) -> None:
+        """Attach the concurrently-running moderation task for tool self-gating."""
+        self._moderation_task = task
+
+    async def ensure_in_scope(self) -> bool:
+        """Block until the concurrent moderation verdict is known.
+
+        Returns False ONLY when moderation explicitly rejected the query, so
+        side-effecting tools (e.g. bookings) refuse instead of performing a write.
+        Fail-open (returns True) when no task is attached or moderation errored —
+        a flaky moderation check must never drop a real farmer booking.
+        """
+        task = self._moderation_task
+        if task is None:
+            return True
+        try:
+            verdict = await task
+        except Exception:
+            return True
+        return not bool(verdict is not None and getattr(verdict, "rejected", False))
 
     def _query_string(self):
         """Get the query string for the agrinet agent."""

--- a/agents/tools/ai_call.py
+++ b/agents/tools/ai_call.py
@@ -54,6 +54,12 @@ async def create_ai_call(
         session_id, union_code, society_code, farmer_code, user_id, species.value,
     )
 
+    # Moderation runs concurrently with the agent, so this booking write must
+    # block on the verdict: a rejected query must never create a real booking.
+    if not await ctx.deps.ensure_in_scope():
+        logger.info("AI call blocked: query failed moderation; session=%s", session_id)
+        return "This helpline only handles dairy farming and animal husbandry questions."
+
     # Session-based cooldown: one booking per session per 30 minutes
     if session_id:
         cache_key = session_id

--- a/agents/tools/health_call.py
+++ b/agents/tools/health_call.py
@@ -49,6 +49,12 @@ async def create_health_call(
         case_type.value,
     )
 
+    # Moderation runs concurrently with the agent, so this booking write must
+    # block on the verdict: a rejected query must never create a real booking.
+    if not await ctx.deps.ensure_in_scope():
+        logger.info("Health call blocked: query failed moderation; session=%s", session_id)
+        return "This helpline only handles dairy farming and animal husbandry questions."
+
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -12,6 +12,7 @@ legitimate farmer call.
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from typing import Literal, Optional
 
@@ -20,8 +21,10 @@ from openai import AsyncOpenAI
 from app.config import settings
 from app.services.translation import (
     OPENAI_PRETRANSLATION_MODEL,
+    OSS_PRETRANSLATION_MODEL,
     _get_langfuse,
     _get_openai_client,
+    _get_oss_pretranslation_client,
 )
 from helpers.utils import get_logger, get_prompt
 
@@ -64,6 +67,20 @@ DECLINE_MESSAGES_EN: dict[str, str] = {
 
 MODERATION_PROMPT_NAME = "voice_moderation_en"
 _STATIC_MODERATION_SYSTEM_PROMPT = get_prompt(MODERATION_PROMPT_NAME)
+
+# Voice moderation runs on the self-hosted gemma vLLM endpoint by default: it is
+# fast (~0.2s, measured in the load sweep) and in-cluster, vs ~1.5s for the
+# OpenAI gpt path that previously served it — which doubled as the long pole on
+# warm-cache voice turns. Override with VOICE_MODERATION_PROVIDER=openai to fall
+# back to the gpt model (OPENAI_PRETRANSLATION_MODEL).
+_MODERATION_PROVIDER = (os.getenv("VOICE_MODERATION_PROVIDER", "vllm") or "vllm").strip().lower()
+
+
+def _moderation_client_and_model() -> tuple[AsyncOpenAI, str, str]:
+    """Return (client, model, provider_label) for the configured moderation backend."""
+    if _MODERATION_PROVIDER == "openai":
+        return _get_openai_client(), OPENAI_PRETRANSLATION_MODEL, "openai"
+    return _get_oss_pretranslation_client(), OSS_PRETRANSLATION_MODEL, "vllm"
 
 
 @dataclass(frozen=True)
@@ -140,13 +157,14 @@ def _build_messages(
 
 async def _create_moderation_response(
     client: AsyncOpenAI,
+    model: str,
     text: str,
     source_lang: str,
     recent_history_text: str = "",
 ):
     return await asyncio.wait_for(
         client.chat.completions.create(
-            model=OPENAI_PRETRANSLATION_MODEL,
+            model=model,
             messages=_build_messages(text, source_lang, recent_history_text),
             max_completion_tokens=200,
             response_format={"type": "json_object"},
@@ -169,13 +187,18 @@ async def check_moderation(
     if not text or not text.strip():
         return _allow("empty input", failed_open=False)
 
-    client = _get_openai_client()
+    try:
+        client, model, provider = _moderation_client_and_model()
+    except Exception as e:
+        logger.error("Moderation client init failed (%s); failing open", e)
+        return _allow(f"moderation client error: {type(e).__name__}", failed_open=True)
     langfuse = _get_langfuse()
 
     try:
         if not langfuse:
             response = await _create_moderation_response(
                 client,
+                model,
                 text,
                 source_lang,
                 recent_history_text,
@@ -191,14 +214,15 @@ async def check_moderation(
                 "text": text,
                 "recent_history_text": recent_history_text,
             },
-            model=OPENAI_PRETRANSLATION_MODEL,
+            model=model,
             metadata={
                 "pipeline_stage": "query_moderation",
-                "moderation_provider": "openai",
+                "moderation_provider": provider,
             },
         ) as observation:
             response = await _create_moderation_response(
                 client,
+                model,
                 text,
                 source_lang,
                 recent_history_text,
@@ -218,7 +242,7 @@ async def check_moderation(
         logger.error(
             "Moderation timed out - source_lang=%s model=%s timeout=%.2fs query_chars=%s query_preview=%r",
             source_lang,
-            OPENAI_PRETRANSLATION_MODEL,
+            model,
             settings.openai_pretranslation_timeout_seconds,
             len(text),
             text[:160],

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -102,6 +102,8 @@ GU_PREFERRED_TRANSLATION_RULES = [
     "Use 'ભૌતિક' for physical (examination/condition), not 'શારીરિક'.",
     "Never use the hallucinated fodder word 'બરબા'. Use 'બરસીમ' (or 'રજકો' where contextually better).",
     "Never output placeholder quantities like '-', '--', or '–' for feed or dose lines. If exact values are missing, keep the wording non-numeric rather than inventing a quantity.",
+    "'Amul AI', 'Amul A I', 'AMUL AI', 'AI helpline', 'amul helpline', 'AI helpline advisor', and 'AI-powered helpline' refer to the Amul Artificial Intelligence digital advisory helpline, not artificial insemination. Render as 'અમૂલ એ.આઈ.' / 'એ.આઈ. હેલ્પલાઇન'; never as 'કૃત્રિમ બીજદાન' or other insemination wording in helpline or assistant identity context.",
+    "When 'AI' appears in product or helpline naming (Amul AI, AI helpline, AI assistant, AI-powered helpline), treat it as Artificial Intelligence, not breeding artificial insemination, unless the sentence is clearly about beejdan, semen, technician booking, or insemination procedure.",
 ]
 
 

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -617,11 +617,11 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
         "- Your job is faithful pretranslation for safe routing, not correction, completion, or advice.\n"
         "- Preserve uncertainty from the original speech. Do not repair missing words, fill missing slots, or choose a clean interpretation when the audio transcript is ambiguous.\n"
         "- Words that look like human names (e.g. સલાદ, સરલા, ગંગા) are almost always ANIMAL NAMES (cow/buffalo names). Transliterate them as-is, do NOT translate literally.\n"
-        "- If a garbled token does not clearly map to a real medicine, feed, symptom, or service term, do NOT invent a meaning. Keep the translation conservative and set confidence to low.\n"
+        "- If a garbled token does not clearly map to a real medicine, feed, symptom, or service term, do NOT invent a meaning. Keep the translation conservative.\n"
         "- Kinship words like બેન, બહેન, ભાઈ are often address markers for Sarlaben or filler in phone speech. Do not turn them into the caller's gender. Use 'Sarlaben' only if the caller is clearly addressing the assistant; otherwise omit the address marker.\n"
-        "- 'ભાઈ' in livestock context may refer to a male animal (bull/ox), but mark confidence low if the word could also be an address marker.\n"
-        "- Prefer veterinary/agricultural meanings only when the term is clear in the original transcript. If choosing the agricultural meaning requires guessing, preserve the uncertain token and set confidence low.\n"
-        "- Do not infer animal species. If cow/buffalo/sheep/goat is unclear, write 'unclear animal' or keep the uncertain token, and set confidence low.\n"
+        "- 'ભાઈ' in livestock context may refer to a male animal (bull/ox); keep it generic if the word could also be an address marker.\n"
+        "- Prefer veterinary/agricultural meanings only when the term is clear in the original transcript. If choosing the agricultural meaning requires guessing, preserve the uncertain token.\n"
+        "- Do not infer animal species. If cow/buffalo/sheep/goat is unclear, write 'unclear animal' or keep the uncertain token.\n"
     )
 
     # -- Ambiguity hints from ambiguity_terms.json ---------------------
@@ -646,11 +646,9 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
     system_content = (
         f"{domain_preamble}\n"
         "Translate the user's message to faithful spoken English for an internal agent. "
-        "Respond with JSON: {\"translation\": \"...\", \"confidence\": \"high\" or \"low\"}.\n\n"
+        "Respond with JSON: {\"translation\": \"...\"}.\n\n"
         "Do not preserve markdown, bullets, bracketed duplicates, or other formatting clutter, but do preserve the meaning uncertainty.\n"
-        "Set confidence to \"high\" only when the core request is clear without guessing: animal or subject, problem or topic, and desired action are identifiable from the transcript.\n"
-        "Set confidence to \"low\" when the input is garbled noise, random syllables, fragmentary, contradictory, or when any key noun, animal species, medicine, feed, product, disease, symptom, or requested action is uncertain.\n"
-        "If confidence is low, still provide the most faithful translation possible, using markers such as 'unclear animal', 'unclear feed name', 'unclear symptom', or '[unclear token]' instead of inventing missing meaning.\n"
+        "When the input is garbled noise, random syllables, fragmentary, contradictory, or when any key noun, animal species, medicine, feed, product, disease, symptom, or requested action is uncertain, still provide the most faithful translation possible, using markers such as 'unclear animal', 'unclear feed name', 'unclear symptom', or '[unclear token]' instead of inventing missing meaning.\n"
         "Never convert a doubtful token into a specific medicine, feed, disease, animal species, or service term just because it would make a plausible livestock question."
     )
 
@@ -661,14 +659,14 @@ def _build_openai_pretranslation_messages(source_name: str, source_code: str, te
 
 
 def _build_structured_pretranslation_prompt(source_name: str, source_code: str, text: str) -> str:
-    """Build the structured translation+confidence prompt for non-OpenAI fallback models."""
+    """Build the structured translation prompt for non-OpenAI fallback models."""
     messages = _build_openai_pretranslation_messages(source_name, source_code, text)
     system_content = messages[0]["content"]
     user_content = messages[1]["content"]
     return (
         "<bos><start_of_turn>user\n"
         f"{system_content}\n\nUser message:\n{user_content}\n\n"
-        'Respond only with valid JSON: {"translation": "...", "confidence": "high" or "low"}.'
+        'Respond only with valid JSON: {"translation": "..."}.'
         "<end_of_turn>\n"
         "<start_of_turn>model\n"
     )
@@ -727,27 +725,22 @@ def _raise_empty_pretranslation(
     raise ValueError("GPT pretranslation returned empty output")
 
 
-def _extract_translation_from_response(response) -> tuple[str, str]:
-    """Extract translation text and confidence from OpenAI JSON response.
-
-    Returns (translation, confidence) where confidence is "high", "low", or "unknown".
-    """
+def _extract_translation_from_response(response) -> str:
+    """Extract the translation string from an OpenAI JSON response."""
     raw = (response.choices[0].message.content or "").strip()
     return _extract_translation_from_raw(raw)
 
 
-def _extract_translation_from_raw(raw: str) -> tuple[str, str]:
-    """Extract translation text and confidence from raw model output."""
+def _extract_translation_from_raw(raw: str) -> str:
+    """Extract the translation string from raw model output."""
     if not raw:
-        return "", "unknown"
+        return ""
     try:
         data = json.loads(raw)
-        translation = (data.get("translation") or "").strip()
-        confidence = (data.get("confidence") or "unknown").strip().lower()
-        return translation, confidence
+        return (data.get("translation") or "").strip()
     except (json.JSONDecodeError, AttributeError):
         # Fallback: use raw content if JSON parsing fails
-        return raw, "unknown"
+        return raw
 
 
 async def translate_to_english_with_structured_fallback(
@@ -755,13 +748,16 @@ async def translate_to_english_with_structured_fallback(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
-    """Fallback pretranslation with the same structured contract as the OpenAI path."""
+) -> str:
+    """Fallback pretranslation with the same structured contract as the OpenAI path.
+
+    Returns the translated text, or an empty string on empty/failed output.
+    """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
     source_code = LANG_CODES.get(source_lang.lower(), source_lang.lower())
@@ -788,17 +784,17 @@ async def translate_to_english_with_structured_fallback(
 
             result = await response.json()
             raw_text = result["choices"][0]["text"].strip()
-            translated_text, confidence = _extract_translation_from_raw(raw_text)
+            translated_text = _extract_translation_from_raw(raw_text)
             translated_text = normalize_voice_output(translated_text, "english")
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             if not translated_text:
                 logger.warning(
-                    "Structured fallback pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "Structured fallback pretranslation returned empty - source_lang=%s query=%r",
                     source_lang,
                     (text or "")[:100],
                 )
-                return text, "low"
-            return translated_text, confidence
+                return text
+            return translated_text
 
 
 async def translate_to_english_with_gpt5_mini(
@@ -806,16 +802,16 @@ async def translate_to_english_with_gpt5_mini(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
+) -> str:
     """Translate input text to English using OpenAI for pipeline pre-translation.
 
-    Returns (translated_text, confidence) where confidence is "high", "low", or "unknown".
+    Returns the translated text, or an empty string on empty/failed output.
     """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     client = _get_openai_client()
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
@@ -832,15 +828,15 @@ async def translate_to_english_with_gpt5_mini(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OpenAI pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OpenAI pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                return text, "low"
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
-            return translated_text, confidence
+            return translated_text
 
         with langfuse.start_as_current_observation(
             name="query_pretranslation",
@@ -863,17 +859,17 @@ async def translate_to_english_with_gpt5_mini(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OpenAI pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OpenAI pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                observation.update(output="__EMPTY__", metadata={"confidence": "low"})
-                return text, "low"
+                observation.update(output="__EMPTY__")
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             observation.update(output=translated_text)
-            return translated_text, confidence
+            return translated_text
     except asyncio.TimeoutError as e:
         logger.error(
             "OpenAI pretranslation timed out - source_lang=%s model=%s timeout_seconds=%.2f query_chars=%s query_preview=%r",
@@ -911,20 +907,20 @@ async def translate_to_english_with_oss_vllm(
     source_lang: str,
     *,
     max_tokens: int = 1024,
-) -> tuple[str, str]:
+) -> str:
     """Pretranslate via the OSS vLLM endpoint (per-request, sticky 'oss' sessions).
 
-    Same return contract as translate_to_english_with_gpt5_mini:
-    (translated_text, confidence) where confidence is "high", "low", or "unknown".
+    Same return contract as translate_to_english_with_gpt5_mini: the translated
+    text, or an empty string on empty/failed output.
 
     Legacy sessions never hit this — the function is only called when the
     sticky pipeline router returns variant='oss'.
     """
     if not text or not text.strip():
-        return text, "unknown"
+        return text
 
     if source_lang.lower() in {"english", "en"}:
-        return text, "high"
+        return text
 
     client = _get_oss_pretranslation_client()
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
@@ -941,15 +937,15 @@ async def translate_to_english_with_oss_vllm(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OSS vLLM pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                return text, "low"
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
-            return translated_text, confidence
+            return translated_text
 
         with langfuse.start_as_current_observation(
             name="query_pretranslation",
@@ -973,17 +969,17 @@ async def translate_to_english_with_oss_vllm(
                 text=text,
                 max_tokens=max_tokens,
             )
-            translated_text, confidence = _extract_translation_from_response(response)
+            translated_text = _extract_translation_from_response(response)
             if not translated_text:
                 logger.warning(
-                    "OSS vLLM pretranslation returned empty; treating as low confidence - source_lang=%s query=%r",
+                    "OSS vLLM pretranslation returned empty - source_lang=%s query=%r",
                     source_lang, (text or "")[:100],
                 )
-                observation.update(output="__EMPTY__", metadata={"confidence": "low"})
-                return text, "low"
+                observation.update(output="__EMPTY__")
+                return text
             translated_text = _apply_exact_glossary_transliteration_replacements(text, translated_text)
             observation.update(output=translated_text)
-            return translated_text, confidence
+            return translated_text
     except asyncio.TimeoutError as e:
         logger.error(
             "OSS vLLM pretranslation timed out - source_lang=%s model=%s timeout_seconds=%.2f query_chars=%s query_preview=%r",

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1222,12 +1222,20 @@ async def stream_voice_message(
             # Moderation receives the raw native-language text so it does
             # not need to wait for pretranslation to finish.
             moderation_started_at = time.monotonic()
+            # Stamp the true completion time so deferring the await (below) does
+            # not inflate the reported moderation latency: the verdict is now
+            # consumed after the agent's prefill, which can be later than when the
+            # moderation call actually finished.
+            moderation_done_at: dict = {"t": None}
             moderation_task = asyncio.create_task(
                 check_moderation(
                     text=query,
                     source_lang=requested_source_lang,
                     recent_history_text=moderation_recent_history,
                 )
+            )
+            moderation_task.add_done_callback(
+                lambda _t: moderation_done_at.__setitem__("t", time.monotonic())
             )
 
             if requested_source_lang not in {"en", "english"}:
@@ -1318,51 +1326,71 @@ async def stream_voice_message(
                     fallback_used=False,
                 )
 
-            # ── Content moderation gate ──────────────────────────────────
-            # Await the moderation task that was started alongside
-            # pretranslation. If it rejected the query, short-circuit with
-            # a canned decline and do not run the agent. Fail-open on any
-            # unexpected exception — a flaky moderation call must never
-            # drop a real farmer call.
-            try:
-                moderation_verdict: ModerationVerdict = await moderation_task
-                trace.attach_stage_timing(
-                    "moderation",
-                    (time.monotonic() - moderation_started_at) * 1000.0,
-                    source_lang=requested_source_lang,
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception as moderation_error:
-                trace.attach_stage_timing(
-                    "moderation",
-                    (time.monotonic() - moderation_started_at) * 1000.0,
-                    status="error",
-                    source_lang=requested_source_lang,
-                )
-                logger.error(
-                    "Moderation task raised unexpectedly for session_id=%s error=%s",
-                    session_id,
-                    moderation_error,
-                )
-                moderation_verdict = None  # type: ignore[assignment]
-            trace.set_moderation(moderation_verdict)
+            # ── Content moderation: deferred gate (runs with the agent) ──────
+            # check_moderation() was kicked off at the top of the turn and runs
+            # concurrently with pretranslation, the farmer-context load, AND the
+            # answer agent's prefill/generation below. We deliberately do NOT
+            # block on it here. The verdict is resolved lazily — via
+            # _resolve_moderation() — only at the points that can emit
+            # caller-facing output for a non-fast-path turn:
+            #   1. the empty-pretranslation short-circuit, and
+            #   2. just before the agent's first streamed chunk is emitted.
+            # This takes the ~1.5s moderation call off the critical path on
+            # warm-cache turns (cold farmer fetches already hid it). A rejected
+            # query is still declined before any answer reaches the caller, and
+            # side-effecting booking tools self-gate on the same verdict via
+            # deps.ensure_in_scope(), so optimistic agent execution can never turn
+            # a rejected query into a real booking write. Fail-open on any
+            # unexpected moderation exception — a flaky check must never drop a
+            # real farmer call.
+            _moderation_resolved = False
+            _moderation_verdict: Optional[ModerationVerdict] = None
 
-            if moderation_verdict is not None:
-                logger.info(
-                    "Moderation verdict: category=%s rejected=%s failed_open=%s reason=%r session_id=%s process_id=%s",
-                    moderation_verdict.category,
-                    moderation_verdict.rejected,
-                    moderation_verdict.failed_open,
-                    moderation_verdict.reason,
-                    session_id,
-                    process_id,
-                )
+            async def _resolve_moderation() -> Optional[ModerationVerdict]:
+                nonlocal _moderation_resolved, _moderation_verdict
+                if _moderation_resolved:
+                    return _moderation_verdict
+                _moderation_resolved = True
+                try:
+                    _moderation_verdict = await moderation_task
+                    done_t = moderation_done_at["t"] or time.monotonic()
+                    trace.attach_stage_timing(
+                        "moderation",
+                        (done_t - moderation_started_at) * 1000.0,
+                        source_lang=requested_source_lang,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as moderation_error:
+                    done_t = moderation_done_at["t"] or time.monotonic()
+                    trace.attach_stage_timing(
+                        "moderation",
+                        (done_t - moderation_started_at) * 1000.0,
+                        status="error",
+                        source_lang=requested_source_lang,
+                    )
+                    logger.error(
+                        "Moderation task raised unexpectedly for session_id=%s error=%s",
+                        session_id,
+                        moderation_error,
+                    )
+                    _moderation_verdict = None
+                trace.set_moderation(_moderation_verdict)
+                if _moderation_verdict is not None:
+                    logger.info(
+                        "Moderation verdict: category=%s rejected=%s failed_open=%s reason=%r session_id=%s process_id=%s",
+                        _moderation_verdict.category,
+                        _moderation_verdict.rejected,
+                        _moderation_verdict.failed_open,
+                        _moderation_verdict.reason,
+                        session_id,
+                        process_id,
+                    )
+                return _moderation_verdict
 
-            if moderation_verdict is not None and moderation_verdict.rejected:
+            async def _moderation_decline_stream(verdict: ModerationVerdict):
+                """Emit the canned decline and write history for a rejected query."""
                 trace.set_route("moderation_rejected")
-                if await _request_is_stale("after_moderation_reject"):
-                    return
                 if nudge_task and not nudge_task.done():
                     nudge_task.cancel()
                     trace.set_nudge(cancel_reason="moderation_rejected")
@@ -1376,7 +1404,7 @@ async def stream_voice_message(
                     except asyncio.CancelledError:
                         pass
                 decline_en = (
-                    moderation_verdict.decline_text_en()
+                    verdict.decline_text_en()
                     or "This helpline only handles dairy farming and animal husbandry questions."
                 )
                 decline_for_caller = await _render_text_for_caller(decline_en, requested_target_lang)
@@ -1386,7 +1414,6 @@ async def stream_voice_message(
                     await update_message_history(session_id, [*history, decl_req, decl_resp])
                 trace.set_outcome("moderation_rejected")
                 yield _emit(_prepare_voice_output(decline_for_caller, requested_target_lang))
-                return
 
             # ── Empty-pretranslation guard ───────────────────────────────
             # Only short-circuit when pretranslation produced no usable text
@@ -1397,6 +1424,15 @@ async def stream_voice_message(
                 requested_source_lang not in {"en", "english"}
                 and not (processing_query or "").strip()
             ):
+                # This short-circuits the agent, so resolve moderation here: a
+                # rejected query must be declined rather than asked to repeat.
+                _verdict = await _resolve_moderation()
+                if _verdict is not None and _verdict.rejected:
+                    if await _request_is_stale("after_moderation_reject"):
+                        return
+                    async for _c in _moderation_decline_stream(_verdict):
+                        yield _c
+                    return
                 trace.set_route("pretranslation_empty")
                 logger.info(
                     "Pretranslation produced no usable text; asking to repeat - session_id=%s process_id=%s query=%r",
@@ -1466,6 +1502,9 @@ async def stream_voice_message(
                 signed_in=signed_in,
                 mobile=mobile,
             )
+            # Let side-effecting tools (bookings) self-gate on the concurrent
+            # moderation verdict before performing any write.
+            deps.set_moderation_task(moderation_task)
 
             message_pairs = "\n\n".join(format_message_pairs(history, 3))
             logger.info(f"Message pairs: {message_pairs}")
@@ -1580,6 +1619,19 @@ async def stream_voice_message(
                                 TRANSLATION_TROUBLE_MESSAGE["en"],
                             )
                             yield trouble
+
+                    # Deferred moderation gate: resolve the concurrently-running
+                    # verdict now, before emitting ANY caller-facing chunk. The
+                    # agent has already done its prefill/tool calls (booking tools
+                    # self-gated on this verdict); if the query was rejected we
+                    # decline here and the agent's streamed output is discarded,
+                    # never reaching the caller.
+                    _verdict = await _resolve_moderation()
+                    if _verdict is not None and _verdict.rejected:
+                        if not await _request_is_stale("after_moderation_reject"):
+                            async for _c in _moderation_decline_stream(_verdict):
+                                yield _c
+                        return
 
                     try:
                         async for chunk in stream_iter:

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1205,7 +1205,6 @@ async def stream_voice_message(
 
             processing_query = query
             processing_lang = "en"
-            pretranslation_confidence = "unknown"
             history_user_text = query
             moderation_recent_history = "\n\n".join(format_message_pairs(history, 2))
             mobile = normalize_phone_to_mobile(user_id)
@@ -1256,18 +1255,17 @@ async def stream_voice_message(
                         model=_pretrans_model,
                     ):
                         if is_oss:
-                            processing_query, pretranslation_confidence = await translate_to_english_with_oss_vllm(
+                            processing_query = await translate_to_english_with_oss_vllm(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                         else:
-                            processing_query, pretranslation_confidence = await translate_to_english_with_gpt5_mini(
+                            processing_query = await translate_to_english_with_gpt5_mini(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                     trace.set_pretranslation(
                         text=processing_query,
-                        confidence=pretranslation_confidence,
                         provider=_pretrans_provider_label,
                         fallback_used=False,
                     )
@@ -1288,13 +1286,12 @@ async def stream_voice_message(
                             input=trace.metadata.get("query"),
                             metadata={"provider": "translategemma", "source_lang": requested_source_lang},
                         ):
-                            processing_query, pretranslation_confidence = await translate_to_english_with_structured_fallback(
+                            processing_query = await translate_to_english_with_structured_fallback(
                                 text=query,
                                 source_lang=requested_source_lang,
                             )
                         trace.set_pretranslation(
                             text=processing_query,
-                            confidence=pretranslation_confidence,
                             provider="translategemma",
                             fallback_used=True,
                         )
@@ -1306,10 +1303,8 @@ async def stream_voice_message(
                             fallback_error,
                         )
                         processing_query = ""
-                        pretranslation_confidence = "low"
                         trace.set_pretranslation(
                             text=processing_query,
-                            confidence=pretranslation_confidence,
                             provider="failed",
                             fallback_used=True,
                         )
@@ -1319,7 +1314,6 @@ async def stream_voice_message(
                 history_user_text = query
                 trace.set_pretranslation(
                     text=query,
-                    confidence="high",
                     provider="none",
                     fallback_used=False,
                 )
@@ -1395,14 +1389,8 @@ async def stream_voice_message(
                 return
 
             # ── Empty-pretranslation guard ───────────────────────────────
-            # The model's own `confidence: low` verdict was previously a
-            # gate here, but it was over-rejecting clear short follow-ups
-            # ("where do I apply online?", "any medicine for this?") because
-            # the pretranslation prompt instructs the model to flag low
-            # whenever any key noun is missing — which is normal for
-            # pronominal turns in a multi-turn conversation. We now only
-            # short-circuit when pretranslation produced no usable text at
-            # all (i.e. both primary and fallback failed). True noise still
+            # Only short-circuit when pretranslation produced no usable text
+            # at all (i.e. both primary and fallback failed). True noise still
             # routes to the agent, which is better at asking for
             # clarification in context than a canned global retry.
             if (

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -303,13 +303,11 @@ class VoiceTrace:
         self,
         *,
         text: str,
-        confidence: str,
         provider: str,
         fallback_used: bool,
     ) -> None:
         self.metadata["pretranslation"] = {
             "text": sanitize_text(text),
-            "confidence": confidence,
             "provider": provider,
             "fallback_used": fallback_used,
         }

--- a/assets/glossary_terms.json
+++ b/assets/glossary_terms.json
@@ -100,6 +100,26 @@
     "transliteration": "Bijdan karyakar"
   },
   {
+    "en": "AI helpline",
+    "gu": "એ.આઈ. હેલ્પલાઇન",
+    "transliteration": "A I helpline"
+  },
+  {
+    "en": "AMUL AI",
+    "gu": "અમૂલ એ.આઈ.",
+    "transliteration": "Amul A I"
+  },
+  {
+    "en": "Amul AI helpline advisor",
+    "gu": "અમૂલ એ.આઈ. હેલ્પલાઇન સલાહકાર",
+    "transliteration": "Amul A I helpline advisor"
+  },
+  {
+    "en": "amul helpline",
+    "gu": "અમૂલ એ.આઈ. હેલ્પલાઇન",
+    "transliteration": "amul helpline"
+  },
+  {
     "en": "Alertness",
     "gu": "સતર્કતા",
     "transliteration": "Satarkta"

--- a/tests/test_pretranslation_ai_technician_booking_regression.py
+++ b/tests/test_pretranslation_ai_technician_booking_regression.py
@@ -57,7 +57,6 @@ if INTEGRATION_ENABLED:
             pytrace=False,
         )
 
-VALID_CONFIDENCE = {"high", "low", "unknown"}
 MATCHER_VERSION = "ai-booking-semantic-v1"
 MATCH_STOPWORDS = {
     "a",
@@ -118,7 +117,6 @@ class PretranslationBookingResult(BaseModel):
     source_lang: str
     source_text: str
     translation: str
-    confidence: str
     matched_groups: tuple[str, ...]
 
 
@@ -133,7 +131,6 @@ class BookingFailureLedgerEntry(BaseModel):
     forbidden_any: tuple[str, ...]
     optional_any: tuple[str, ...]
     translation: str
-    confidence: str
     notes: str = ""
 
 
@@ -239,7 +236,7 @@ def _validate_booking_translation(case: BookingQueryCase, translation: str) -> t
     return True, tuple(matched), ""
 
 
-def _failure_ledger(case: BookingQueryCase, translation: str, confidence: str, reason: str) -> str:
+def _failure_ledger(case: BookingQueryCase, translation: str, reason: str) -> str:
     entry = BookingFailureLedgerEntry(
         matcher_version=MATCHER_VERSION,
         case_id=case.case_id,
@@ -249,7 +246,6 @@ def _failure_ledger(case: BookingQueryCase, translation: str, confidence: str, r
         forbidden_any=case.forbidden_any,
         optional_any=case.optional_any,
         translation=translation,
-        confidence=confidence,
         notes=reason or case.notes,
     )
     return json.dumps(entry.model_dump(), ensure_ascii=False, sort_keys=True)
@@ -739,11 +735,10 @@ def test_negative_translations_are_not_full_booking_intent(case_id: str, transla
     ids=[case.case_id for case in ENGLISH_BOOKING_TURN1_CASES],
 )
 def test_english_queries_passthrough_pretranslation_unchanged(english_query: str):
-    translated, confidence = asyncio.run(
+    translated = asyncio.run(
         translate_to_english_with_gpt5_mini(english_query, "en")
     )
     assert translated == english_query
-    assert confidence == "high"
 
 
 def test_gujarati_glossary_transliteration_does_not_corrupt_other_topic_bija():
@@ -766,20 +761,18 @@ def test_vllm_pretranslation_gujarati_booking_turn1(case: BookingQueryCase):
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
     hints = _get_glossary_hints_for_gu_query(case.source_text, max_results=20)
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     ok, matched, reason = _validate_booking_translation(case, translation)
-    ledger = _failure_ledger(case, translation, confidence, reason)
+    ledger = _failure_ledger(case, translation, reason)
     assert ok, (
         f"Gujarati booking pretranslation failed semantic checks.\n"
         f"case_id={case.case_id}\n"
         f"source_text={case.source_text!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"hints={hints!r}\n"
         f"matched={matched!r}\n"
         f"failure_ledger_json={ledger}"
@@ -790,7 +783,6 @@ def test_vllm_pretranslation_gujarati_booking_turn1(case: BookingQueryCase):
         source_lang=case.source_lang,
         source_text=case.source_text,
         translation=translation,
-        confidence=confidence,
         matched_groups=matched,
     )
 
@@ -801,20 +793,18 @@ def test_vllm_pretranslation_gujarati_technician_selection(case: BookingQueryCas
     if not INTEGRATION_ENABLED:
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     ok, matched, reason = _validate_booking_translation(case, translation)
-    ledger = _failure_ledger(case, translation, confidence, reason)
+    ledger = _failure_ledger(case, translation, reason)
     assert ok, (
         f"Gujarati technician-selection pretranslation failed semantic checks.\n"
         f"case_id={case.case_id}\n"
         f"source_text={case.source_text!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"matched={matched!r}\n"
         f"failure_ledger_json={ledger}"
     )
@@ -826,11 +816,10 @@ def test_vllm_pretranslation_negative_fodder_seed_not_insemination_booking():
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 for live booking regressions")
 
     case = next(c for c in NEGATIVE_NON_BOOKING_CASES if c.case_id == "neg-gu-fodder-seed")
-    translation, confidence = asyncio.run(
+    translation = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "gu")
     )
     assert translation.strip()
-    assert confidence in VALID_CONFIDENCE
 
     booking_probe = BookingQueryCase(
         case_id="probe-full-booking",
@@ -842,8 +831,7 @@ def test_vllm_pretranslation_negative_fodder_seed_not_insemination_booking():
     ok_booking, _, _ = _validate_booking_translation(booking_probe, translation)
     assert not ok_booking, (
         f"Fodder-seed query was misread as AI booking.\n"
-        f"translation={translation!r}\n"
-        f"confidence={confidence!r}"
+        f"translation={translation!r}"
     )
 
 
@@ -854,11 +842,10 @@ def test_english_booking_queries_remain_valid_after_passthrough(case: BookingQue
     if not INTEGRATION_ENABLED:
         pytest.skip("Set PRETRANSLATION_AI_BOOKING_INTEGRATION=1 to run integration suite marker")
 
-    translated, confidence = asyncio.run(
+    translated = asyncio.run(
         translate_to_english_with_gpt5_mini(case.source_text, "en")
     )
     assert translated == case.source_text
-    assert confidence == "high"
 
     ok, matched, reason = _validate_booking_translation(case, translated)
     assert ok, (

--- a/tests/test_pretranslation_glossary_vllm_integration.py
+++ b/tests/test_pretranslation_glossary_vllm_integration.py
@@ -61,7 +61,6 @@ from app.services.translation import (
 )
 
 
-VALID_CONFIDENCE = {"high", "low", "unknown"}
 MATCHER_VERSION = "semantic-alias-v2"
 MATCH_STOPWORDS = {
     "a",
@@ -167,7 +166,6 @@ class PretranslationRegressionResult(BaseModel):
 
     case_id: str = Field(min_length=1)
     translation: str = Field(min_length=1)
-    confidence: str = Field(pattern="^(high|low|unknown)$")
     matched_expected: str = Field(min_length=1)
 
 
@@ -181,7 +179,6 @@ class GlossaryFailureLedgerEntry(BaseModel):
     glossary_gu: str = Field(min_length=1)
     expected_any: tuple[str, ...] = Field(min_length=1)
     translation: str = Field(min_length=1)
-    confidence: str = Field(pattern="^(high|low|unknown)$")
     hints: str
 
 
@@ -302,7 +299,6 @@ def _failure_ledger(
     case: GlossaryRegressionCase,
     hints: str,
     translation: str,
-    confidence: str,
 ) -> str:
     entry = GlossaryFailureLedgerEntry(
         matcher_version=MATCHER_VERSION,
@@ -312,7 +308,6 @@ def _failure_ledger(
         glossary_gu=case.glossary_gu,
         expected_any=case.expected_any,
         translation=translation,
-        confidence=confidence,
         hints=hints,
     )
     return json.dumps(
@@ -391,16 +386,14 @@ def test_vllm_pretranslation_uses_glossary_term(case: GlossaryRegressionCase):
         f"hints={hints!r}"
     )
 
-    translation, confidence = asyncio.run(translate_to_english_with_gpt5_mini(case.source_text, "gu"))
+    translation = asyncio.run(translate_to_english_with_gpt5_mini(case.source_text, "gu"))
     assert translation.strip(), f"Empty pretranslation for {case.case_id}"
-    assert confidence in VALID_CONFIDENCE
 
     matched_expected = _contains_expected_alias(translation, case.expected_any)
     failure_ledger = _failure_ledger(
         case=case,
         hints=hints,
         translation=translation,
-        confidence=confidence,
     )
     assert matched_expected is not None, (
         f"Pretranslation did not contain the expected glossary term or alias.\n"
@@ -408,13 +401,11 @@ def test_vllm_pretranslation_uses_glossary_term(case: GlossaryRegressionCase):
         f"source_text={case.source_text!r}\n"
         f"expected_any={case.expected_any!r}\n"
         f"translation={translation!r}\n"
-        f"confidence={confidence!r}\n"
         f"failure_ledger_json={failure_ledger}"
     )
 
     PretranslationRegressionResult(
         case_id=case.case_id,
         translation=translation,
-        confidence=confidence,
         matched_expected=matched_expected,
     )

--- a/tests/test_translation_vocabulary.py
+++ b/tests/test_translation_vocabulary.py
@@ -16,14 +16,20 @@ import pytest
 import sys
 import os
 import re
+import json
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.services.translation import (
     _post_normalize_gu_translation,
+    GU_PREFERRED_TRANSLATION_RULES,
     GU_TERM_POLICY,
     GU_POST_REPLACEMENTS,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GLOSSARY_PATH = REPO_ROOT / "assets" / "glossary_terms.json"
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +425,26 @@ class TestNonexistentWords:
 # ---------------------------------------------------------------------------
 # Identity / introduction phrase corrections
 # ---------------------------------------------------------------------------
+
+class TestAmulAiHelplineDisambiguation:
+    """Amul AI (Artificial Intelligence) must not be translated as insemination."""
+
+    def test_gujarati_output_rules_disambiguate_amul_ai_product_name(self):
+        rules = "\n".join(GU_PREFERRED_TRANSLATION_RULES)
+        assert "Amul AI" in rules
+        assert "AI helpline" in rules
+        assert "અમૂલ એ.આઈ." in rules
+        assert "કૃત્રિમ બીજદાન" in rules
+        assert "Artificial Intelligence" in rules
+
+    def test_amul_ai_glossary_entries_present(self):
+        glossary = json.loads(GLOSSARY_PATH.read_text(encoding="utf-8"))
+        by_en = {entry["en"]: entry["gu"] for entry in glossary}
+        assert by_en["Amul AI helpline advisor"] == "અમૂલ એ.આઈ. હેલ્પલાઇન સલાહકાર"
+        assert by_en["AI helpline"] == "એ.આઈ. હેલ્પલાઇન"
+        assert by_en["AMUL AI"] == "અમૂલ એ.આઈ."
+        assert by_en["amul helpline"] == "અમૂલ એ.આઈ. હેલ્પલાઇન"
+
 
 class TestIdentityPhrases:
     """

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -340,7 +340,6 @@ class TestHelperCoverage:
         assert "faithful pretranslation" in prompt
         assert "Preserve uncertainty" in prompt
         assert "Do not infer animal species" in prompt
-        assert "Set confidence to \"high\" only when the core request is clear without guessing" in prompt
         assert "unclear animal" in prompt
         assert "Never convert a doubtful token into a specific medicine, feed, disease, animal species, or service term" in prompt
 
@@ -350,7 +349,6 @@ class TestHelperCoverage:
         assert "Kinship words" in prompt
         assert "Do not turn them into the caller's gender" in prompt
         assert "address marker" in prompt
-        assert "mark confidence low if the word could also be an address marker" in prompt
 
     @pytest.mark.parametrize("query", [
         "મારી ભેસ્ટને તાવ છે",
@@ -723,18 +721,17 @@ class TestHelperCoverage:
         assert "તાવ" in result
 
     def test_extract_translation_from_raw_json(self):
-        translated, confidence = _extract_translation_from_raw(
+        translated = _extract_translation_from_raw(
             '{"translation": "the cow has fever", "confidence": "low"}'
         )
         assert translated == "the cow has fever"
-        assert confidence == "low"
 
     def test_empty_fallback_pretranslation_short_circuits_with_repeat_prompt(self, monkeypatch):
         # Contract (see df9985f): the short-circuit now fires only when
         # pretranslation produces NO usable text at all (primary raised and
-        # fallback returned empty). A merely low-confidence-but-non-empty
-        # pretranslation routes to the agent instead, which clarifies in
-        # context. Here both primary and fallback fail to yield text.
+        # fallback returned empty). A non-empty pretranslation routes to the
+        # agent instead, which clarifies in context. Here both primary and
+        # fallback fail to yield text.
         from app.services import voice as voice_module
         from agents import voice as voice_agent_module
 
@@ -742,7 +739,7 @@ class TestHelperCoverage:
             raise TimeoutError("primary pretranslation failed")
 
         async def _fallback_pretranslation(*args, **kwargs):
-            return "", "low"
+            return ""
 
         agent_called = False
         history_store: dict[str, list] = {}
@@ -807,7 +804,7 @@ class TestMultiTurnFlows:
             agent_called["value"] = True
 
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever", "high"
+            return "My cow has fever"
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -839,7 +836,7 @@ class TestMultiTurnFlows:
             agent_called["value"] = True
 
         async def _pretranslate(*args, **kwargs):
-            return "yes", "high"
+            return "yes"
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -912,7 +909,7 @@ class TestMultiTurnFlows:
             )
 
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever.", "high"
+            return "My cow has fever."
 
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
 
@@ -990,7 +987,7 @@ class TestMultiTurnFlows:
 
         monkeypatch.setattr(voice_module, "get_or_fetch_farmer_data", _fake_farmer_data)
         async def _pretranslate(*args, **kwargs):
-            return "My cow has fever.", "high"
+            return "My cow has fever."
         monkeypatch.setattr(voice_module, "translate_to_english_with_gpt5_mini", _pretranslate)
         from agents import voice as voice_agent_module
         monkeypatch.setattr(voice_agent_module.voice_agent, "run_stream", _unexpected_base_run_stream)

--- a/tests/test_voice_regressions_apr11_12_integration.py
+++ b/tests/test_voice_regressions_apr11_12_integration.py
@@ -208,17 +208,15 @@ def test_fixture_contains_integration_scenarios():
     assert {"feedback_removed", "stt_retry_ceiling", "voice_text_cleanup"}.issubset(scenario_ids)
 
 
-def test_real_openai_pretranslation_confidence_for_clear_and_garbled_inputs():
+def test_real_openai_pretranslation_for_clear_and_garbled_inputs():
     if not os.getenv("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY is required for this integration test")
 
-    clear_text, clear_confidence = asyncio.run(translate_to_english_with_gpt5_mini("ગાયને તાવ છે", "gu"))
-    noisy_text, noisy_confidence = asyncio.run(translate_to_english_with_gpt5_mini("કાળજ (વેચાવ)", "gu"))
+    clear_text = asyncio.run(translate_to_english_with_gpt5_mini("ગાયને તાવ છે", "gu"))
+    noisy_text = asyncio.run(translate_to_english_with_gpt5_mini("કાળજ (વેચાવ)", "gu"))
 
     assert clear_text
-    assert clear_confidence == "high"
     assert noisy_text
-    assert noisy_confidence in {"low", "high", "unknown"}
 
 
 def test_real_translategemma_output_is_speakable():


### PR DESCRIPTION
Promotes `amul-dev` → `amul-prod`. **5 commits, all validated on dev.**

## Contents

- **#151** `2f80351` — Remove pretranslation completeness/confidence rating. Pretranslators return plain `str` (no `high/low/unknown` verdict); empty-translation guard + moderation untouched. *Validated on an isolated dev container 2026-05-29 (auth, gu/en utterances, fragment + empty paths all correct).*
- **#153** `43b30cd` — Fix "Amul AI" mistranslated as artificial **insemination** (કૃત્રિમ બીજદાન). Adds disambiguation rules + glossary entries. *117 vocabulary tests pass.*
- **876b9bc** — Run content moderation **concurrently with the agent** (deferred gate overlaps agent prefill). Rejected queries are still declined before any answer emits; booking tools self-gate via `deps.ensure_in_scope`. Fail-open preserved.
- **d2fcdf5** — Run moderation on **self-hosted gemma (vLLM)** instead of gpt-5.1 (`VOICE_MODERATION_PROVIDER=vllm` default, `openai` override). ~0.4s vs ~1.5s; makes the OSS path fully self-hosted.

## Moderation validation (dev, 2026-06-01)

Built `amul-dev` HEAD in an isolated container, `VOICE_MODERATION_PROVIDER` unset → defaulted to **vllm**. Logs confirmed `model=gemma-4-31b-it provider=vllm`.

| Query | Result |
|---|---|
| cow has fever (in-scope) | ✅ answered |
| milk dropped (in-scope) | ✅ answered |
| election prediction | ✅ rejected `cultural_sensitivity`, ~0.43s, polite decline — no answer leaked |
| cricket score | ✅ rejected `irrelevant`, ~0.44s |
| human medication | ✅ rejected `irrelevant`, ~0.43s |

Concurrent gate confirmed: out-of-scope queries are declined before any answer streams. Fail-open intact.

## Deploy
Not auto-deployed. After merge: trigger `infra/scripts/legacy-import/run-voice-oan-api-build.sh` (Argo kaniko build of `amul-prod` → push `registry.prod.amulai.in` → roll `voice-oan-api` in ns `amul-prod`). Requires kubectl on the prod cluster (VM3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)