### PR TITLE
fix(schemes): normalize union name aliases (sarhad→kutch) for scheme lookup [prod]

### DIFF
--- a/agents/tools/union_schemes.py
+++ b/agents/tools/union_schemes.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic_ai import RunContext
 
 from agents.deps import FarmerContext
-from app.models.union import UnionName
+from app.models.union import UnionName, canonical_union_name
 from app.services.scheme_ingestion import (
     SchemeCacheError,
     SchemeDependencyError,
@@ -43,7 +43,9 @@ async def get_union_scheme_data(ctx: RunContext[FarmerContext], scheme_name: str
     Returns:
         A JSON-formatted string of cached scheme records, or a clear no-data message.
     """
-    farmer_unions = [union_name.strip().lower() for union_name in ctx.deps.farmer_unions if union_name]
+    # Normalize each raw union name (dairy brand / spelling variant, e.g. "sarhad"
+    # for Kutch) to its canonical UnionName value before matching the supported set.
+    farmer_unions = [canonical_union_name(union_name) for union_name in ctx.deps.farmer_unions if union_name]
     normalized_union_name = next((union_name for union_name in farmer_unions if union_name in SUPPORTED_SCHEME_UNIONS), None)
     normalized_scheme_name = scheme_name.strip() if scheme_name else None
     logger.info(

--- a/app/models/union.py
+++ b/app/models/union.py
@@ -3,4 +3,51 @@ from enum import Enum
 
 class UnionName(str, Enum):
     BANAS = "banas"
+    SABAR = "sabar"
+    KAIRA = "kaira"
+    SUMUL = "sumul"
+    PANCHMAHAL = "panchmahal"
+    BARODA = "baroda"
+    VALSAD = "valsad"
+    RAJKOT = "rajkot"
+    BHAVNAGAR = "bhavnagar"
+    MEHSANA = "mehsana"
+    SURENDRANAGAR = "surendranagar"
+    JAMNAGAR = "jamnagar"
+    GANDHINAGAR = "gandhinagar"
+    BHARUCH = "bharuch"
     KUTCH = "kutch"
+    BOTAD = "botad"
+    JUNAGADH = "junagadh"
+    AMRELI = "amreli"
+    MORBI = "morbi"
+    PORBANDAR = "porbandar"
+    AHMEDABAD = "ahmedabad"
+
+
+# Brand / spelling variants that farmer-source APIs return for a union, mapped to
+# the canonical UnionName value. A union is often returned by its dairy brand
+# (Kutch -> "Sarhad", Mehsana -> "Dudhsagar") or an alternate spelling
+# ("Kachchh", "Banaskantha"). Normalizing through this map lets union-scoped
+# features (e.g. scheme lookup) resolve a farmer's union regardless of which
+# name the source returns. Keys are lowercase; values equal a UnionName value.
+UNION_NAME_ALIASES: dict[str, str] = {
+    "sarhad": UnionName.KUTCH.value,
+    "kachchh": UnionName.KUTCH.value,
+    "kutchh": UnionName.KUTCH.value,
+    "banaskantha": UnionName.BANAS.value,
+    "dudhsagar": UnionName.MEHSANA.value,
+}
+
+
+def canonical_union_name(name: str | None) -> str:
+    """Normalize a raw union name to its canonical ``UnionName`` value.
+
+    Trims and lowercases the input, then maps known brand/spelling variants
+    (see :data:`UNION_NAME_ALIASES`) to the canonical union. Returns the cleaned
+    input unchanged when no alias applies, and ``""`` for ``None``/blank.
+    """
+    if not name:
+        return ""
+    key = name.strip().lower()
+    return UNION_NAME_ALIASES.get(key, key)

--- a/tests/test_union_aliases.py
+++ b/tests/test_union_aliases.py
@@ -1,0 +1,63 @@
+"""Tests for canonical union-name normalization and its use in the voice union scheme tool.
+
+A farmer-source API returns a union by its dairy brand or a spelling variant
+(e.g. "sarhad" for Kutch's Sarhad Dairy). The scheme tool must resolve those to
+the canonical union so scheme lookup works.
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.union import UnionName, canonical_union_name, UNION_NAME_ALIASES
+import agents.tools.union_schemes as us
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("sarhad", "kutch"),
+    ("Sarhad", "kutch"),
+    ("  KACHCHH  ", "kutch"),
+    ("kutchh", "kutch"),
+    ("kutch", "kutch"),
+    ("banaskantha", "banas"),
+    ("banas", "banas"),
+    ("dudhsagar", "mehsana"),
+    ("kaira", "kaira"),
+    ("", ""),
+    (None, ""),
+])
+def test_canonical_union_name(raw, expected):
+    assert canonical_union_name(raw) == expected
+
+
+def test_alias_targets_are_valid_unions():
+    valid = {u.value for u in UnionName}
+    for canonical in UNION_NAME_ALIASES.values():
+        assert canonical in valid
+
+
+def _ctx(unions):
+    return SimpleNamespace(deps=SimpleNamespace(farmer_unions=unions))
+
+
+def test_tool_resolves_sarhad_to_kutch(monkeypatch):
+    async def fake_records(union_name):
+        assert union_name == "kutch"  # canonicalized before lookup
+        return [{"scheme_title": "Group Personal Accident Insurance Scheme (GPAIS)"}]
+
+    monkeypatch.setattr(us, "get_cached_scheme_records_for_union", fake_records)
+
+    out = asyncio.run(us.get_union_scheme_data(_ctx(["sarhad"]), None))
+    assert "GPAIS" in out
+    assert "could not be determined" not in out
+
+
+def test_tool_unsupported_union_still_fails():
+    out = asyncio.run(us.get_union_scheme_data(_ctx(["dudhsagar"]), None))
+    assert "could not be determined" in out


### PR DESCRIPTION
PROD counterpart of #164. Same change cherry-picked onto `amul-prod`.

Normalizes farmer union names (dairy-brand/spelling variants) to canonical `UnionName` values so the voice scheme tool resolves e.g. Kutch's `sarhad` → kutch; also completes the voice `UnionName` enum to match amul-oan-api. Verified against live prod cache: sarhad/kachchh→kutch (2 schemes), banaskantha→banas (13). Fixes the alias class only; the ~98% empty-union upstream gap is separate.

See #164 for full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)