### PR TITLE
Fix/voice stt hangup threshold

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -272,7 +272,14 @@ _HISTORY_MARKERS = {
     "stt_no_audio": "[stt:no-audio]",
     "stt_unclear": "[stt:unclear-speech]",
     "moderation_reject": "[moderation-rejected]",
+    "auto_hangup_non_meaningful": "[auto-hangup:non-meaningful-threshold]",
 }
+
+NON_MEANINGFUL_TURN_HANGUP_THRESHOLD = 3
+NON_MEANINGFUL_HISTORY_MARKERS = frozenset({
+    _HISTORY_MARKERS["stt_no_audio"],
+    _HISTORY_MARKERS["stt_unclear"],
+})
 
 
 def _is_fragment_query(query: str) -> bool:
@@ -327,6 +334,57 @@ def _has_meaningful_history(history: list) -> bool:
                 continue
             return True
     return False
+
+
+def _recent_user_turn_texts(history: list, limit: int) -> list[str]:
+    """Return most recent user prompt texts, newest first."""
+    if limit <= 0:
+        return []
+    turns: list[str] = []
+    for msg in reversed(history or []):
+        user_text = None
+        for part in getattr(msg, "parts", []) or []:
+            if getattr(part, "part_kind", "") != "user-prompt":
+                continue
+            content = getattr(part, "content", None)
+            if not isinstance(content, str):
+                continue
+            text = content.strip()
+            if text:
+                user_text = text
+                break
+        if user_text is None:
+            continue
+        turns.append(user_text)
+        if len(turns) >= limit:
+            break
+    return turns
+
+
+def _consecutive_non_meaningful_user_turns(
+    history: list,
+    *,
+    current_user_marker: Optional[str] = None,
+) -> int:
+    """Count trailing non-meaningful user turns including the current marker."""
+    recent_turns: list[str] = []
+    if isinstance(current_user_marker, str):
+        marker = current_user_marker.strip()
+        if marker:
+            recent_turns.append(marker)
+    recent_turns.extend(
+        _recent_user_turn_texts(
+            history,
+            NON_MEANINGFUL_TURN_HANGUP_THRESHOLD,
+        )
+    )
+    count = 0
+    for text in recent_turns:
+        if text in NON_MEANINGFUL_HISTORY_MARKERS:
+            count += 1
+            continue
+        break
+    return count
 
 
 def _is_hold_message(query: str) -> bool:
@@ -1031,7 +1089,34 @@ async def stream_voice_message(
                     if stt_signal == "No audio/User is speaking softly"
                     else _canonical_history_user_text("stt_unclear")
                 )
+                non_meaningful_tail = _consecutive_non_meaningful_user_turns(
+                    history,
+                    current_user_marker=history_signal,
+                )
                 history_response = _FRAGMENT_RESPONSES["en"] if not final_attempt else "Sorry, I still could not hear you clearly. Please try again later."
+                if non_meaningful_tail >= (NON_MEANINGFUL_TURN_HANGUP_THRESHOLD + 1):
+                    logger.info(
+                        "Auto-hangup on STT/non-meaningful threshold+1; session_id=%s process_id=%s signal=%s final_attempt=%s non_meaningful_tail=%s",
+                        session_id,
+                        process_id,
+                        stt_signal,
+                        final_attempt,
+                        non_meaningful_tail,
+                    )
+                    goodbye = TELEPHONY_TERMINATE_CALL_TOKEN.get(
+                        requested_target_lang,
+                        TELEPHONY_TERMINATE_CALL_TOKEN["en"],
+                    )
+                    hang_req, hang_resp = _history_pair(
+                        _canonical_history_user_text("auto_hangup_non_meaningful"),
+                        TELEPHONY_TERMINATE_CALL_TOKEN["en"],
+                    )
+                    with trace.stage("history_write"):
+                        await update_message_history(session_id, [*history, hang_req, hang_resp])
+                    trace.set_outcome("stt_signal_auto_hangup")
+                    # Emit raw telephony terminate token; do not language-normalize.
+                    yield _emit(goodbye)
+                    return
                 stt_req, stt_resp = _history_pair(history_signal, history_response)
                 with trace.stage("history_write"):
                     await update_message_history(session_id, [*history, stt_req, stt_resp])
@@ -1054,7 +1139,8 @@ async def stream_voice_message(
                     TELEPHONY_TERMINATE_CALL_TOKEN["en"],
                 )
                 trace.set_outcome("hold_message")
-                yield _emit(_prepare_voice_output(goodbye, requested_target_lang))
+                # Emit raw telephony terminate token; do not language-normalize.
+                yield _emit(goodbye)
                 return
 
             # ── Greeting short-circuit ────────────────────────────────────

