### PR TITLE
voice: fan out milk-collection over all of a mobile's farmer accounts

### DIFF
--- a/agents/deps.py
+++ b/agents/deps.py
@@ -3,6 +3,21 @@ from typing import Optional, Literal
 from pydantic import BaseModel, Field, PrivateAttr
 
 
+class FarmerAccount(BaseModel):
+    """One (union, society, farmer) account tied to the caller's mobile.
+
+    A single mobile can map to several PashuGPT accounts (e.g. a separate
+    cow account and buffalo account). Milk-collection lookups fan out over
+    all of these so a farmer's data is never missed just because the agent
+    happened to pick the wrong account's codes.
+    """
+    union_code: Optional[str] = None
+    society_code: Optional[str] = None
+    farmer_code: Optional[str] = None
+    farmer_name: Optional[str] = None
+    society_name: Optional[str] = None
+
+
 class FarmerContext(BaseModel):
     """Context for the voice agent.
 
@@ -27,6 +42,10 @@ class FarmerContext(BaseModel):
     ai_technician_info: str = Field(default="", description="Pre-built internal AI technician context string.")
     signed_in: bool = Field(default=False, description="Whether the session is signed in/authenticated for farmer-specific tools.")
     mobile: Optional[str] = Field(default=None, description="Normalized mobile number when available.")
+    farmer_accounts: list[FarmerAccount] = Field(
+        default_factory=list,
+        description="All (union, society, farmer) accounts on the caller's mobile, for multi-account fan-out.",
+    )
 
     # Handle to the per-turn content-moderation task, which now runs concurrently
     # with the agent (see app.services.voice). Side-effecting tools await it via

--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -49,7 +49,7 @@ BASE_TOOLS = [
     ),
     Tool(
         _with_nudge_signal(get_farmer_milk_collection_details),
-        takes_ctx=False,
+        takes_ctx=True,
         docstring_format='auto',
         require_parameter_descriptions=True,
     ),

--- a/agents/tools/milk_collection.py
+++ b/agents/tools/milk_collection.py
@@ -2,7 +2,9 @@
 import os
 
 from pydantic import ValidationError
+from pydantic_ai import RunContext
 
+from agents.deps import FarmerAccount, FarmerContext
 from app.models.milk_collection import FarmerMilkCollectionRequestModel
 from agents.tools.farmer_animal_backends import get_farmer_milk_collection_details_api
 from helpers.utils import get_logger
@@ -58,7 +60,50 @@ def _format_milk_collection_summary(response) -> str:
     return "\n".join(lines)
 
 
+async def _fetch_one_account(
+    account: FarmerAccount,
+    fromdate: str,
+    todate: str,
+    token: str,
+):
+    """Fetch milk/deduction for one account. Returns the response, or None on failure.
+
+    Dates are validated once by the caller before fan-out, so a per-account
+    failure here is always an upstream/API issue, not a date problem.
+    """
+    request = FarmerMilkCollectionRequestModel(
+        unionCode=account.union_code or "",
+        societyCode=account.society_code or "",
+        farmerCode=account.farmer_code or "",
+        fromdate=fromdate,
+        todate=todate,
+    )
+    response = await get_farmer_milk_collection_details_api(request, token)
+    logger.info(
+        "Milk collection lookup: union=%s society=%s farmer=%s from=%s to=%s ok=%s milk=%s ded=%s",
+        account.union_code, account.society_code, account.farmer_code, fromdate, todate,
+        response is not None,
+        len(response.milk) if response else 0,
+        len(response.deduction) if response else 0,
+    )
+    return response
+
+
+def _account_label(account: FarmerAccount, multi: bool) -> str:
+    """Header for an account's section, only shown when fanning out over >1 account."""
+    if not multi:
+        return ""
+    parts = []
+    if account.society_name:
+        parts.append(account.society_name)
+    if account.farmer_code:
+        parts.append(f"farmer code {account.farmer_code}")
+    label = ", ".join(parts) if parts else f"account {account.farmer_code or '?'}"
+    return f"Account — {label}:"
+
+
 async def get_farmer_milk_collection_details(
+    ctx: RunContext[FarmerContext],
     union_code: str,
     society_code: str,
     farmer_code: str,
@@ -66,74 +111,87 @@ async def get_farmer_milk_collection_details(
     todate: str,
 ) -> str:
     """
-    Fetch milk collection and deduction details for a farmer.
+    Fetch milk collection and deduction details for the signed-in farmer.
+
+    A single mobile number can have more than one account (for example a
+    separate cow account and buffalo account). This tool automatically looks
+    up every account on the caller's mobile and reports them together, so you
+    do not need to pick one. The codes you pass are only a fallback used when
+    no farmer accounts are available in context.
 
     Args:
-        union_code: Union code for the farmer from farmer context.
-        society_code: Society code for the farmer from farmer context.
-        farmer_code: Farmer code for the farmer from farmer context.
+        ctx: The run context (automatically provided).
+        union_code: Union code from farmer context (fallback only).
+        society_code: Society code from farmer context (fallback only).
+        farmer_code: Farmer code from farmer context (fallback only).
         fromdate: Start date in YYYY-MM-DD format (ISO).
         todate: End date in YYYY-MM-DD format (ISO).
 
     Returns:
-        str: Formatted milk collection and deduction details, or a clear failure message.
+        str: Formatted milk collection and deduction details across all of the
+             farmer's accounts, or a clear failure message.
     """
-    logger.info(
-        "Milk collection tool invoked: union=%s society=%s farmer=%s fromdate=%s todate=%s",
-        union_code,
-        society_code,
-        farmer_code,
-        fromdate,
-        todate,
-    )
-
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
         return "Milk collection lookup failed. Service is not configured."
 
+    # Prefer the structured accounts from context (every account on the mobile).
+    # Fall back to the LLM-supplied codes only when context has none.
+    accounts = list(ctx.deps.farmer_accounts) if ctx.deps and ctx.deps.farmer_accounts else []
+    if not accounts:
+        accounts = [
+            FarmerAccount(
+                union_code=union_code,
+                society_code=society_code,
+                farmer_code=farmer_code,
+            )
+        ]
+    logger.info(
+        "Milk collection tool invoked: accounts=%s from=%s to=%s (llm_codes=%s/%s/%s)",
+        len(accounts), fromdate, todate, union_code, society_code, farmer_code,
+    )
+
+    # Validate the date range once — it is the same for every account, so a bad
+    # date is a single clear failure rather than a per-account error.
     try:
-        request = FarmerMilkCollectionRequestModel(
-            unionCode=union_code,
-            societyCode=society_code,
-            farmerCode=farmer_code,
+        FarmerMilkCollectionRequestModel(
+            unionCode=accounts[0].union_code or "",
+            societyCode=accounts[0].society_code or "",
+            farmerCode=accounts[0].farmer_code or "",
             fromdate=fromdate,
             todate=todate,
-        )
-        request.validate_date_range()
+        ).validate_date_range()
     except (ValidationError, ValueError) as e:
-        logger.info(
-            "Milk collection lookup validation failed: union=%s society=%s farmer=%s fromdate=%s todate=%s error=%s",
-            union_code,
-            society_code,
-            farmer_code,
-            fromdate,
-            todate,
-            e,
-        )
+        logger.info("Milk collection date validation failed: from=%s to=%s error=%s", fromdate, todate, e)
         return f"Milk collection lookup failed. {e}"
 
-    response = await get_farmer_milk_collection_details_api(request, token)
-    if response is None:
-        logger.info(
-            "Milk collection API failed: union=%s society=%s farmer=%s fromdate=%s todate=%s",
-            union_code,
-            society_code,
-            farmer_code,
-            fromdate,
-            todate,
-        )
+    multi = len(accounts) > 1
+    sections: list[str] = []
+    any_success = False
+    total_milk = 0
+
+    for account in accounts:
+        result = await _fetch_one_account(account, fromdate, todate, token)
+        if result is None:
+            sections.append(
+                (_account_label(account, multi) + "\n" if multi else "")
+                + "Unable to fetch milk collection details for this account right now."
+            )
+            continue
+
+        any_success = True
+        total_milk += len(result.milk)
+        summary = _format_milk_collection_summary(result)
+        label = _account_label(account, multi)
+        sections.append(f"{label}\n{summary}" if label else summary)
+
+    if not any_success:
         return "Milk collection lookup failed. Unable to fetch details at the moment."
 
+    body = "\n\n".join(sections)
     logger.info(
-        "Milk collection lookup succeeded: union=%s society=%s farmer=%s from=%s to=%s milk_records=%s deductions=%s",
-        union_code,
-        society_code,
-        farmer_code,
-        fromdate,
-        todate,
-        len(response.milk),
-        len(response.deduction),
+        "Milk collection aggregate: accounts=%s any_success=%s total_milk_records=%s",
+        len(accounts), any_success, total_milk,
     )
-    formatted = _format_milk_collection_summary(response)
-    return f"Milk collection details fetched successfully:\n\n{formatted}"
+    return f"Milk collection details fetched successfully:\n\n{body}"

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -68,7 +68,7 @@ from app.services.translation import (
 from app.services.voice_trace import VoiceTrace, create_voice_trace
 # NOTE: Removing telemetry for now.
 # from app.tasks.telemetry import send_telemetry
-from agents.deps import FarmerContext
+from agents.deps import FarmerAccount, FarmerContext
 from agents.models import (
     LLM_MODEL_NAME,
     OSS_LLM_MODEL_NAME,
@@ -696,6 +696,42 @@ def _collect_farmer_unions(envelope: Optional[FarmerDataEnvelope]) -> list[str]:
     return unions
 
 
+def _collect_farmer_accounts(envelope: Optional[FarmerDataEnvelope]) -> list[FarmerAccount]:
+    """Extract every (union, society, farmer) account on the caller's mobile.
+
+    A mobile can map to multiple PashuGPT accounts (e.g. a cow account and a
+    buffalo account). The milk-collection tool fans out over all of these so
+    a farmer's data is never missed because the agent picked one account.
+    Deduplicated on (union_code, society_code, farmer_code).
+    """
+    if envelope is None:
+        return []
+
+    seen: set[tuple] = set()
+    accounts: list[FarmerAccount] = []
+    for farmer in envelope.farmers:
+        record = farmer.model_dump()
+        union_code = record.get("unionCode") or record.get("union_code")
+        society_code = record.get("societyCode") or record.get("society_code")
+        farmer_code = record.get("farmerCode") or record.get("farmer_code")
+        if not (union_code and society_code and farmer_code):
+            continue
+        key = (str(union_code), str(society_code), str(farmer_code))
+        if key in seen:
+            continue
+        seen.add(key)
+        accounts.append(
+            FarmerAccount(
+                union_code=str(union_code),
+                society_code=str(society_code),
+                farmer_code=str(farmer_code),
+                farmer_name=record.get("farmerName") or record.get("farmer_name"),
+                society_name=record.get("societyName") or record.get("society_name"),
+            )
+        )
+    return accounts
+
+
 async def _build_union_scheme_summary(farmer_unions: list[str]) -> str:
     scheme_unions = [union_name for union_name in farmer_unions if union_name in SUPPORTED_SCHEME_CONTEXT_UNIONS]
     if not scheme_unions:
@@ -1211,6 +1247,7 @@ async def stream_voice_message(
             signed_in = _is_signed_in_session(user_info, user_id)
             farmer_info = ""
             farmer_unions: list[str] = []
+            farmer_accounts: list[FarmerAccount] = []
             ai_technician_info = ""
             farmer_cache_task = (
                 asyncio.create_task(get_or_fetch_farmer_data(mobile))
@@ -1456,6 +1493,7 @@ async def stream_voice_message(
                         envelope = await farmer_cache_task
                     farmer_info = _build_compact_farmer_summary(envelope)
                     farmer_unions = _collect_farmer_unions(envelope)
+                    farmer_accounts = _collect_farmer_accounts(envelope)
                     with trace.stage("scheme_summary"):
                         scheme_summary = await _build_union_scheme_summary(farmer_unions)
                     if scheme_summary:
@@ -1501,6 +1539,7 @@ async def stream_voice_message(
                 ai_technician_info=ai_technician_info,
                 signed_in=signed_in,
                 mobile=mobile,
+                farmer_accounts=farmer_accounts,
             )
             # Let side-effecting tools (bookings) self-gate on the concurrent
             # moderation verdict before performing any write.

--- a/tests/test_milk_collection_tool.py
+++ b/tests/test_milk_collection_tool.py
@@ -1,16 +1,23 @@
 import asyncio
-import json
 import os
 import sys
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.models.milk_collection import FarmerMilkCollectionResponseModel
+from agents.deps import FarmerAccount, FarmerContext
 from agents.tools.milk_collection import get_farmer_milk_collection_details
 
 
+def _ctx(accounts=None):
+    """Minimal RunContext stand-in carrying FarmerContext deps."""
+    deps = FarmerContext(query="milk", farmer_accounts=accounts or [])
+    return SimpleNamespace(deps=deps)
+
+
 class TestMilkCollectionTool:
-    def test_success_returns_formatted_json_with_aliases(self, monkeypatch):
+    def test_success_returns_labelled_summary(self, monkeypatch):
         monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
 
         async def _fake_api(request, token):
@@ -25,7 +32,7 @@ class TestMilkCollectionTool:
             return FarmerMilkCollectionResponseModel.model_validate(
                 {
                     "result": "success",
-                    "milk": [{"date": "2026-04-01", "qty": 10, "fat": 6, "snf": 9, "amount": 500}],
+                    "milk": [{"date": "2026-04-01", "shift": "M", "qty": 10, "fat": 6, "snf": 9, "amount": 500}],
                     "deduction": [{"date": "2026-04-01", "accountname": "Feed", "amount": 100}],
                 }
             )
@@ -35,19 +42,78 @@ class TestMilkCollectionTool:
             _fake_api,
         )
 
+        # Single account in context: no per-account header, labelled fields.
+        accounts = [FarmerAccount(union_code="0201", society_code="001066", farmer_code="000123")]
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                "0201",
-                "001066",
-                "000123",
-                "2026-04-01",
-                "2026-04-01",
+                _ctx(accounts), "0201", "001066", "000123", "2026-04-01", "2026-04-01"
             )
         )
 
         assert "Milk collection details fetched successfully" in result
-        payload = json.loads(result.split("\n\n", 1)[1])
-        assert payload["deduction"][0]["accountname"] == "Feed"
+        assert "quantity 10 liters" in result
+        assert "fat 6, SNF 9, amount 500 rupees" in result
+        assert "Feed: amount 100 rupees" in result
+        assert "Account —" not in result  # single account => no header
+
+    def test_multi_account_fans_out_over_all_accounts(self, monkeypatch):
+        monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
+
+        async def _fake_api(request, token):
+            # farmer 0006 has two morning records; 1006 is empty.
+            if request.farmer_code == "0006":
+                return FarmerMilkCollectionResponseModel.model_validate(
+                    {"milk": [
+                        {"date": "03-06-2026", "shift": "M", "qty": 2.38, "fat": 7.2, "snf": 9.1, "amount": 146.47},
+                        {"date": "03-06-2026", "shift": "M", "qty": 9.68, "fat": 4.2, "snf": 8.5, "amount": 355.93},
+                    ], "deduction": []}
+                )
+            return FarmerMilkCollectionResponseModel.model_validate({"milk": [], "deduction": []})
+
+        monkeypatch.setattr(
+            "agents.tools.milk_collection.get_farmer_milk_collection_details_api",
+            _fake_api,
+        )
+
+        accounts = [
+            FarmerAccount(union_code="2017", society_code="1", farmer_code="1006", society_name="LALAVADA"),
+            FarmerAccount(union_code="2017", society_code="1", farmer_code="0006", society_name="LALAVADA"),
+        ]
+        result = asyncio.run(
+            get_farmer_milk_collection_details(
+                _ctx(accounts), "2017", "1", "1006", "2026-06-03", "2026-06-03"
+            )
+        )
+
+        # Both accounts present, each labelled; the populated account's records surface.
+        assert "farmer code 1006" in result
+        assert "farmer code 0006" in result
+        assert "quantity 2.38 liters" in result
+        assert "quantity 9.68 liters" in result
+
+    def test_falls_back_to_supplied_codes_when_no_accounts_in_context(self, monkeypatch):
+        monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
+        seen = {}
+
+        async def _fake_api(request, token):
+            seen["codes"] = request.to_query_params()
+            return FarmerMilkCollectionResponseModel.model_validate(
+                {"milk": [{"date": "2026-04-01", "shift": "M", "qty": 5, "fat": 4, "snf": 8, "amount": 200}], "deduction": []}
+            )
+
+        monkeypatch.setattr(
+            "agents.tools.milk_collection.get_farmer_milk_collection_details_api",
+            _fake_api,
+        )
+
+        # Empty context -> use the LLM-supplied codes.
+        result = asyncio.run(
+            get_farmer_milk_collection_details(
+                _ctx([]), "2021", "1066", "123", "2026-04-01", "2026-04-01"
+            )
+        )
+        assert seen["codes"]["farmerCode"] == "123"
+        assert "quantity 5 liters" in result
 
     def test_missing_token_returns_clear_failure_and_does_not_call_backend(self, monkeypatch):
         monkeypatch.delenv("PASHUGPT_TOKEN", raising=False)
@@ -62,17 +128,13 @@ class TestMilkCollectionTool:
 
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                "2021",
-                "1066",
-                "123",
-                "2026-04-01",
-                "2026-04-01",
+                _ctx(), "2021", "1066", "123", "2026-04-01", "2026-04-01"
             )
         )
 
         assert result == "Milk collection lookup failed. Service is not configured."
 
-    def test_invalid_date_returns_validation_failure_and_does_not_call_backend(self, monkeypatch):
+    def test_invalid_date_returns_validation_failure(self, monkeypatch):
         monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
 
         async def _unexpected_api(request, token):
@@ -83,13 +145,10 @@ class TestMilkCollectionTool:
             _unexpected_api,
         )
 
