### PR TITLE
OSS → managed fallback for voice pipelines (behind FALLBACK_ENABLED)

### DIFF
--- a/agents/tools/ai_call.py
+++ b/agents/tools/ai_call.py
@@ -10,7 +10,7 @@ from pydantic_ai import RunContext
 from agents.deps import FarmerContext
 from agents.models.ai_call import AICallRequestModel, AISpecies
 from agents.tools.farmer_animal_backends import create_ai_call_api
-from app.core.cache import cache
+from app.core.cache import cache, try_reserve, release_reservation
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -60,20 +60,6 @@ async def create_ai_call(
         logger.info("AI call blocked: query failed moderation; session=%s", session_id)
         return "This helpline only handles dairy farming and animal husbandry questions."
 
-    # Session-based cooldown: one booking per session per 30 minutes
-    if session_id:
-        cache_key = session_id
-        try:
-            existing = await cache.get(cache_key, namespace=AI_CALL_CACHE_NAMESPACE)
-            if existing:
-                logger.info("AI call already booked for session %s, skipping", session_id)
-                return (
-                    "This session already has an active artificial insemination booking. "
-                    "Please try again later or contact your society for assistance."
-                )
-        except Exception as e:
-            logger.warning("Failed to check AI call cooldown: %s", e)
-
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
@@ -86,8 +72,25 @@ async def create_ai_call(
         userId=user_id,
         species=species,
     )
+
+    # Atomic reservation immediately before the write: first caller wins; a
+    # concurrent/duplicate submit OR a fallback re-run for the same session
+    # short-circuits instead of double-booking (Redis SET NX, shared across
+    # containers). Released below if the booking API itself fails.
+    _reserved = False
+    if session_id:
+        if not await try_reserve(session_id, AI_CALL_CACHE_NAMESPACE, AI_CALL_COOLDOWN_TTL):
+            logger.info("AI call already booked/in-flight for session %s, skipping", session_id)
+            return (
+                "This session already has an active artificial insemination booking. "
+                "Please try again later or contact your society for assistance."
+            )
+        _reserved = True
+
     response = await create_ai_call_api(request, token)
     if response is None:
+        if _reserved:
+            await release_reservation(session_id, AI_CALL_CACHE_NAMESPACE)
         logger.info("AI call API failed for session=%s", session_id)
         return "Artificial insemination call booking failed. Unable to create booking at the moment."
 

--- a/agents/tools/health_call.py
+++ b/agents/tools/health_call.py
@@ -9,7 +9,7 @@ from agents.deps import FarmerContext
 from agents.models.ai_call import AISpecies
 from agents.models.health_call import HealthCallRequestModel, HealthCaseType
 from agents.tools.farmer_animal_backends import create_health_call_api
-from app.core.cache import cache
+from app.core.cache import cache, try_reserve, release_reservation
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -61,19 +61,6 @@ async def create_health_call(
         logger.info("Health call blocked: query failed moderation; session=%s", session_id)
         return "This helpline only handles dairy farming and animal husbandry questions."
 
-    # Session cooldown: one booking per session; also idempotent on agent re-run.
-    if session_id:
-        try:
-            existing = await cache.get(session_id, namespace=HEALTH_CALL_CACHE_NAMESPACE)
-            if existing:
-                logger.info("Health call already booked for session %s, skipping", session_id)
-                return (
-                    "This session already has an active health call booking. "
-                    "Please try again later or contact your society for assistance."
-                )
-        except Exception as e:
-            logger.warning("Failed to check health call cooldown: %s", e)
-
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
@@ -88,8 +75,24 @@ async def create_health_call(
         remark=remark,
     )
 
+    # Atomic reservation immediately before the write: first caller wins; a
+    # concurrent/duplicate submit OR a fallback re-run for the same session
+    # short-circuits instead of double-booking (Redis SET NX, shared across
+    # containers). Released below if the booking API itself fails.
+    _reserved = False
+    if session_id:
+        if not await try_reserve(session_id, HEALTH_CALL_CACHE_NAMESPACE, HEALTH_CALL_COOLDOWN_TTL):
+            logger.info("Health call already booked/in-flight for session %s, skipping", session_id)
+            return (
+                "This session already has an active health call booking. "
+                "Please try again later or contact your society for assistance."
+            )
+        _reserved = True
+
     response = await create_health_call_api(request, token)
     if response is None:
+        if _reserved:
+            await release_reservation(session_id, HEALTH_CALL_CACHE_NAMESPACE)
         logger.info(
             "Health call API failed: session=%s union=%s society=%s farmer=%s species=%s case_type=%s",
             session_id,

--- a/agents/tools/health_call.py
+++ b/agents/tools/health_call.py
@@ -9,9 +9,15 @@ from agents.deps import FarmerContext
 from agents.models.ai_call import AISpecies
 from agents.models.health_call import HealthCallRequestModel, HealthCaseType
 from agents.tools.farmer_animal_backends import create_health_call_api
+from app.core.cache import cache
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
+
+# One booking per session per 30 min (mirrors create_ai_call). Also makes this
+# tool idempotent against an agent re-run (OSS->managed streaming fallback).
+HEALTH_CALL_COOLDOWN_TTL = 60 * 30  # 30 minutes
+HEALTH_CALL_CACHE_NAMESPACE = "health_call_booked"
 
 
 async def create_health_call(
@@ -55,6 +61,19 @@ async def create_health_call(
         logger.info("Health call blocked: query failed moderation; session=%s", session_id)
         return "This helpline only handles dairy farming and animal husbandry questions."
 
+    # Session cooldown: one booking per session; also idempotent on agent re-run.
+    if session_id:
+        try:
+            existing = await cache.get(session_id, namespace=HEALTH_CALL_CACHE_NAMESPACE)
+            if existing:
+                logger.info("Health call already booked for session %s, skipping", session_id)
+                return (
+                    "This session already has an active health call booking. "
+                    "Please try again later or contact your society for assistance."
+                )
+        except Exception as e:
+            logger.warning("Failed to check health call cooldown: %s", e)
+
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
@@ -81,6 +100,18 @@ async def create_health_call(
             case_type.value,
         )
         return "Health call booking failed.\n\nUnable to create health call at the moment."
+
+    # Mark this session as booked so a re-run (or retry) does not double-book.
+    if session_id:
+        try:
+            await cache.set(
+                session_id,
+                {"ticket": response.ticket_number, "species": species.value},
+                ttl=HEALTH_CALL_COOLDOWN_TTL,
+                namespace=HEALTH_CALL_CACHE_NAMESPACE,
+            )
+        except Exception as e:
+            logger.warning("Failed to set health call cooldown: %s", e)
 
     ticket_number = response.ticket_number
     logger.info(

--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,19 @@ class Settings(BaseSettings):
     oss_llm_model_name: Optional[str] = os.getenv("OSS_LLM_MODEL_NAME")
     oss_variant_ttl: int = int(os.getenv("OSS_VARIANT_TTL", str(60 * 60 * 24 * 7)))  # 7d sticky
 
+    # Standard OSS -> managed fallback (see docs/oss-fallback-design.md).
+    # Kill-switch defaults OFF: when false, pipelines keep today's behaviour.
+    fallback_enabled: bool = os.getenv("FALLBACK_ENABLED", "false").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+    # Per-pipeline OSS time-to-respond budgets before falling back to managed.
+    fallback_chat_oss_timeout_ms: int = int(os.getenv("FALLBACK_CHAT_OSS_TIMEOUT_MS", "8000"))
+    fallback_moderation_oss_timeout_ms: int = int(os.getenv("FALLBACK_MODERATION_OSS_TIMEOUT_MS", "5000"))
+    fallback_pretranslation_oss_timeout_ms: int = int(os.getenv("FALLBACK_PRETRANSLATION_OSS_TIMEOUT_MS", "10000"))
+    fallback_suggestions_oss_timeout_ms: int = int(os.getenv("FALLBACK_SUGGESTIONS_OSS_TIMEOUT_MS", "6000"))
+    # Deadline for the managed (fallback) tier.
+    fallback_managed_timeout_ms: int = int(os.getenv("FALLBACK_MANAGED_TIMEOUT_MS", "20000"))
+
     # Voice pipeline behavioral flags
     # RETRIEVAL_AUDIT_LOG: log intent/retrieval_called/query per turn for replay analysis
     retrieval_audit_log: bool = _get_bool_env("RETRIEVAL_AUDIT_LOG", default=False)

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -44,6 +44,32 @@ def build_cache_key(key: str, namespace: str | None = None) -> str:
         return f"{settings.redis_key_prefix}{namespace}:{key}"
     return f"{settings.redis_key_prefix}{key}"
 
+
+async def try_reserve(key: str, namespace: str, ttl: int) -> bool:
+    """Atomically reserve a key (Redis SET NX). Returns True if newly reserved
+    (caller owns it and should proceed), False if a reservation already exists
+    (caller should skip). On a cache error, returns True (proceed UNGUARDED) — a
+    booking must not be blocked by a transient cache blip. Makes side-effecting
+    tools safe against concurrent duplicate submits + fallback re-runs across
+    containers (shared Redis)."""
+    try:
+        await cache.add(key, True, ttl=ttl, namespace=namespace)
+        return True
+    except ValueError:
+        return False
+    except Exception as e:  # cache unavailable -> fail-open on the guard
+        logger.warning("Reservation add failed (%s:%s): %s; proceeding unguarded", namespace, key, str(e))
+        return True
+
+
+async def release_reservation(key: str, namespace: str) -> None:
+    """Release a reservation so a genuine retry can proceed (e.g. the booking API
+    call failed). Best-effort."""
+    try:
+        await cache.delete(key, namespace=namespace)
+    except Exception as e:
+        logger.warning("Reservation release failed (%s:%s): %s", namespace, key, str(e))
+
 logger.info(
     f"Cache configured with Redis at {settings.redis_host}:{settings.redis_port} "
     f"(DB: {settings.redis_db}, Prefix: {settings.redis_key_prefix}, "

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -1,0 +1,317 @@
+"""Standard OSS -> managed fallback for LLM pipelines.
+
+See docs/oss-fallback-design.md. One mechanism, used by every unary pipeline
+(pretranslation, moderation, suggestions): a resolved pipeline *variant* becomes
+an ordered *attempt chain* — ``[oss, managed]`` for OSS sessions, ``[managed]``
+otherwise — and ``execute_with_fallback`` walks it, classifying each failure,
+falling back on infrastructure errors, and recording every failure for the
+``oss_fallback`` metric.
+
+Gated by ``settings.fallback_enabled`` (default off): when disabled, callers keep
+their existing code path, so merging this changes nothing until it is flipped on.
+
+Streaming core-chat fallback (``stream_with_fallback``, first-token commit) is a
+later increment and intentionally not implemented here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Awaitable, Callable, Optional
+
+from app.config import settings
+from agents.models import (
+    LLM_MODEL,
+    LLM_MODEL_NAME,
+    LLM_PROVIDER,
+    OSS_INFERENCE_ENDPOINT_URL,
+    OSS_LLM_MODEL,
+    OSS_LLM_MODEL_NAME,
+    oss_model_available,
+)
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Optional Sentry breadcrumbs — best-effort, never a hard dependency.
+try:  # pragma: no cover - import guard
+    import sentry_sdk as _sentry
+except Exception:  # pragma: no cover
+    _sentry = None
+
+# Optional Langfuse trace tagging — best-effort.
+try:  # pragma: no cover - import guard
+    from langfuse import get_client as _get_langfuse_client
+except Exception:  # pragma: no cover
+    _get_langfuse_client = None
+
+
+class FallbackReason(str, Enum):
+    """Why an OSS attempt failed. Drives the ``oss_fallback`` rate, sliced by
+    pipeline x reason x endpoint — the lever to reduce fallbacks over time."""
+
+    TIMEOUT = "timeout"            # asyncio/HTTP read timeout
+    CONNECTION = "connection"      # connect refused / DNS / reset
+    HTTP_5XX = "http_5xx"          # vLLM server error
+    RATE_LIMITED = "rate_limited"  # 429 / queue full
+    OOM = "oom"                    # 5xx whose body marks CUDA OOM
+    BAD_OUTPUT = "bad_output"      # schema/validation exhausted (pydantic-ai) — NOT fallbackable
+    CANCELLED = "cancelled"        # caller hung up — NOT fallbackable
+    UNKNOWN = "unknown"
+
+
+# We fall back on infrastructure failures only. ``bad_output`` stays on the same
+# model (pydantic-ai already retries it; once exhausted it is a model-quality
+# problem to fix, not mask) and ``cancelled`` means the caller is gone.
+FALLBACKABLE = {
+    FallbackReason.TIMEOUT,
+    FallbackReason.CONNECTION,
+    FallbackReason.HTTP_5XX,
+    FallbackReason.RATE_LIMITED,
+    FallbackReason.OOM,
+    FallbackReason.UNKNOWN,
+}
+
+_OOM_MARKERS = ("out of memory", "cuda", "oom", "kv cache", "no available memory")
+
+
+def classify(exc: BaseException) -> FallbackReason:
+    """Map an exception raised by an OSS attempt to a FallbackReason.
+
+    Defensive by design: we inspect status codes, attribute and type names, and
+    message text rather than importing every provider's exception hierarchy, so
+    this keeps working across openai/httpx/aiohttp/pydantic-ai version churn.
+    """
+    if isinstance(exc, asyncio.CancelledError):
+        return FallbackReason.CANCELLED
+
+    name = type(exc).__name__
+    msg = str(exc).lower()
+
+    # Timeouts (asyncio.TimeoutError, httpx.ReadTimeout, openai.APITimeoutError, ...)
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)) or "timeout" in name.lower():
+        return FallbackReason.TIMEOUT
+
+    # HTTP status carried by openai.APIStatusError / httpx responses / pydantic-ai ModelHTTPError.
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        resp = getattr(exc, "response", None)
+        status = getattr(resp, "status_code", None) or getattr(resp, "status", None)
+    if isinstance(status, int):
+        if status == 429:
+            return FallbackReason.RATE_LIMITED
+        if 500 <= status <= 599:
+            if any(m in msg for m in _OOM_MARKERS):
+                return FallbackReason.OOM
+            return FallbackReason.HTTP_5XX
+
+    # Connection-level failures.
+    if isinstance(exc, ConnectionError) or any(
+        tok in name.lower() for tok in ("connect", "connection")
+    ) or "connection" in msg or "refused" in msg:
+        return FallbackReason.CONNECTION
+
+    # pydantic-ai schema/validation exhaustion — explicitly not fallbackable.
+    if any(tok in name for tok in ("UnexpectedModelBehavior", "Validation", "Unexpected")):
+        return FallbackReason.BAD_OUTPUT
+
+    if any(m in msg for m in _OOM_MARKERS):
+        return FallbackReason.OOM
+
+    return FallbackReason.UNKNOWN
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One tier in a fallback chain. Carries the pydantic-ai model object (agent
+    pipelines pass it as ``model=``), telemetry labels, and a per-attempt
+    timeout. ``timeout=None`` means no deadline (used when fallback is disabled)."""
+
+    kind: str                 # "oss" | "managed"
+    model: Any                # pydantic-ai model object
+    model_name: str
+    provider: str             # "vllm" | "openai" | "anthropic"
+    endpoint: str             # OSS endpoint URL, or "managed"
+    timeout: Optional[float]  # seconds
+
+
+def _oss_timeout_for(pipeline: str) -> float:
+    return {
+        "chat": settings.fallback_chat_oss_timeout_ms,
+        "moderation": settings.fallback_moderation_oss_timeout_ms,
+        "pretranslation": settings.fallback_pretranslation_oss_timeout_ms,
+        "suggestions": settings.fallback_suggestions_oss_timeout_ms,
+    }.get(pipeline, settings.fallback_moderation_oss_timeout_ms) / 1000.0
+
+
+def _managed_attempt() -> Attempt:
+    return Attempt(
+        kind="managed",
+        model=LLM_MODEL,
+        model_name=LLM_MODEL_NAME,
+        provider=LLM_PROVIDER,
+        endpoint="managed",
+        timeout=settings.fallback_managed_timeout_ms / 1000.0,
+    )
+
+
+def attempt_chain(variant: str, pipeline: str) -> list[Attempt]:
+    """Ordered tiers for a resolved variant.
+
+    * fallback disabled -> single tier = the variant's own model, no deadline
+      (behaviour identical to today; only used if a caller routes through here).
+    * OSS session with OSS configured -> ``[oss, managed]``.
+    * everything else -> ``[managed]`` (nothing to fall back to).
+    """
+    if not settings.fallback_enabled:
+        # Single tier matching the variant; no fallback, no added deadline.
+        if variant == "oss" and oss_model_available():
+            return [Attempt("oss", OSS_LLM_MODEL, OSS_LLM_MODEL_NAME or "oss",
+                            "vllm", OSS_INFERENCE_ENDPOINT_URL or "oss", None)]
+        return [Attempt("managed", LLM_MODEL, LLM_MODEL_NAME, LLM_PROVIDER, "managed", None)]
+
+    if variant == "oss" and oss_model_available():
+        oss = Attempt(
+            kind="oss",
+            model=OSS_LLM_MODEL,
+            model_name=OSS_LLM_MODEL_NAME or "oss",
+            provider="vllm",
+            endpoint=OSS_INFERENCE_ENDPOINT_URL or "oss",
+            timeout=_oss_timeout_for(pipeline),
+        )
+        return [oss, _managed_attempt()]
+    return [_managed_attempt()]
+
+
+@dataclass
+class FallbackEvent:
+    """Recorded for every classified OSS failure — both fallbacks (``fell_back=True``)
+    and non-fallbackable failures (``fell_back=False``), so dashboards see the full
+    picture, not just the fallbacks."""
+
+    pipeline: str
+    session_id: str
+    from_variant: str
+    to_variant: Optional[str]
+    reason: FallbackReason
+    error_class: str
+    error_detail: str
+    oss_endpoint: str
+    oss_model: str
+    latency_ms: int
+    fell_back: bool
+    committed: bool = False
+
+
+def emit(event: FallbackEvent) -> None:
+    """Record a fallback event.
+
+    Canonical sink is a structured log line (always available, greppable, and the
+    source for the ``oss_fallback`` rate metric). Langfuse trace-tagging and a
+    Sentry breadcrumb are added best-effort. NOTE: this intentionally does not use
+    the canonical telemetry queue — that pipeline is for farmer Q&A analytics, not
+    ops metrics; revisit if a fallback event type is added there."""
+    logger.warning(
+        "oss_fallback pipeline=%s reason=%s fell_back=%s from=%s to=%s "
+        "endpoint=%s model=%s latency_ms=%s error_class=%s committed=%s session=%s detail=%s",
+        event.pipeline,
+        event.reason.value,
+        event.fell_back,
+        event.from_variant,
+        event.to_variant,
+        event.oss_endpoint,
+        event.oss_model,
+        event.latency_ms,
+        event.error_class,
+        event.committed,
+        event.session_id,
+        event.error_detail,
+    )
+
+    if _sentry is not None:
+        try:  # pragma: no cover - best effort
+            _sentry.add_breadcrumb(
+                category="oss_fallback",
+                level="warning",
+                message=f"{event.pipeline} {event.reason.value} fell_back={event.fell_back}",
+                data={
+                    "pipeline": event.pipeline,
+                    "reason": event.reason.value,
+                    "endpoint": event.oss_endpoint,
+                    "error_class": event.error_class,
+                    "latency_ms": event.latency_ms,
+                },
+            )
+        except Exception:
+            pass
+
+    if _get_langfuse_client is not None:
+        try:  # pragma: no cover - best effort
+            client = _get_langfuse_client()
+            if client is not None:
+                client.update_current_trace(
+                    tags=[f"oss_fallback:{event.pipeline}:{event.reason.value}"],
+                    metadata={
+                        "oss_fallback": {
+                            "pipeline": event.pipeline,
+                            "reason": event.reason.value,
+                            "fell_back": event.fell_back,
+                            "endpoint": event.oss_endpoint,
+                            "model": event.oss_model,
+                            "latency_ms": event.latency_ms,
+                        }
+                    },
+                )
+        except Exception:
+            pass
+
+
+async def execute_with_fallback(
+    *,
+    pipeline: str,
+    session_id: str,
+    variant: str,
+    run: Callable[[Attempt], Awaitable[Any]],
+) -> Any:
+    """Run ``run(attempt)`` against each tier of the chain, falling back on a
+    classified infrastructure failure and recording every failure via ``emit``.
+
+    ``run`` receives the active :class:`Attempt` and returns the awaitable for that
+    tier (e.g. ``agent.run(..., model=attempt.model)``). Returns whatever ``run``
+    returns. Re-raises when the failure is non-fallbackable or the chain is
+    exhausted, so the caller's existing degrade path (moderation fail-closed,
+    pretranslation safe-default, suggestions ``[]``) stays the terminal net.
+    """
+    chain = attempt_chain(variant, pipeline)
+    for i, attempt in enumerate(chain):
+        t0 = time.monotonic()
+        try:
+            if attempt.timeout is None:
+                return await run(attempt)
+            return await asyncio.wait_for(run(attempt), attempt.timeout)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            reason = classify(exc)
+            is_last = i == len(chain) - 1
+            will_fall_back = reason in FALLBACKABLE and not is_last
+            emit(
+                FallbackEvent(
+                    pipeline=pipeline,
+                    session_id=session_id,
+                    from_variant=attempt.kind,
+                    to_variant=chain[i + 1].kind if will_fall_back else None,
+                    reason=reason,
+                    error_class=type(exc).__name__,
+                    error_detail=str(exc)[:500],
+                    oss_endpoint=attempt.endpoint,
+                    oss_model=attempt.model_name,
+                    latency_ms=int((time.monotonic() - t0) * 1000),
+                    fell_back=will_fall_back,
+                )
+            )
+            if not will_fall_back:
+                raise

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -20,7 +20,7 @@ import asyncio
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 from app.config import settings
 from agents.models import (
@@ -315,3 +315,116 @@ async def execute_with_fallback(
             )
             if not will_fall_back:
                 raise
+
+
+async def _aclose(agen) -> None:
+    close = getattr(agen, "aclose", None)
+    if close is not None:
+        try:  # pragma: no cover - best effort cleanup
+            await close()
+        except Exception:
+            pass
+
+
+async def stream_with_fallback(
+    *,
+    pipeline: str,
+    session_id: str,
+    variant: str,
+    make_stream: Callable[[Attempt], AsyncIterator[Any]],
+) -> AsyncIterator[Any]:
+    """Stream a chain tier with *first-token commit* semantics.
+
+    ``make_stream(attempt)`` returns an async iterator of chunks (e.g. English
+    text deltas from an agent run on ``attempt.model``). The first yielded chunk
+    is the **commit point**:
+
+    * Failure BEFORE the first chunk, on a fallbackable reason and not the last
+      tier -> silently swap to the next tier (the client has seen nothing).
+    * Failure before the first chunk that is non-fallbackable or on the last tier
+      -> re-raise (no tokens sent; caller handles it as today).
+    * Failure AFTER the first chunk -> the client already has partial output, so a
+      transparent swap is impossible; the exception propagates (no worse than
+      today). The per-attempt timeout therefore bounds time-to-first-token only.
+
+    Every classified failure is recorded via ``emit`` (``committed`` distinguishes
+    pre- from post-commit).
+    """
+    chain = attempt_chain(variant, pipeline)
+    last_exc: Optional[BaseException] = None
+    for i, attempt in enumerate(chain):
+        t0 = time.monotonic()
+        agen = make_stream(attempt).__aiter__()
+
+        # ── first chunk (commit point), bounded by the per-attempt deadline ──
+        try:
+            if attempt.timeout is None:
+                first = await agen.__anext__()
+            else:
+                first = await asyncio.wait_for(agen.__anext__(), attempt.timeout)
+        except StopAsyncIteration:
+            await _aclose(agen)
+            return  # empty but successful stream
+        except asyncio.CancelledError:
+            await _aclose(agen)
+            raise
+        except Exception as exc:
+            await _aclose(agen)
+            reason = classify(exc)
+            is_last = i == len(chain) - 1
+            will_fall_back = reason in FALLBACKABLE and not is_last
+            emit(
+                FallbackEvent(
+                    pipeline=pipeline,
+                    session_id=session_id,
+                    from_variant=attempt.kind,
+                    to_variant=chain[i + 1].kind if will_fall_back else None,
+                    reason=reason,
+                    error_class=type(exc).__name__,
+                    error_detail=str(exc)[:500],
+                    oss_endpoint=attempt.endpoint,
+                    oss_model=attempt.model_name,
+                    latency_ms=int((time.monotonic() - t0) * 1000),
+                    fell_back=will_fall_back,
+                    committed=False,
+                )
+            )
+            last_exc = exc
+            if will_fall_back:
+                continue
+            raise
+
+        # ── committed: client now receives this tier's output ──
+        yield first
+        try:
+            async for chunk in agen:
+                yield chunk
+        except asyncio.CancelledError:
+            await _aclose(agen)
+            raise
+        except Exception as exc:
+            await _aclose(agen)
+            emit(
+                FallbackEvent(
+                    pipeline=pipeline,
+                    session_id=session_id,
+                    from_variant=attempt.kind,
+                    to_variant=None,
+                    reason=classify(exc),
+                    error_class=type(exc).__name__,
+                    error_detail=str(exc)[:500],
+                    oss_endpoint=attempt.endpoint,
+                    oss_model=attempt.model_name,
+                    latency_ms=int((time.monotonic() - t0) * 1000),
+                    fell_back=False,
+                    committed=True,
+                )
+            )
+            raise
+        else:
+            await _aclose(agen)
+        return
+
+    # All tiers failed before commit.
+    if last_exc is not None:
+        raise last_exc

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import asyncio
 import time
+
+import anyio
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
@@ -291,7 +293,8 @@ async def execute_with_fallback(
         try:
             if attempt.timeout is None:
                 return await run(attempt)
-            return await asyncio.wait_for(run(attempt), attempt.timeout)
+            with anyio.fail_after(attempt.timeout):
+                return await run(attempt)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -354,24 +357,45 @@ async def stream_with_fallback(
     last_exc: Optional[BaseException] = None
     for i, attempt in enumerate(chain):
         t0 = time.monotonic()
-        agen = make_stream(attempt).__aiter__()
+        committed = False
 
-        # ── first chunk (commit point), bounded by the per-attempt deadline ──
+        # IMPORTANT: consume the agent generator with a plain `async for`. Do NOT
+        # wrap it in asyncio.wait_for / anyio.fail_after / a separate task —
+        # pydantic-ai's run_stream opens an anyio cancel scope *inside* make_stream
+        # that stays open across the `yield`, so any external timeout/task wrapper
+        # unwinds the scopes out of order ("cancel scope in a different task" /
+        # "not the current task's cancel scope"). `async for` lets Python manage the
+        # generator lifecycle in this task. A first-token deadline, if wanted, is
+        # applied INSIDE make_stream (same frame as run_stream).
         try:
-            if attempt.timeout is None:
-                first = await agen.__anext__()
-            else:
-                first = await asyncio.wait_for(agen.__anext__(), attempt.timeout)
-        except StopAsyncIteration:
-            await _aclose(agen)
-            return  # empty but successful stream
+            async for chunk in make_stream(attempt):
+                committed = True
+                yield chunk
+            return  # stream finished cleanly
         except asyncio.CancelledError:
-            await _aclose(agen)
             raise
         except Exception as exc:
-            await _aclose(agen)
             reason = classify(exc)
             is_last = i == len(chain) - 1
+            if committed:
+                # Client already received output — a transparent swap is impossible.
+                emit(
+                    FallbackEvent(
+                        pipeline=pipeline,
+                        session_id=session_id,
+                        from_variant=attempt.kind,
+                        to_variant=None,
+                        reason=reason,
+                        error_class=type(exc).__name__,
+                        error_detail=str(exc)[:500],
+                        oss_endpoint=attempt.endpoint,
+                        oss_model=attempt.model_name,
+                        latency_ms=int((time.monotonic() - t0) * 1000),
+                        fell_back=False,
+                        committed=True,
+                    )
+                )
+                raise
             will_fall_back = reason in FALLBACKABLE and not is_last
             emit(
                 FallbackEvent(
@@ -394,35 +418,8 @@ async def stream_with_fallback(
                 continue
             raise
 
-        # ── committed: client now receives this tier's output ──
-        yield first
-        try:
-            async for chunk in agen:
-                yield chunk
-        except asyncio.CancelledError:
-            await _aclose(agen)
-            raise
-        except Exception as exc:
-            await _aclose(agen)
-            emit(
-                FallbackEvent(
-                    pipeline=pipeline,
-                    session_id=session_id,
-                    from_variant=attempt.kind,
-                    to_variant=None,
-                    reason=classify(exc),
-                    error_class=type(exc).__name__,
-                    error_detail=str(exc)[:500],
-                    oss_endpoint=attempt.endpoint,
-                    oss_model=attempt.model_name,
-                    latency_ms=int((time.monotonic() - t0) * 1000),
-                    fell_back=False,
-                    committed=True,
-                )
-            )
-            raise
-        else:
-            await _aclose(agen)
+    if last_exc is not None:
+        raise last_exc
         return
 
     # All tiers failed before commit.

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -19,6 +19,7 @@ from typing import Literal, Optional
 from openai import AsyncOpenAI
 
 from app.config import settings
+from app.services.fallback import execute_with_fallback
 from app.services.translation import (
     OPENAI_PRETRANSLATION_MODEL,
     OSS_PRETRANSLATION_MODEL,
@@ -37,11 +38,14 @@ ModerationCategory = Literal[
     "offensive",
     "cultural_sensitivity",
     "aberration",
+    # Internal-only: not a model output. Marks a fail-CLOSED verdict (the
+    # moderation gate could not produce a trustworthy result on any tier).
+    "unavailable",
 ]
 
 
 REJECT_CATEGORIES: frozenset[str] = frozenset(
-    {"irrelevant", "offensive", "cultural_sensitivity", "aberration"}
+    {"irrelevant", "offensive", "cultural_sensitivity", "aberration", "unavailable"}
 )
 
 
@@ -62,6 +66,10 @@ DECLINE_MESSAGES_EN: dict[str, str] = {
         "This helpline only handles dairy farming and animal husbandry questions. "
         "For other matters, please contact the appropriate service."
     ),
+    "unavailable": (
+        "I'm having trouble processing your request right now. "
+        "Please try again in a moment."
+    ),
 }
 
 
@@ -77,10 +85,19 @@ _MODERATION_PROVIDER = (os.getenv("VOICE_MODERATION_PROVIDER", "vllm") or "vllm"
 
 
 def _moderation_client_and_model() -> tuple[AsyncOpenAI, str, str]:
-    """Return (client, model, provider_label) for the configured moderation backend."""
+    """Return (client, model, provider_label) for the configured moderation backend
+    (legacy path: single global VOICE_MODERATION_PROVIDER)."""
     if _MODERATION_PROVIDER == "openai":
         return _get_openai_client(), OPENAI_PRETRANSLATION_MODEL, "openai"
     return _get_oss_pretranslation_client(), OSS_PRETRANSLATION_MODEL, "vllm"
+
+
+def _client_model_for_kind(kind: str) -> tuple[AsyncOpenAI, str, str]:
+    """Return (client, model, provider_label) for one fallback-chain attempt:
+    'oss' -> self-hosted vLLM, anything else -> managed OpenAI."""
+    if kind == "oss":
+        return _get_oss_pretranslation_client(), OSS_PRETRANSLATION_MODEL, "vllm"
+    return _get_openai_client(), OPENAI_PRETRANSLATION_MODEL, "openai"
 
 
 @dataclass(frozen=True)
@@ -89,6 +106,7 @@ class ModerationVerdict:
     reason: str
     raw_output: Optional[str] = None
     failed_open: bool = False
+    failed_closed: bool = False
 
     @property
     def rejected(self) -> bool:
@@ -104,6 +122,17 @@ def _allow(reason: str, *, raw_output: Optional[str] = None, failed_open: bool =
         reason=reason,
         raw_output=raw_output,
         failed_open=failed_open,
+    )
+
+
+def _block_unavailable(reason: str, *, raw_output: Optional[str] = None) -> ModerationVerdict:
+    """Fail-CLOSED verdict: blocks the turn with a generic 'try again' decline
+    when moderation can't produce a trustworthy result."""
+    return ModerationVerdict(
+        category="unavailable",
+        reason=reason,
+        raw_output=raw_output,
+        failed_closed=True,
     )
 
 
@@ -135,6 +164,37 @@ def _parse_verdict(raw: str) -> ModerationVerdict:
             stripped[:200],
         )
         return _allow(f"unknown category: {category}", raw_output=raw, failed_open=True)
+
+    return ModerationVerdict(category=category, reason=reason, raw_output=raw)  # type: ignore[arg-type]
+
+
+def _parse_verdict_strict(raw: str) -> ModerationVerdict:
+    """Like _parse_verdict but fails CLOSED on malformed/untrustworthy output
+    (returns an `unavailable` reject) instead of failing open. Valid verdicts —
+    including reject categories — are returned unchanged. Used on the
+    fallback-enabled path so a garbage response blocks rather than waves through."""
+    stripped = (raw or "").strip()
+    if not stripped:
+        logger.warning("Moderation returned empty output; failing closed")
+        return _block_unavailable("empty model output", raw_output=raw)
+
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        logger.warning("Moderation returned non-JSON output; failing closed - raw=%r", stripped[:200])
+        return _block_unavailable("non-json model output", raw_output=raw)
+
+    if not isinstance(data, dict):
+        logger.warning("Moderation returned non-object JSON; failing closed - raw=%r", stripped[:200])
+        return _block_unavailable("non-object model output", raw_output=raw)
+
+    category = (data.get("category") or "").strip().lower()
+    reason = (data.get("reason") or "").strip()[:200]
+
+    valid = {"in_scope", "irrelevant", "offensive", "cultural_sensitivity", "aberration"}
+    if category not in valid:
+        logger.warning("Moderation returned unknown category=%r; failing closed - raw=%r", category, stripped[:200])
+        return _block_unavailable(f"unknown category: {category}", raw_output=raw)
 
     return ModerationVerdict(category=category, reason=reason, raw_output=raw)  # type: ignore[arg-type]
 
@@ -177,16 +237,57 @@ async def check_moderation(
     text: str,
     source_lang: str,
     recent_history_text: str = "",
+    variant: str = "legacy",
+    session_id: str = "",
 ) -> ModerationVerdict:
     """Classify a caller utterance. Returns a ModerationVerdict.
 
-    Fails open on any error — the returned verdict will have
-    `category == "in_scope"` and `failed_open == True` so the caller can
-    still log the failure but will not block the farmer.
+    With ``settings.fallback_enabled`` (standard path): route by the session
+    *variant* (OSS for OSS sessions, managed for legacy) through the OSS->managed
+    fallback chain, and **fail CLOSED** — return an ``unavailable`` reject when no
+    tier produces a trustworthy verdict. Mirrors amul-oan-api moderation. Failing
+    closed only triggers when both OSS and managed fail, so it does not drop calls
+    on a single-provider blip.
+
+    Without it (legacy path): a single global provider
+    (``VOICE_MODERATION_PROVIDER``) and **fail OPEN** — today's behaviour, so the
+    kill-switch reverts exactly.
     """
     if not text or not text.strip():
         return _allow("empty input", failed_open=False)
 
+    if not settings.fallback_enabled:
+        return await _check_moderation_legacy(text, source_lang, recent_history_text)
+
+    async def _run(attempt):
+        client, model, _provider = _client_model_for_kind(attempt.kind)
+        response = await _create_moderation_response(client, model, text, source_lang, recent_history_text)
+        raw = (response.choices[0].message.content or "").strip()
+        return _parse_verdict_strict(raw)
+
+    try:
+        return await execute_with_fallback(
+            pipeline="moderation",
+            session_id=session_id or "",
+            variant=variant,
+            run=_run,
+        )
+    except Exception as e:
+        logger.error(
+            "Moderation failed on all tiers; failing closed - source_lang=%s error=%s",
+            source_lang,
+            type(e).__name__,
+        )
+        return _block_unavailable(f"moderation unavailable: {type(e).__name__}")
+
+
+async def _check_moderation_legacy(
+    text: str,
+    source_lang: str,
+    recent_history_text: str = "",
+) -> ModerationVerdict:
+    """Legacy moderation: single global provider (VOICE_MODERATION_PROVIDER),
+    fails OPEN. Used when ``settings.fallback_enabled`` is false."""
     try:
         client, model, provider = _moderation_client_and_model()
     except Exception as e:

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1844,10 +1844,10 @@ async def stream_voice_message(
 
 
                 if settings.fallback_enabled:
-                    # OSS -> managed first-token commit. Eager-start the agent as a task so
-                    # it runs in parallel with the moderation gate (latency preserved). On a
-                    # pre-first-token OSS failure we silently swap to managed; a post-first-
-                    # token failure can't swap (caller already heard audio) -> canned line.
+                    # OSS -> managed first-token commit. A pre-first-token OSS failure
+                    # silently swaps to managed; a post-first-token failure can't swap
+                    # (caller already heard audio) -> canned line. The agent stream is
+                    # driven from a single task (see below) for anyio task-affinity.
                     _fb_holder: dict = {}
 
                     async def _make_stream(attempt):
@@ -1868,16 +1868,25 @@ async def stream_voice_message(
                         variant=pipeline_variant,
                         make_stream=_make_stream,
                     ).__aiter__()
-                    # Eager start: kick the first-token pull now, concurrent with moderation.
-                    _first_pull = asyncio.create_task(_src.__anext__())
 
+                    # Pull the first token in THIS task — pydantic-ai's anyio stream
+                    # must be advanced from a single task (a separate create_task would
+                    # cross task boundaries and break its cancel scope). Parallelism is
+                    # preserved because the moderation check is already running on its
+                    # own background task (moderation_task), overlapping the agent.
+                    _NO_FIRST = object()
+                    _first_chunk = _NO_FIRST
+                    _stream_error = None
+                    try:
+                        _first_chunk = await _src.__anext__()
+                    except StopAsyncIteration:
+                        _first_chunk = _NO_FIRST  # empty stream (no tokens), not an error
+                    except Exception as _e:  # pre-first-token: OSS + managed both failed
+                        _stream_error = _e
+
+                    # Moderation gate — resolve before emitting anything to the caller.
                     _verdict = await _resolve_moderation()
                     if _verdict is not None and _verdict.rejected:
-                        _first_pull.cancel()
-                        try:
-                            await _first_pull
-                        except BaseException:
-                            pass
                         try:
                             await _src.aclose()
                         except Exception:
@@ -1887,30 +1896,39 @@ async def stream_voice_message(
                                 yield _c
                         return
 
-                    async def _committed_stream():
-                        try:
-                            _first = await _first_pull
-                        except StopAsyncIteration:
-                            return
-                        yield _first
-                        async for _c in _src:
-                            yield _c
-
-                    try:
-                        async for _out in _consume_agent_text(_committed_stream()):
-                            yield _out
-                    except Exception as _stream_err:
+                    if _stream_error is not None:
                         logger.error(
-                            "Voice agent stream failed after first token; session_id=%s process_id=%s error=%s",
-                            session_id, process_id, _stream_err,
+                            "Voice agent stream failed before first token; session_id=%s process_id=%s error=%s",
+                            session_id, process_id, _stream_error,
                         )
                         if not await _request_is_stale("after_stream_error"):
                             _trouble = TRANSLATION_TROUBLE_MESSAGE.get(
                                 requested_target_lang, TRANSLATION_TROUBLE_MESSAGE["en"],
                             )
                             yield _emit(_trouble)
-                    _agent_output = _agent_output.strip()
-                    new_messages = _fb_holder.get("new_messages", [])
+                        new_messages = _fb_holder.get("new_messages", [])
+                    else:
+                        async def _committed_stream():
+                            if _first_chunk is not _NO_FIRST:
+                                yield _first_chunk
+                            async for _c in _src:
+                                yield _c
+
+                        try:
+                            async for _out in _consume_agent_text(_committed_stream()):
+                                yield _out
+                        except Exception as _post_err:
+                            logger.error(
+                                "Voice agent stream failed after first token; session_id=%s process_id=%s error=%s",
+                                session_id, process_id, _post_err,
+                            )
+                            if not await _request_is_stale("after_stream_error"):
+                                _trouble = TRANSLATION_TROUBLE_MESSAGE.get(
+                                    requested_target_lang, TRANSLATION_TROUBLE_MESSAGE["en"],
+                                )
+                                yield _emit(_trouble)
+                        _agent_output = _agent_output.strip()
+                        new_messages = _fb_holder.get("new_messages", [])
                 else:
                     async with active_agent.run_stream(
                         user_prompt=user_message,

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1233,6 +1233,8 @@ async def stream_voice_message(
                     text=query,
                     source_lang=requested_source_lang,
                     recent_history_text=moderation_recent_history,
+                    variant=pipeline_variant,
+                    session_id=session_id,
                 )
             )
             moderation_task.add_done_callback(

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -55,7 +55,7 @@ from app.services.stt_signals import (
     count_consecutive_stt_signals,
 )
 from app.services.moderation import ModerationVerdict, check_moderation
-from app.services.fallback import execute_with_fallback
+from app.services.fallback import execute_with_fallback, stream_with_fallback
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
@@ -1621,74 +1621,55 @@ async def stream_voice_message(
                 # translation overlap instead of running strictly back-to-back.
                 agent_started_at = time.monotonic()
                 _agent_output = ""
-                async with active_agent.run_stream(
-                    user_prompt=user_message,
-                    message_history=model_input_history,
-                    deps=deps,
-                    usage_limits=usage_limits,
-                    model=request_model,
-                ) as response_stream:
-                    # debounce_by=0 disables pydantic-ai's default 100ms token
-                    # debounce so the first agent delta reaches the translation
-                    # stage immediately (every ms counts for phone TTFT). Our own
-                    # sentence batching downstream re-aggregates the smaller chunks.
-                    stream_iter = response_stream.stream_text(delta=True, debounce_by=0)
-                    first_text_chunk_received = False
-                    sentence_buffer = ""
-                    translation_batch: list[str] = []
-                    batch_word_count = 0
-                    async def _yield_translated_text(text_to_translate: str) -> AsyncGenerator[str, None]:
-                        if not text_to_translate:
-                            return
-                        text_to_translate = _guard_identity_drift(text_to_translate)
-                        try:
-                            with trace.stage(
-                                "output_translation",
-                                as_type="generation",
-                                input={"chars": len(text_to_translate)},
-                                metadata={"target_lang": requested_target_lang},
-                            ):
-                                async for chunk in translate_text_stream_fast(
-                                    text=text_to_translate,
-                                    source_lang="english",
-                                    target_lang=requested_target_lang,
-                                ):
-                                    if await _request_is_stale("during_output_translation"):
-                                        return
-                                    cleaned = (
-                                        _prepare_voice_output(chunk, requested_target_lang)
-                                        if isinstance(chunk, str) and chunk
-                                        else chunk
-                                    )
-                                    if isinstance(cleaned, str) and cleaned.strip():
-                                        trace.mark("first_translation_chunk_ms")
-                                    yield cleaned
-                        except Exception as e:
-                            trace.increment("output_translation_errors")
-                            logger.error(
-                                "Translation pipeline output translation failed for session_id=%s error=%s",
-                                session_id,
-                                e,
-                            )
-                            trouble = TRANSLATION_TROUBLE_MESSAGE.get(
-                                requested_target_lang,
-                                TRANSLATION_TROUBLE_MESSAGE["en"],
-                            )
-                            yield trouble
+                first_text_chunk_received = False
+                sentence_buffer = ""
+                translation_batch: list[str] = []
+                batch_word_count = 0
 
-                    # Deferred moderation gate: resolve the concurrently-running
-                    # verdict now, before emitting ANY caller-facing chunk. The
-                    # agent has already done its prefill/tool calls (booking tools
-                    # self-gated on this verdict); if the query was rejected we
-                    # decline here and the agent's streamed output is discarded,
-                    # never reaching the caller.
-                    _verdict = await _resolve_moderation()
-                    if _verdict is not None and _verdict.rejected:
-                        if not await _request_is_stale("after_moderation_reject"):
-                            async for _c in _moderation_decline_stream(_verdict):
-                                yield _c
+                async def _yield_translated_text(text_to_translate: str) -> AsyncGenerator[str, None]:
+                    if not text_to_translate:
                         return
+                    text_to_translate = _guard_identity_drift(text_to_translate)
+                    try:
+                        with trace.stage(
+                            "output_translation",
+                            as_type="generation",
+                            input={"chars": len(text_to_translate)},
+                            metadata={"target_lang": requested_target_lang},
+                        ):
+                            async for chunk in translate_text_stream_fast(
+                                text=text_to_translate,
+                                source_lang="english",
+                                target_lang=requested_target_lang,
+                            ):
+                                if await _request_is_stale("during_output_translation"):
+                                    return
+                                cleaned = (
+                                    _prepare_voice_output(chunk, requested_target_lang)
+                                    if isinstance(chunk, str) and chunk
+                                    else chunk
+                                )
+                                if isinstance(cleaned, str) and cleaned.strip():
+                                    trace.mark("first_translation_chunk_ms")
+                                yield cleaned
+                    except Exception as e:
+                        trace.increment("output_translation_errors")
+                        logger.error(
+                            "Translation pipeline output translation failed for session_id=%s error=%s",
+                            session_id,
+                            e,
+                        )
+                        trouble = TRANSLATION_TROUBLE_MESSAGE.get(
+                            requested_target_lang,
+                            TRANSLATION_TROUBLE_MESSAGE["en"],
+                        )
+                        yield trouble
 
+
+                # Token consumer (nudge / staleness / batch-translation) — shared by both
+                # the fallback and legacy source paths so the proven loop isn't duplicated.
+                async def _consume_agent_text(stream_iter):
+                    nonlocal _agent_output, first_text_chunk_received, sentence_buffer, translation_batch, batch_word_count
                     try:
                         async for chunk in stream_iter:
                             if await _request_is_stale("during_agent_stream"):
@@ -1861,23 +1842,109 @@ async def stream_voice_message(
                             except asyncio.CancelledError:
                                 pass
 
-                    logger.info(f"Streaming complete for session {session_id}")
+
+                if settings.fallback_enabled:
+                    # OSS -> managed first-token commit. Eager-start the agent as a task so
+                    # it runs in parallel with the moderation gate (latency preserved). On a
+                    # pre-first-token OSS failure we silently swap to managed; a post-first-
+                    # token failure can't swap (caller already heard audio) -> canned line.
+                    _fb_holder: dict = {}
+
+                    async def _make_stream(attempt):
+                        async with active_agent.run_stream(
+                            user_prompt=user_message,
+                            message_history=model_input_history,
+                            deps=deps,
+                            usage_limits=usage_limits,
+                            model=attempt.model,
+                        ) as rs:
+                            async for _c in rs.stream_text(delta=True, debounce_by=0):
+                                yield _c
+                            _fb_holder["new_messages"] = rs.new_messages()
+
+                    _src = stream_with_fallback(
+                        pipeline="chat",
+                        session_id=session_id,
+                        variant=pipeline_variant,
+                        make_stream=_make_stream,
+                    ).__aiter__()
+                    # Eager start: kick the first-token pull now, concurrent with moderation.
+                    _first_pull = asyncio.create_task(_src.__anext__())
+
+                    _verdict = await _resolve_moderation()
+                    if _verdict is not None and _verdict.rejected:
+                        _first_pull.cancel()
+                        try:
+                            await _first_pull
+                        except BaseException:
+                            pass
+                        try:
+                            await _src.aclose()
+                        except Exception:
+                            pass
+                        if not await _request_is_stale("after_moderation_reject"):
+                            async for _c in _moderation_decline_stream(_verdict):
+                                yield _c
+                        return
+
+                    async def _committed_stream():
+                        try:
+                            _first = await _first_pull
+                        except StopAsyncIteration:
+                            return
+                        yield _first
+                        async for _c in _src:
+                            yield _c
+
+                    try:
+                        async for _out in _consume_agent_text(_committed_stream()):
+                            yield _out
+                    except Exception as _stream_err:
+                        logger.error(
+                            "Voice agent stream failed after first token; session_id=%s process_id=%s error=%s",
+                            session_id, process_id, _stream_err,
+                        )
+                        if not await _request_is_stale("after_stream_error"):
+                            _trouble = TRANSLATION_TROUBLE_MESSAGE.get(
+                                requested_target_lang, TRANSLATION_TROUBLE_MESSAGE["en"],
+                            )
+                            yield _emit(_trouble)
                     _agent_output = _agent_output.strip()
-                    new_messages = response_stream.new_messages()
-                    trace.attach_stage_timing(
-                        "agent",
-                        (time.monotonic() - agent_started_at) * 1000.0,
-                        signed_in=bool(signed_in and mobile),
-                        request_limit=usage_limits.request_limit,
-                        pipeline_variant=pipeline_variant,
-                        model=request_model_name,
-                        provider=request_provider,
-                    )
-                    trace.set_agent(
-                        signed_in=bool(signed_in and mobile),
-                        output=_agent_output,
-                        new_messages=new_messages,
-                    )
+                    new_messages = _fb_holder.get("new_messages", [])
+                else:
+                    async with active_agent.run_stream(
+                        user_prompt=user_message,
+                        message_history=model_input_history,
+                        deps=deps,
+                        usage_limits=usage_limits,
+                        model=request_model,
+                    ) as response_stream:
+                        stream_iter = response_stream.stream_text(delta=True, debounce_by=0)
+                        _verdict = await _resolve_moderation()
+                        if _verdict is not None and _verdict.rejected:
+                            if not await _request_is_stale("after_moderation_reject"):
+                                async for _c in _moderation_decline_stream(_verdict):
+                                    yield _c
+                            return
+                        async for _out in _consume_agent_text(stream_iter):
+                            yield _out
+                        _agent_output = _agent_output.strip()
+                        new_messages = response_stream.new_messages()
+
+                trace.attach_stage_timing(
+                    "agent",
+                    (time.monotonic() - agent_started_at) * 1000.0,
+                    signed_in=bool(signed_in and mobile),
+                    request_limit=usage_limits.request_limit,
+                    pipeline_variant=pipeline_variant,
+                    model=request_model_name,
+                    provider=request_provider,
+                )
+                trace.set_agent(
+                    signed_in=bool(signed_in and mobile),
+                    output=_agent_output,
+                    new_messages=new_messages,
+                )
 
             # If the LLM called signal_conversation_state("conversation_closing"),
             # append the termination token so RAYA disconnects the call.

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -55,6 +55,7 @@ from app.services.stt_signals import (
     count_consecutive_stt_signals,
 )
 from app.services.moderation import ModerationVerdict, check_moderation
+from app.services.fallback import execute_with_fallback
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
@@ -1250,65 +1251,50 @@ async def stream_voice_message(
                 if await _request_is_stale("before_query_pretranslation"):
                     moderation_task.cancel()
                     return
-                try:
-                    with trace.stage(
-                        "pretranslation",
-                        as_type="generation",
-                        input=trace.metadata.get("query"),
-                        metadata={
-                            "provider": _pretrans_provider_label,
-                            "source_lang": requested_source_lang,
-                            "pipeline_variant": pipeline_variant,
-                        },
-                        model=_pretrans_model,
-                    ):
-                        if is_oss:
-                            processing_query = await translate_to_english_with_oss_vllm(
-                                text=query,
-                                source_lang=requested_source_lang,
-                            )
-                        else:
-                            processing_query = await translate_to_english_with_gpt5_mini(
-                                text=query,
-                                source_lang=requested_source_lang,
-                            )
-                    trace.set_pretranslation(
-                        text=processing_query,
-                        provider=_pretrans_provider_label,
-                        fallback_used=False,
-                    )
-                    history_user_text = processing_query or _canonical_history_user_text("low_confidence")
-                except Exception as e:
-                    logger.error(
-                        "OpenAI pretranslation failed for session_id=%s source_lang=%s model=%s error=%s",
-                        session_id,
-                        requested_source_lang,
-                        OPENAI_PRETRANSLATION_MODEL,
-                        e,
-                    )
+                if settings.fallback_enabled:
+                    # Standard OSS -> managed fallback. Drops the legacy TranslateGemma
+                    # stopgap (decision #7): TranslateGemma is also self-hosted vLLM, so
+                    # it shared a failure domain with the OSS pretranslation it backed up.
+                    # The managed tier is the OpenAI pretranslation (translate_to_english_with_gpt5_mini),
+                    # which was the pre-OSS primary.
                     try:
-                        logger.info("Falling back to TranslateGemma pretranslation for session_id=%s", session_id)
                         with trace.stage(
-                            "pretranslation_fallback",
+                            "pretranslation",
                             as_type="generation",
                             input=trace.metadata.get("query"),
-                            metadata={"provider": "translategemma", "source_lang": requested_source_lang},
+                            metadata={
+                                "provider": _pretrans_provider_label,
+                                "source_lang": requested_source_lang,
+                                "pipeline_variant": pipeline_variant,
+                            },
+                            model=_pretrans_model,
                         ):
-                            processing_query = await translate_to_english_with_structured_fallback(
-                                text=query,
-                                source_lang=requested_source_lang,
+                            processing_query = await execute_with_fallback(
+                                pipeline="pretranslation",
+                                session_id=session_id,
+                                variant=pipeline_variant,
+                                run=lambda a: (
+                                    translate_to_english_with_oss_vllm(
+                                        text=query, source_lang=requested_source_lang
+                                    )
+                                    if a.kind == "oss"
+                                    else translate_to_english_with_gpt5_mini(
+                                        text=query, source_lang=requested_source_lang
+                                    )
+                                ),
                             )
                         trace.set_pretranslation(
                             text=processing_query,
-                            provider="translategemma",
-                            fallback_used=True,
+                            provider=_pretrans_provider_label,
+                            fallback_used=False,
                         )
                         history_user_text = processing_query or _canonical_history_user_text("low_confidence")
-                    except Exception as fallback_error:
+                    except Exception as e:
                         logger.error(
-                            "TranslateGemma pretranslation fallback failed for session_id=%s error=%s",
+                            "pretranslation failed (all tiers) for session_id=%s source_lang=%s error=%s",
                             session_id,
-                            fallback_error,
+                            requested_source_lang,
+                            e,
                         )
                         processing_query = ""
                         trace.set_pretranslation(
@@ -1317,6 +1303,74 @@ async def stream_voice_message(
                             fallback_used=True,
                         )
                         history_user_text = _canonical_history_user_text("pretranslation_failed")
+                else:
+                    try:
+                        with trace.stage(
+                            "pretranslation",
+                            as_type="generation",
+                            input=trace.metadata.get("query"),
+                            metadata={
+                                "provider": _pretrans_provider_label,
+                                "source_lang": requested_source_lang,
+                                "pipeline_variant": pipeline_variant,
+                            },
+                            model=_pretrans_model,
+                        ):
+                            if is_oss:
+                                processing_query = await translate_to_english_with_oss_vllm(
+                                    text=query,
+                                    source_lang=requested_source_lang,
+                                )
+                            else:
+                                processing_query = await translate_to_english_with_gpt5_mini(
+                                    text=query,
+                                    source_lang=requested_source_lang,
+                                )
+                        trace.set_pretranslation(
+                            text=processing_query,
+                            provider=_pretrans_provider_label,
+                            fallback_used=False,
+                        )
+                        history_user_text = processing_query or _canonical_history_user_text("low_confidence")
+                    except Exception as e:
+                        logger.error(
+                            "OpenAI pretranslation failed for session_id=%s source_lang=%s model=%s error=%s",
+                            session_id,
+                            requested_source_lang,
+                            OPENAI_PRETRANSLATION_MODEL,
+                            e,
+                        )
+                        try:
+                            logger.info("Falling back to TranslateGemma pretranslation for session_id=%s", session_id)
+                            with trace.stage(
+                                "pretranslation_fallback",
+                                as_type="generation",
+                                input=trace.metadata.get("query"),
+                                metadata={"provider": "translategemma", "source_lang": requested_source_lang},
+                            ):
+                                processing_query = await translate_to_english_with_structured_fallback(
+                                    text=query,
+                                    source_lang=requested_source_lang,
+                                )
+                            trace.set_pretranslation(
+                                text=processing_query,
+                                provider="translategemma",
+                                fallback_used=True,
+                            )
+                            history_user_text = processing_query or _canonical_history_user_text("low_confidence")
+                        except Exception as fallback_error:
+                            logger.error(
+                                "TranslateGemma pretranslation fallback failed for session_id=%s error=%s",
+                                session_id,
+                                fallback_error,
+                            )
+                            processing_query = ""
+                            trace.set_pretranslation(
+                                text=processing_query,
+                                provider="failed",
+                                fallback_used=True,
+                            )
+                            history_user_text = _canonical_history_user_text("pretranslation_failed")
 
             else:
                 history_user_text = query

--- a/tests/test_booking_idempotency.py
+++ b/tests/test_booking_idempotency.py
@@ -1,0 +1,92 @@
+"""Voice booking tools must be idempotent per session so an agent re-run (the
+OSS->managed streaming fallback re-executes tool calls) cannot double-book.
+Mirror of amul-oan-api's test; voice tools take ctx (session_id + ensure_in_scope)."""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from agents.tools import ai_call as ai_mod
+from agents.tools import health_call as hc_mod
+from agents.models.ai_call import AISpecies
+from agents.models.health_call import HealthCaseType
+
+
+def _ctx(session_id):
+    async def _ensure_in_scope():
+        return True
+
+    return SimpleNamespace(deps=SimpleNamespace(session_id=session_id, ensure_in_scope=_ensure_in_scope))
+
+
+def _patch_cache(monkeypatch, module):
+    store = {}
+
+    async def fake_get(key, namespace=None):
+        return store.get((namespace, key))
+
+    async def fake_set(key, value, ttl=None, namespace=None):
+        store[(namespace, key)] = value
+
+    monkeypatch.setattr(module.cache, "get", fake_get)
+    monkeypatch.setattr(module.cache, "set", fake_set)
+    monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
+    return store
+
+
+def test_ai_call_idempotent_on_rerun(monkeypatch):
+    _patch_cache(monkeypatch, ai_mod)
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {"ticket_number": "T1"})
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    species = next(iter(AISpecies))
+
+    r1 = asyncio.run(ai_mod.create_ai_call(_ctx("s1"), "U", "S", "F", "tech1", species))
+    r2 = asyncio.run(ai_mod.create_ai_call(_ctx("s1"), "U", "S", "F", "tech1", species))
+
+    assert calls["n"] == 1
+    assert "booked successfully" in r1
+    assert "already" in r2.lower()
+
+
+def test_health_call_idempotent_on_rerun(monkeypatch):
+    _patch_cache(monkeypatch, hc_mod)
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="H1")
+
+    monkeypatch.setattr(hc_mod, "create_health_call_api", fake_api)
+    species = next(iter(AISpecies))
+    case_type = next(iter(HealthCaseType))
+
+    # remark differs across the re-run (model output varies) — session key still dedupes
+    r1 = asyncio.run(hc_mod.create_health_call(_ctx("s1"), "U", "S", "F", species, case_type, "remark v1"))
+    r2 = asyncio.run(hc_mod.create_health_call(_ctx("s1"), "U", "S", "F", species, case_type, "remark v2"))
+
+    assert calls["n"] == 1
+    assert "booked successfully" in r1
+    assert "already" in r2.lower()
+
+
+def test_ai_call_no_session_does_not_crash(monkeypatch):
+    _patch_cache(monkeypatch, ai_mod)
+
+    async def fake_api(request, token):
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {})
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    species = next(iter(AISpecies))
+    r = asyncio.run(ai_mod.create_ai_call(_ctx(None), "U", "S", "F", "tech1", species))
+    assert "booked successfully" in r

--- a/tests/test_booking_idempotency.py
+++ b/tests/test_booking_idempotency.py
@@ -26,16 +26,30 @@ def _ctx(session_id):
 
 
 def _patch_cache(monkeypatch, module):
+    """In-memory cache simulating Redis: add() is atomic SET-NX (raises if key
+    exists), shared by try_reserve/release_reservation and the tool's set/get."""
     store = {}
 
-    async def fake_get(key, namespace=None):
-        return store.get((namespace, key))
+    async def fake_add(key, value, ttl=None, namespace=None):
+        k = (namespace, key)
+        if k in store:
+            raise ValueError("key exists")  # aiocache add == Redis SET NX
+        store[k] = value
+        return True
 
     async def fake_set(key, value, ttl=None, namespace=None):
         store[(namespace, key)] = value
 
-    monkeypatch.setattr(module.cache, "get", fake_get)
+    async def fake_get(key, namespace=None):
+        return store.get((namespace, key))
+
+    async def fake_delete(key, namespace=None):
+        store.pop((namespace, key), None)
+
+    monkeypatch.setattr(module.cache, "add", fake_add)
     monkeypatch.setattr(module.cache, "set", fake_set)
+    monkeypatch.setattr(module.cache, "get", fake_get)
+    monkeypatch.setattr(module.cache, "delete", fake_delete)
     monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
     return store
 
@@ -78,6 +92,32 @@ def test_health_call_idempotent_on_rerun(monkeypatch):
     assert calls["n"] == 1
     assert "booked successfully" in r1
     assert "already" in r2.lower()
+
+
+def test_ai_call_concurrent_submits_book_once(monkeypatch):
+    """Two concurrent submits for the same session (double-tap / retry) must
+    result in exactly ONE booking — the atomic reservation closes the race."""
+    _patch_cache(monkeypatch, ai_mod)
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        await asyncio.sleep(0.02)  # booking latency — the window two requests race in
+        return SimpleNamespace(ticket_number=f"T{calls['n']}", ait_name="AIT", model_dump=lambda: {})
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    species = next(iter(AISpecies))
+
+    async def go():
+        return await asyncio.gather(
+            ai_mod.create_ai_call(_ctx("sX"), "U", "S", "F", "t", species),
+            ai_mod.create_ai_call(_ctx("sX"), "U", "S", "F", "t", species),
+        )
+
+    r1, r2 = asyncio.run(go())
+    assert calls["n"] == 1
+    assert any("booked successfully" in r for r in (r1, r2))
+    assert any("already" in r.lower() for r in (r1, r2))
 
 
 def test_ai_call_no_session_does_not_crash(monkeypatch):

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,167 @@
+"""Unit tests for the standard OSS -> managed fallback module.
+
+Sets a dummy OPENAI_API_KEY before importing app code, because agents.models
+constructs the LLM model eagerly at import.
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import asyncio
+
+import pytest
+
+from app.services import fallback as fb
+from app.services.fallback import FallbackReason, classify, execute_with_fallback
+
+
+# ── classify() ──────────────────────────────────────────────────────────────
+
+class _StatusError(Exception):
+    def __init__(self, code, msg=""):
+        super().__init__(msg)
+        self.status_code = code
+
+
+def test_classify_timeout():
+    assert classify(asyncio.TimeoutError()) is FallbackReason.TIMEOUT
+    assert classify(TimeoutError()) is FallbackReason.TIMEOUT
+
+
+def test_classify_connection():
+    assert classify(ConnectionError("connection refused")) is FallbackReason.CONNECTION
+
+
+def test_classify_http_status():
+    assert classify(_StatusError(429)) is FallbackReason.RATE_LIMITED
+    assert classify(_StatusError(503)) is FallbackReason.HTTP_5XX
+    assert classify(_StatusError(500, "CUDA out of memory")) is FallbackReason.OOM
+
+
+def test_classify_bad_output():
+    class UnexpectedModelBehavior(Exception):
+        pass
+
+    assert classify(UnexpectedModelBehavior("schema mismatch")) is FallbackReason.BAD_OUTPUT
+
+
+def test_classify_cancelled():
+    assert classify(asyncio.CancelledError()) is FallbackReason.CANCELLED
+
+
+def test_classify_unknown():
+    assert classify(ValueError("???")) is FallbackReason.UNKNOWN
+
+
+def test_bad_output_and_cancelled_not_fallbackable():
+    assert FallbackReason.BAD_OUTPUT not in fb.FALLBACKABLE
+    assert FallbackReason.CANCELLED not in fb.FALLBACKABLE
+    assert FallbackReason.TIMEOUT in fb.FALLBACKABLE
+
+
+# ── attempt_chain() + execute_with_fallback() ────────────────────────────────
+
+@pytest.fixture
+def oss_enabled(monkeypatch):
+    """Fallback ON, OSS available; capture emitted events instead of logging."""
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb, "oss_model_available", lambda: True)
+    monkeypatch.setattr(fb, "OSS_LLM_MODEL", object())
+    monkeypatch.setattr(fb, "OSS_LLM_MODEL_NAME", "gemma-test")
+    monkeypatch.setattr(fb, "OSS_INFERENCE_ENDPOINT_URL", "http://oss:8020/v1")
+    events = []
+    monkeypatch.setattr(fb, "emit", events.append)
+    return events
+
+
+def test_chain_oss_two_tiers(oss_enabled):
+    chain = fb.attempt_chain("oss", "moderation")
+    assert [a.kind for a in chain] == ["oss", "managed"]
+    assert chain[0].endpoint == "http://oss:8020/v1"
+    assert chain[0].timeout is not None
+
+
+def test_chain_legacy_single_tier(oss_enabled):
+    chain = fb.attempt_chain("legacy", "moderation")
+    assert [a.kind for a in chain] == ["managed"]
+
+
+def test_chain_disabled_single_tier_no_deadline(monkeypatch):
+    monkeypatch.setattr(fb.settings, "fallback_enabled", False)
+    chain = fb.attempt_chain("oss", "moderation")
+    assert len(chain) == 1
+    assert chain[0].timeout is None
+
+
+def test_falls_back_to_managed_on_connection_error(oss_enabled):
+    async def run(attempt):
+        if attempt.kind == "oss":
+            raise ConnectionError("connection refused")
+        return "managed-result"
+
+    result = asyncio.run(
+        execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+    )
+    assert result == "managed-result"
+    assert len(oss_enabled) == 1
+    ev = oss_enabled[0]
+    assert ev.fell_back is True
+    assert ev.reason is FallbackReason.CONNECTION
+    assert ev.from_variant == "oss" and ev.to_variant == "managed"
+
+
+def test_does_not_fall_back_on_bad_output(oss_enabled):
+    class UnexpectedModelBehavior(Exception):
+        pass
+
+    async def run(attempt):
+        raise UnexpectedModelBehavior("schema mismatch")
+
+    with pytest.raises(UnexpectedModelBehavior):
+        asyncio.run(
+            execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+        )
+    # Recorded for visibility, but not a fallback.
+    assert len(oss_enabled) == 1
+    assert oss_enabled[0].fell_back is False
+    assert oss_enabled[0].reason is FallbackReason.BAD_OUTPUT
+
+
+def test_success_on_oss_emits_nothing(oss_enabled):
+    async def run(attempt):
+        return f"ok-{attempt.kind}"
+
+    result = asyncio.run(
+        execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+    )
+    assert result == "ok-oss"
+    assert oss_enabled == []
+
+
+def test_both_tiers_fail_raises_and_records_both(oss_enabled):
+    async def run(attempt):
+        raise ConnectionError("refused")
+
+    with pytest.raises(ConnectionError):
+        asyncio.run(
+            execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+        )
+    assert len(oss_enabled) == 2
+    assert oss_enabled[0].fell_back is True   # oss -> managed
+    assert oss_enabled[1].fell_back is False  # managed was last tier
+
+
+def test_legacy_session_no_fallback_attempted(oss_enabled):
+    calls = []
+
+    async def run(attempt):
+        calls.append(attempt.kind)
+        raise ConnectionError("refused")
+
+    with pytest.raises(ConnectionError):
+        asyncio.run(
+            execute_with_fallback(pipeline="moderation", session_id="s1", variant="legacy", run=run)
+        )
+    assert calls == ["managed"]  # only one tier for legacy sessions
+    assert len(oss_enabled) == 1 and oss_enabled[0].fell_back is False

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -165,3 +165,75 @@ def test_legacy_session_no_fallback_attempted(oss_enabled):
         )
     assert calls == ["managed"]  # only one tier for legacy sessions
     assert len(oss_enabled) == 1 and oss_enabled[0].fell_back is False
+
+
+# ── stream_with_fallback() (first-token commit) ──────────────────────────────
+
+async def _collect(agen):
+    return [c async for c in agen]
+
+
+def test_stream_success_on_oss_no_fallback(oss_enabled):
+    async def make_stream(attempt):
+        for c in ["a", "b", "c"]:
+            yield f"{attempt.kind}:{c}"
+
+    chunks = asyncio.run(
+        _collect(fb.stream_with_fallback(
+            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream))
+    )
+    assert chunks == ["oss:a", "oss:b", "oss:c"]
+    assert oss_enabled == []
+
+
+def test_stream_precommit_failure_swaps_to_managed(oss_enabled):
+    async def make_stream(attempt):
+        if attempt.kind == "oss":
+            raise ConnectionError("refused")  # before any yield
+            yield  # pragma: no cover - makes this an async generator
+        for c in ["x", "y"]:
+            yield f"managed:{c}"
+
+    chunks = asyncio.run(
+        _collect(fb.stream_with_fallback(
+            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream))
+    )
+    assert chunks == ["managed:x", "managed:y"]
+    assert len(oss_enabled) == 1
+    ev = oss_enabled[0]
+    assert ev.committed is False and ev.fell_back is True and ev.reason is FallbackReason.CONNECTION
+
+
+def test_stream_postcommit_failure_propagates(oss_enabled):
+    async def make_stream(attempt):
+        yield f"{attempt.kind}:first"
+        raise ConnectionError("died mid-stream")
+
+    got = []
+
+    async def drive():
+        async for c in fb.stream_with_fallback(
+            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream
+        ):
+            got.append(c)
+
+    with pytest.raises(ConnectionError):
+        asyncio.run(drive())
+    assert got == ["oss:first"]              # committed chunk reached the client
+    assert len(oss_enabled) == 1
+    assert oss_enabled[0].committed is True and oss_enabled[0].fell_back is False
+
+
+def test_stream_precommit_bad_output_does_not_swap(oss_enabled):
+    class UnexpectedModelBehavior(Exception):
+        pass
+
+    async def make_stream(attempt):
+        raise UnexpectedModelBehavior("schema")
+        yield  # pragma: no cover
+
+    with pytest.raises(UnexpectedModelBehavior):
+        asyncio.run(_collect(fb.stream_with_fallback(
+            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream)))
+    assert len(oss_enabled) == 1
+    assert oss_enabled[0].committed is False and oss_enabled[0].fell_back is False

--- a/tests/test_fallback_integration.py
+++ b/tests/test_fallback_integration.py
@@ -1,0 +1,90 @@
+"""End-to-end fault-injection (voice): with FALLBACK_ENABLED and the OSS endpoint
+DEAD, moderation and core-chat streaming must fall back to the managed model.
+
+SKIPPED unless RUN_FALLBACK_INTEGRATION=1 and a real OPENAI_API_KEY is set — makes
+real managed-model calls and needs network (run in staging/CI).
+
+    RUN_FALLBACK_INTEGRATION=1 OPENAI_API_KEY=sk-... LLM_MODEL_NAME=gpt-4.1 \\
+        .venv/bin/python -m pytest tests/test_fallback_integration.py -o asyncio_mode=auto -s
+"""
+
+import os
+
+import asyncio
+
+import pytest
+
+_KEY = os.getenv("OPENAI_API_KEY", "")
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_FALLBACK_INTEGRATION") != "1" or not _KEY or _KEY == "test-key",
+    reason="set RUN_FALLBACK_INTEGRATION=1 and a real OPENAI_API_KEY (needs network + managed model)",
+)
+
+DEAD_OSS_URL = "http://127.0.0.1:1/v1"  # port 1 -> connection refused
+
+
+@pytest.fixture
+def oss_dead(monkeypatch):
+    from app.services import fallback as fb
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    dead = OpenAIChatModel("gemma-dead", provider=OpenAIProvider(base_url=DEAD_OSS_URL, api_key="x"))
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb, "oss_model_available", lambda: True)
+    monkeypatch.setattr(fb, "OSS_LLM_MODEL", dead)
+    monkeypatch.setattr(fb, "OSS_INFERENCE_ENDPOINT_URL", DEAD_OSS_URL)
+    events = []
+    monkeypatch.setattr(fb, "emit", events.append)
+    return fb, events, dead
+
+
+def test_unary_moderation_falls_back_to_managed(oss_dead, monkeypatch):
+    fb, events, _dead = oss_dead
+    from app.services import moderation as mod
+    from openai import AsyncOpenAI
+
+    dead_client = AsyncOpenAI(base_url=DEAD_OSS_URL, api_key="x")
+    real_client, real_model, _ = mod._client_model_for_kind("managed")  # real OpenAI
+
+    monkeypatch.setattr(
+        mod,
+        "_client_model_for_kind",
+        lambda kind: (dead_client, "gemma-dead", "vllm") if kind == "oss" else (real_client, real_model, "openai"),
+    )
+
+    verdict = asyncio.run(
+        mod.check_moderation("My cow has a fever, what should I do?", "english", variant="oss", session_id="it-mod")
+    )
+    assert verdict.category != "unavailable", "managed tier should have produced a real verdict"
+    assert any(e.fell_back for e in events), "expected an OSS->managed fallback event"
+
+
+def test_streaming_voice_falls_back_to_managed(oss_dead):
+    fb, events, _dead = oss_dead
+    from agents.voice import voice_agent
+    from agents.deps import FarmerContext
+
+    deps = FarmerContext(query="Reply with a short greeting.", session_id="it-voice")
+
+    async def make_stream(attempt):
+        async with voice_agent.run_stream(
+            user_prompt="Reply with a short greeting.",
+            message_history=[],
+            deps=deps,
+            model=attempt.model,
+        ) as rs:
+            async for c in rs.stream_text(delta=True, debounce_by=0):
+                yield c
+
+    async def drive():
+        chunks = []
+        async for c in fb.stream_with_fallback(
+            pipeline="chat", session_id="it-voice", variant="oss", make_stream=make_stream
+        ):
+            chunks.append(c)
+        return chunks
+
+    chunks = asyncio.run(drive())
+    assert "".join(chunks).strip(), "expected streamed tokens from the managed model"
+    assert any(e.fell_back and not e.committed for e in events), "expected a pre-first-token OSS->managed swap"

--- a/tests/test_voice_moderation_fallback.py
+++ b/tests/test_voice_moderation_fallback.py
@@ -1,0 +1,103 @@
+"""Tests for voice moderation matching chat: variant-routed OSS->managed
+fallback + fail-closed (behind FALLBACK_ENABLED)."""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import fallback as fb
+from app.services import moderation as mod
+
+
+def _resp(content: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+# ── strict parser (fail-closed) ──────────────────────────────────────────────
+
+def test_parse_strict_valid_in_scope():
+    v = mod._parse_verdict_strict('{"category": "in_scope", "reason": "ok"}')
+    assert v.category == "in_scope" and not v.rejected and not v.failed_closed
+
+
+def test_parse_strict_valid_reject():
+    v = mod._parse_verdict_strict('{"category": "offensive", "reason": "x"}')
+    assert v.category == "offensive" and v.rejected
+
+
+@pytest.mark.parametrize("raw", ["", "not json", '"a string"', '{"category": "weird"}'])
+def test_parse_strict_malformed_fails_closed(raw):
+    v = mod._parse_verdict_strict(raw)
+    assert v.category == "unavailable" and v.rejected and v.failed_closed
+
+
+def test_unavailable_verdict_has_generic_decline():
+    v = mod._block_unavailable("all tiers down")
+    assert v.rejected is True
+    assert v.decline_text_en()  # a non-empty generic "try again" message
+
+
+# ── check_moderation: fallback + fail-closed ─────────────────────────────────
+
+@pytest.fixture
+def oss_on(monkeypatch):
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb, "oss_model_available", lambda: True)
+    monkeypatch.setattr(fb, "OSS_LLM_MODEL", object())
+    monkeypatch.setattr(fb, "OSS_LLM_MODEL_NAME", "gemma-test")
+    monkeypatch.setattr(fb, "OSS_INFERENCE_ENDPOINT_URL", "http://oss:8020/v1")
+    events = []
+    monkeypatch.setattr(fb, "emit", events.append)
+    # deterministic per-kind backends
+    monkeypatch.setattr(mod, "_client_model_for_kind",
+                        lambda kind: (f"{kind}-client", f"{kind}-model", kind))
+    return events
+
+
+def test_oss_failure_falls_back_to_managed(oss_on, monkeypatch):
+    async def fake_create(client, model, text, source_lang, recent_history_text=""):
+        if model.startswith("oss"):
+            raise ConnectionError("vllm refused")
+        return _resp('{"category": "in_scope", "reason": "ok"}')
+    monkeypatch.setattr(mod, "_create_moderation_response", fake_create)
+
+    v = asyncio.run(mod.check_moderation("hi", "gu", variant="oss", session_id="s"))
+    assert v.category == "in_scope" and not v.rejected
+    assert len(oss_on) == 1 and oss_on[0].fell_back is True
+
+
+def test_both_tiers_fail_fails_closed(oss_on, monkeypatch):
+    async def fake_create(client, model, text, source_lang, recent_history_text=""):
+        raise ConnectionError("down")
+    monkeypatch.setattr(mod, "_create_moderation_response", fake_create)
+
+    v = asyncio.run(mod.check_moderation("hi", "gu", variant="oss", session_id="s"))
+    assert v.category == "unavailable" and v.rejected and v.failed_closed
+
+
+def test_valid_reject_on_oss_does_not_fall_back(oss_on, monkeypatch):
+    async def fake_create(client, model, text, source_lang, recent_history_text=""):
+        return _resp('{"category": "offensive", "reason": "abuse"}')
+    monkeypatch.setattr(mod, "_create_moderation_response", fake_create)
+
+    v = asyncio.run(mod.check_moderation("...", "gu", variant="oss", session_id="s"))
+    assert v.category == "offensive" and v.rejected
+    assert oss_on == []  # a valid verdict is success, no fallback
+
+
+def test_legacy_path_used_when_disabled(monkeypatch):
+    monkeypatch.setattr(fb.settings, "fallback_enabled", False)
+    sentinel = mod._allow("legacy-was-called", failed_open=True)
+
+    async def fake_legacy(text, source_lang, recent_history_text=""):
+        return sentinel
+    monkeypatch.setattr(mod, "_check_moderation_legacy", fake_legacy)
+
+    v = asyncio.run(mod.check_moderation("hi", "gu", variant="oss", session_id="s"))
+    assert v is sentinel  # disabled -> today's fail-open legacy path, unchanged


### PR DESCRIPTION
## Summary

OSS → managed runtime fallback for voice (companion to the amul-oan-api PR; design
doc lives there). **Behind `FALLBACK_ENABLED` (default off).**

## Included (voice-oan-api)
- **`app/services/fallback.py`** (mirror) — attempt chain + `execute_with_fallback`
  + `stream_with_fallback` (first-token commit) + classification + `emit`.
- **Pretranslation** OSS vLLM → managed OpenAI (drops TranslateGemma stopgap) ·
  **Moderation** now variant-routed + **fail-closed** (off the old global provider /
  fail-open), per team direction · **Core chat (streaming)** first-token commit, agent
  runs concurrently with the deferred moderation gate; post-first-token failure →
  localized "try again" line · **Booking idempotency** guard added to
  `create_health_call`.

## Testing
`test_fallback.py` (19) · `test_voice_moderation_fallback.py` (11) ·
`test_booking_idempotency.py` — pass (`-o asyncio_mode=auto`).
`test_fallback_integration.py` (skip-by-default) fault-injection validated via tunnel
(OSS dead → managed: unary moderation + core-chat streaming PASS). Pre-existing
`amul-dev` suite failures (prompt/matcher/fixture) are unrelated.

## Notes for review
A real anyio/`run_stream` streaming bug was found via fault-injection and fixed
(`async for` consumption, no external timeout wrapper; removed a cross-task eager-start).
Verify in prod the managed tier is an **independent** failure domain (locally
`LLM_PROVIDER=vllm` made it the same vLLM as OSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