--- a/assets/glossary_terms.json
+++ b/assets/glossary_terms.json
@@ -3001,8 +3001,8 @@
   },
   {
     "en": "Retained placenta",
-    "gu": "માટી ન ખસવી",
-    "transliteration": "mati na khasavi"
+    "gu": "મેલી ન પડવી",
+    "transliteration": "meli na padvi"
   },
   {
     "en": "Retained Placenta (RP)",

--- a/tests/test_voice_fixes.py
+++ b/tests/test_voice_fixes.py
@@ -9,11 +9,17 @@ Covers:
 import pytest
 import sys
 import os
+from pydantic_ai.messages import ModelRequest, UserPromptPart
 
 # Add project root to path so imports work
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.services.voice import _is_bare_greeting, _is_fragment_query, _is_hold_message
+from app.services.voice import (
+    _consecutive_non_meaningful_user_turns,
+    _is_bare_greeting,
+    _is_fragment_query,
+    _is_hold_message,
+)
 from app.services.stt_signals import detect_stt_signal
 from app.services.translation import _post_normalize_gu_translation
 from agents.tools.terms import get_ambiguity_hints_for_query
@@ -121,6 +127,30 @@ class TestFragmentDetection:
         assert _is_fragment_query(query) is False
 
 
+
+
+class TestNonMeaningfulTurnCounter:
+    def test_counts_consecutive_tail_including_current_marker(self):
+        history = [
+            ModelRequest(parts=[UserPromptPart(content="[stt:no-audio]")]),
+            ModelRequest(parts=[UserPromptPart(content="[stt:unclear-speech]")]),
+        ]
+        count = _consecutive_non_meaningful_user_turns(
+            history,
+            current_user_marker="[stt:no-audio]",
+        )
+        assert count == 3
+
+    def test_stops_counting_when_recent_turn_is_meaningful(self):
+        history = [
+            ModelRequest(parts=[UserPromptPart(content="[stt:no-audio]")]),
+            ModelRequest(parts=[UserPromptPart(content="my cow has fever")]),
+        ]
+        count = _consecutive_non_meaningful_user_turns(
+            history,
+            current_user_marker="[stt:no-audio]",
+        )
+        assert count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -1028,7 +1028,7 @@ class TestMultiTurnFlows:
 
         monkeypatch.setattr(voice_module, "generate_stt_signal_response", _fake_generate)
 
-        for _ in range(3):
+        for _ in range(4):
             output, history = asyncio.run(
                 _collect_stream(
                     query="No audio/User is speaking softly",
@@ -1040,10 +1040,11 @@ class TestMultiTurnFlows:
             )
             outputs.append(output)
 
-        assert final_flags == [False, False, True]
+        assert final_flags == [False, False, True, True]
         assert "ફરીથી" in outputs[0]
         assert "ફરીથી" in outputs[1]
         assert "પછીથી ફરી પ્રયાસ કરો" in outputs[2] or "થોડા સમય પછી ફરી કોલ કરો" in outputs[2]
+        assert outputs[3].strip() == "Goodbye."
         history_text = " ".join(
             getattr(part, "content", "")
             for msg in history
@@ -1051,6 +1052,7 @@ class TestMultiTurnFlows:
             if isinstance(getattr(part, "content", None), str)
         )
         assert "[stt:no-audio]" in history_text
+        assert "[auto-hangup:non-meaningful-threshold]" in history_text
         assert "No audio/User is speaking softly" not in history_text
 
     def test_tool_triggered_nudge_fires_once_before_first_chunk(self, monkeypatch):

--- a/tests/test_voice_regressions_apr11_12_integration.py
+++ b/tests/test_voice_regressions_apr11_12_integration.py
@@ -364,9 +364,9 @@ def test_repeated_stt_failure_hits_retry_ceiling(monkeypatch):
     assert len(stt_calls) >= 1
     assert _contains_any(outputs[0], ["સંભળાતો નથી", "ફરીથી"])
     assert _contains_any(outputs[1], ["સંભળાતો નથી", "ફરીથી"])
-    assert _contains_any(outputs[2], ["સંભળાતો નથી", "ફરીથી"])
-    assert _contains_any(outputs[3], ["પછીથી ફરી પ્રયાસ કરો", "later", "try again later"])
-    assert _contains_none(outputs[3], ["ફરીથી બોલો", "please repeat", "say that again"])
+    assert _contains_any(outputs[2], ["પછીથી ફરી પ્રયાસ કરો", "later", "try again later"])
+    assert _contains_none(outputs[2], ["ફરીથી બોલો", "please repeat", "say that again"])
+    assert outputs[3].strip() == "Goodbye."
 
 
 def test_pretranslation_total_failure_asks_to_repeat_without_agent_call(monkeypatch):


### PR DESCRIPTION
Implemented a non-meaningful-turn guard in the main voice flow to improve call termination behavior without using scoring/moderation parallelism. The logic now counts consecutive STT non-meaningful markers from the last user turns ([stt:no-audio], [stt:unclear-speech]) and applies a two-step termination contract: on the threshold turn it returns the existing final “try again later” prompt, and if one more non-meaningful STT turn occurs it emits the raw Goodbye. telephony token and writes [auto-hangup:non-meaningful-threshold] to history for traceability.

Also updated regression/unit tests to match this behavior, kept fragment handling as-is (not part of threshold counting), and ensured hangup token emission bypasses output normalization so Goodbye. is preserved exactly.