+        accounts = [FarmerAccount(union_code="2021", society_code="1066", farmer_code="123")]
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                "2021",
-                "1066",
-                "123",
-                "01-04-2026",
-                "2026-04-01",
+                _ctx(accounts), "2021", "1066", "123", "01-04-2026", "2026-04-01"
             )
         )
 
@@ -109,11 +168,7 @@ class TestMilkCollectionTool:
 
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                "2021",
-                "1066",
-                "123",
-                "2026-04-01",
-                "2026-04-01",
+                _ctx(), "2021", "1066", "123", "2026-04-01", "2026-04-01"
             )
         )
 


### PR DESCRIPTION
## Problem
A single mobile can map to multiple PashuGPT accounts (e.g. a cow account and a buffalo account). Voice's farmer-context builder used `farmers[0]`, so the agent ran the milk lookup against just **one** account's codes. For `8320075240` that was the empty cow account (`farmerCode 1006`) while the actual milk sat under the buffalo account (`0006`: 2.38L + 9.68L) — so voice answered "no milk today" while chat (which landed on `0006`) worked. **This is the real cause of "milk works on chat, not voice."** (The earlier formatting hotfix #160/#161 was real but addressed a different symptom.)

## Fix
The milk tool now takes `RunContext` and **fans out over every account** on the caller's mobile, aggregating per-account results, instead of trusting the single set of codes the small OSS model happened to pick.
- `agents/deps.py`: add `FarmerAccount`; `FarmerContext` carries `farmer_accounts`.
- `voice.py`: `_collect_farmer_accounts(envelope)` (dedup on union/society/farmer), populated into deps.
- `milk_collection.py`: `get_farmer_milk_collection_details(ctx, ...)` queries all accounts; single account → no per-account header (unchanged UX), multiple → labelled sections; date range validated once; falls back to LLM-supplied codes when context has no accounts (cold cache).
- `tools/__init__.py`: register with `takes_ctx=True`.

## Verified on dev (live, farmer 8320075240)
Logs: `accounts=2` → `1006` milk=0, `0006` milk=2 → `total_milk_records=2`. Agent answered *"12.06 liters total, in two collections"* (= 2.38 + 9.68) — the records voice missed entirely before.
6 milk-tool unit tests pass (multi-account, single-account, cold-cache fallback, invalid-date). Zero new failures vs `amul-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)