### PR TITLE
fix(tools): hide get_union_scheme_data for unsupported unions

### DIFF
--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -13,7 +13,7 @@ from agents.tools.health_call import create_health_call
 from agents.tools.conversation_state import signal_conversation_state
 from agents.tools.farmer_cached import get_farmer_profile, get_herd_summary, list_animal_tags
 from agents.tools.common import fire_tool_call_nudge
-from agents.tools.union_schemes import get_union_scheme_data
+from agents.tools.union_schemes import get_union_scheme_data, prepare_get_union_scheme_data
 
 
 def _with_nudge_signal(func):
@@ -101,6 +101,7 @@ SIGNED_IN_FARMER_TOOLS = [
         takes_ctx=True,
         docstring_format='auto',
         require_parameter_descriptions=False,
+        prepare=prepare_get_union_scheme_data,
     ),
 ]
 

--- a/agents/tools/union_schemes.py
+++ b/agents/tools/union_schemes.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from pydantic_ai import RunContext
+from pydantic_ai.tools import ToolDefinition
 
 from agents.deps import FarmerContext
 from app.models.union import UnionName
@@ -20,6 +21,25 @@ SUPPORTED_SCHEME_UNIONS = {
 }
 
 logger = get_logger(__name__)
+
+
+async def prepare_get_union_scheme_data(
+    ctx: RunContext[FarmerContext], tool_def: ToolDefinition
+) -> ToolDefinition | None:
+    """Hide get_union_scheme_data from the LLM unless the farmer is in a supported union.
+
+    Prevents wasted tool calls and the misleading "union could not be determined"
+    bail-out for farmers from unions whose scheme catalog isn't ingested
+    (e.g., dudhsagar). The LLM won't see the tool in its schema this turn, so it can't call it.
+    """
+    farmer_unions = [u.strip().lower() for u in (ctx.deps.farmer_unions or []) if u]
+    if any(u in SUPPORTED_SCHEME_UNIONS for u in farmer_unions):
+        return tool_def
+    logger.info(
+        "Hiding get_union_scheme_data tool because farmer_unions=%s has no supported union",
+        farmer_unions,
+    )
+    return None
 
 
 def _filter_scheme_records(records: list[dict[str, Any]], scheme_name: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Add a pydantic-ai `prepare` callback (`prepare_get_union_scheme_data`) that removes `get_union_scheme_data` from the LLM's tool schema unless the farmer's union is in `SUPPORTED_SCHEME_UNIONS` (`banas`, `kutch`).
- Banas/Kutch behavior unchanged. The voice-specific `_with_nudge_signal(...)` wrapper on the tool function is preserved; `prepare` operates on the `Tool` definition layer above it.

## Why
Production Langfuse voice traces (sessions `cd1414cb-fa98-4869-8ee7-70a83c5f68b1` and `fbf0584c-95f3-4bd1-b4aa-d5fc94d40a9b`, both `voice-production`, provider `RAYA`) show that for farmers from non-supported unions — `dudhsagar` in the debug set, society codes `CHAROL.D.U.S.M.L` and `HOTELPUR MPCS LTD` — the LLM picks `get_union_scheme_data` per the prompt rules, receives `"Scheme data is unavailable because the farmer union could not be determined from the current farmer context."`, and then either:
- skips retrieval entirely (legacy gpt-5.1 path in `cd1414cb`), or
- wastes a parallel tool call (gemma OSS in `fbf0584c`).

Routing this via `prepare` enforces the gate at the protocol level: the tool isn't in the schema the LLM sees for that turn, so the call is physically impossible to emit. This also reduces noise in Langfuse Sessions (no more bail-out responses cluttering traces).

## Test plan
- [x] Smoke test the callback across `farmer_unions` of `["dudhsagar"]`, `[]`, `["banas"]`, `["kutch"]`, `["sabar","kutch"]` — HIDDEN/VISIBLE matches expectations.
- [ ] Run voice repo pytest suite (requires installing `pytest` in `voice-oan-api/.venv` — not currently present).
- [ ] Validate in a prod canary voice session that the misleading bail string no longer appears for Dudhsagar / other non-supported-union farmers.

## Companion change
Identical fix raised in `OpenAgriNet/amul-oan-api` for the web chat agent (which has its own copy of this tool). The web chat session in the debug set (`aa180af1-ac47-4ea9-abf3-0e2b003a6d86`) is addressed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)