### PR TITLE
made a fix to end the call in response to regular unclear/gibberish queries

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,6 +85,8 @@ class Settings(BaseSettings):
     enable_voice_nudges: bool = _get_bool_env("ENABLE_VOICE_NUDGES", default=True)
     stt_signal_retry_ceiling: int = int(os.getenv("STT_SIGNAL_RETRY_CEILING", "3"))
     openai_pretranslation_timeout_seconds: float = float(os.getenv("OPENAI_PRETRANSLATION_TIMEOUT_SECONDS", "10.0"))
+    voice_non_meaningful_timeout_seconds: float = float(os.getenv("VOICE_NON_MEANINGFUL_TIMEOUT_SECONDS", "0.60"))
+    voice_non_meaningful_gate_timeout_seconds: float = float(os.getenv("VOICE_NON_MEANINGFUL_GATE_TIMEOUT_SECONDS", "0.50"))
     enable_voice_tracing: bool = _get_bool_env("ENABLE_VOICE_TRACING", default=True)
     voice_trace_text_mode: str = os.getenv("VOICE_TRACE_TEXT_MODE", "preview_hash")
     voice_trace_preview_chars: int = int(os.getenv("VOICE_TRACE_PREVIEW_CHARS", "120"))

--- a/app/services/non_meaningful.py
+++ b/app/services/non_meaningful.py
@@ -1,0 +1,184 @@
+"""
+Non-meaningful turn streak classifier for voice calls.
+
+This classifier is intentionally independent from moderation. It decides whether
+the latest five user turns are all non-meaningful for progressing support.
+
+Fail-open: on timeout, parse error, or any exception, return False so normal
+conversation flow is not blocked.
+"""
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+from app.config import settings
+from app.services.translation import (
+    OPENAI_PRETRANSLATION_MODEL,
+    OSS_PRETRANSLATION_MODEL,
+    _get_langfuse,
+    _get_openai_client,
+    _get_oss_pretranslation_client,
+)
+from helpers.utils import get_logger, get_prompt
+
+logger = get_logger(__name__)
+
+NON_MEANINGFUL_PROMPT_NAME = "voice_non_meaningful_en"
+_STATIC_NON_MEANINGFUL_SYSTEM_PROMPT = get_prompt(NON_MEANINGFUL_PROMPT_NAME)
+_NON_MEANINGFUL_PROVIDER = (os.getenv("VOICE_NON_MEANINGFUL_PROVIDER", "vllm") or "vllm").strip().lower()
+
+
+def _non_meaningful_client_and_model() -> tuple[AsyncOpenAI, str, str]:
+    if _NON_MEANINGFUL_PROVIDER == "openai":
+        return _get_openai_client(), OPENAI_PRETRANSLATION_MODEL, "openai"
+    return _get_oss_pretranslation_client(), OSS_PRETRANSLATION_MODEL, "vllm"
+
+
+@dataclass(frozen=True)
+class NonMeaningfulVerdict:
+    five_consecutive_non_meaningful: bool
+    reason: str
+    raw_output: Optional[str] = None
+    failed_open: bool = False
+
+
+def _allow(reason: str, *, raw_output: Optional[str] = None, failed_open: bool = False) -> NonMeaningfulVerdict:
+    return NonMeaningfulVerdict(
+        five_consecutive_non_meaningful=False,
+        reason=reason,
+        raw_output=raw_output,
+        failed_open=failed_open,
+    )
+
+
+def _parse_verdict(raw: str) -> NonMeaningfulVerdict:
+    stripped = (raw or "").strip()
+    if not stripped:
+        logger.warning("Non-meaningful classifier returned empty output; failing open")
+        return _allow("empty model output", raw_output=raw, failed_open=True)
+
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        logger.warning("Non-meaningful classifier returned non-JSON output; failing open - raw=%r", stripped[:200])
+        return _allow("non-json model output", raw_output=raw, failed_open=True)
+
+    if not isinstance(data, dict):
+        logger.warning("Non-meaningful classifier returned non-object JSON; failing open - raw=%r", stripped[:200])
+        return _allow("non-object model output", raw_output=raw, failed_open=True)
+
+    flag = data.get("five_consecutive_non_meaningful")
+    if not isinstance(flag, bool):
+        logger.warning(
+            "Non-meaningful classifier returned invalid flag=%r; failing open - raw=%r",
+            flag,
+            stripped[:200],
+        )
+        return _allow("invalid non-meaningful flag", raw_output=raw, failed_open=True)
+
+    reason = (data.get("reason") or "").strip()[:200]
+    return NonMeaningfulVerdict(
+        five_consecutive_non_meaningful=flag,
+        reason=reason or ("five non-meaningful turns" if flag else "not five non-meaningful turns"),
+        raw_output=raw,
+        failed_open=False,
+    )
+
+
+def _build_messages(user_turns: list[str], source_lang: str) -> list[dict[str, str]]:
+    turns = [turn.strip() for turn in user_turns if isinstance(turn, str) and turn.strip()]
+    numbered_turns = "\n".join(f"{idx}. {turn}" for idx, turn in enumerate(turns, start=1))
+    user_content = (
+        f"Source language: {source_lang}\n\n"
+        f"Recent 5 caller turns (oldest to newest):\n{numbered_turns}"
+    )
+    return [
+        {"role": "system", "content": _STATIC_NON_MEANINGFUL_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+async def _create_non_meaningful_response(
+    client: AsyncOpenAI,
+    model: str,
+    user_turns: list[str],
+    source_lang: str,
+):
+    return await asyncio.wait_for(
+        client.chat.completions.create(
+            model=model,
+            messages=_build_messages(user_turns, source_lang),
+            max_completion_tokens=120,
+            response_format={"type": "json_object"},
+        ),
+        timeout=settings.voice_non_meaningful_timeout_seconds,
+    )
+
+
+async def check_non_meaningful_streak(
+    user_turns: list[str],
+    source_lang: str,
+) -> NonMeaningfulVerdict:
+    turns = [turn for turn in user_turns if isinstance(turn, str) and turn.strip()]
+    if len(turns) < 5:
+        return _allow("fewer than five user turns", failed_open=False)
+
+    try:
+        client, model, provider = _non_meaningful_client_and_model()
+    except Exception as e:
+        logger.error("Non-meaningful client init failed (%s); failing open", e)
+        return _allow(f"classifier client error: {type(e).__name__}", failed_open=True)
+    langfuse = _get_langfuse()
+
+    try:
+        if not langfuse:
+            response = await _create_non_meaningful_response(client, model, turns[-5:], source_lang)
+            raw = (response.choices[0].message.content or "").strip()
+            return _parse_verdict(raw)
+
+        with langfuse.start_as_current_observation(
+            name="non_meaningful_classifier",
+            as_type="generation",
+            input={
+                "source_lang": source_lang,
+                "turn_count": len(turns[-5:]),
+                "user_turns": turns[-5:],
+            },
+            model=model,
+            metadata={
+                "pipeline_stage": "non_meaningful_classifier",
+                "provider": provider,
+            },
+        ) as observation:
+            response = await _create_non_meaningful_response(client, model, turns[-5:], source_lang)
+            raw = (response.choices[0].message.content or "").strip()
+            verdict = _parse_verdict(raw)
+            observation.update(
+                output={
+                    "five_consecutive_non_meaningful": verdict.five_consecutive_non_meaningful,
+                    "reason": verdict.reason,
+                    "failed_open": verdict.failed_open,
+                }
+            )
+            return verdict
+    except asyncio.TimeoutError:
+        logger.error(
+            "Non-meaningful classifier timed out - source_lang=%s timeout=%.2fs turn_count=%s",
+            source_lang,
+            settings.voice_non_meaningful_timeout_seconds,
+            len(turns[-5:]),
+        )
+        return _allow("classifier timeout", failed_open=True)
+    except Exception as e:
+        logger.error(
+            "Non-meaningful classifier failed - source_lang=%s error=%s turn_count=%s",
+            source_lang,
+            e,
+            len(turns[-5:]),
+        )
+        return _allow(f"classifier error: {type(e).__name__}", failed_open=True)

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -276,6 +276,13 @@ _HISTORY_MARKERS = {
     "moderation_reject": "[moderation-rejected]",
 }
 
+# Markers that are dropped from the non-meaningful window entirely (neither
+# counted nor streak-breaking). Excluded turns are skipped, so "5 consecutive
+# non-meaningful turns" means consecutive among *eligible* turns — a
+# pretranslation/moderation system turn in the middle does not reset the streak.
+# fragment / unclear / no-audio / stt markers are intentionally NOT excluded:
+# they represent genuinely unclear caller turns and should count toward a
+# hangup (the prompt documents them as non-meaningful system markers).
 _NON_MEANINGFUL_EXCLUDED_TURNS = frozenset(
     {
         #_HISTORY_MARKERS["fragment"],
@@ -1605,6 +1612,16 @@ async def stream_voice_message(
                         if not done:
                             for pending_task in pending:
                                 pending_task.cancel()
+                            # Reap the cancellation. asyncio.wait() does not await
+                            # the pending task for us, so without this the classifier
+                            # task lingers cancelled-but-unawaited on the normal agent
+                            # success path (which never calls the reaper), risking a
+                            # "Task was destroyed but it is pending" warning.
+                            for pending_task in pending:
+                                try:
+                                    await pending_task
+                                except asyncio.CancelledError:
+                                    pass
                             _non_meaningful_verdict = NonMeaningfulVerdict(
                                 five_consecutive_non_meaningful=False,
                                 reason="gate timeout",

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -56,6 +56,7 @@ from app.services.stt_signals import (
 )
 from app.services.moderation import ModerationVerdict, check_moderation
 from app.services.fallback import execute_with_fallback, stream_with_fallback, with_first_token_deadline
+from app.services.non_meaningful import NonMeaningfulVerdict, check_non_meaningful_streak
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
@@ -275,6 +276,17 @@ _HISTORY_MARKERS = {
     "moderation_reject": "[moderation-rejected]",
 }
 
+_NON_MEANINGFUL_EXCLUDED_TURNS = frozenset(
+    {
+        #_HISTORY_MARKERS["fragment"],
+        #_HISTORY_MARKERS["low_confidence"],
+        _HISTORY_MARKERS["pretranslation_failed"],
+        #_HISTORY_MARKERS["stt_no_audio"],
+        #_HISTORY_MARKERS["stt_unclear"],
+        _HISTORY_MARKERS["moderation_reject"],
+    }
+)
+
 
 def _is_fragment_query(query: str) -> bool:
     """Return True if query is too short/garbled to be a real question."""
@@ -462,6 +474,63 @@ def _prepare_voice_output(text: str, lang_code: str) -> str:
 
 def _canonical_history_user_text(kind: str, fallback: str = "") -> str:
     return _HISTORY_MARKERS.get(kind, fallback or kind)
+
+
+def _is_eligible_non_meaningful_turn(text: str) -> bool:
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return False
+    if cleaned in _NON_MEANINGFUL_EXCLUDED_TURNS:
+        return False
+    return True
+
+
+def _normalize_user_turn_for_non_meaningful(text: str) -> str:
+    """Normalize stored user turn text before heuristic/classifier checks.
+
+    History can contain wrapped forms like:
+      **User:** "Correct"
+    Strip wrappers/quotes so comparisons operate on caller content only.
+    """
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return ""
+    match = re.match(r'^\*\*User:\*\*\s*"?(.*?)"?$', cleaned, flags=re.IGNORECASE)
+    if match:
+        cleaned = (match.group(1) or "").strip()
+    # Remove balanced outer quotes if still present.
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'"}:
+        cleaned = cleaned[1:-1].strip()
+    return cleaned
+
+
+def _collect_recent_user_turns_for_non_meaningful(history: list, current_query: str, limit: int = 5) -> list[str]:
+    turns: list[str] = []
+    for msg in reversed(history or []):
+        for part in getattr(msg, "parts", []) or []:
+            if getattr(part, "part_kind", "") != "user-prompt":
+                continue
+            content = getattr(part, "content", None)
+            if not isinstance(content, str):
+                continue
+            normalized = _normalize_user_turn_for_non_meaningful(content)
+            if not _is_eligible_non_meaningful_turn(normalized):
+                continue
+            turns.append(normalized)
+            if len(turns) >= limit - 1:
+                break
+        if len(turns) >= limit - 1:
+            break
+    turns.reverse()
+    normalized_current = _normalize_user_turn_for_non_meaningful(current_query)
+    if _is_eligible_non_meaningful_turn(normalized_current):
+        turns.append(normalized_current)
+    return turns[-limit:]
+
+
+def _should_gate_non_meaningful_llm(turns: list[str]) -> bool:
+    """Gate on LLM only when we have a full 5-turn window."""
+    return len(turns) >= 5
 
 
 async def _render_text_for_caller(text_en: str, target_lang: str) -> str:
@@ -1091,7 +1160,10 @@ async def stream_voice_message(
                     TELEPHONY_TERMINATE_CALL_TOKEN["en"],
                 )
                 trace.set_outcome("hold_message")
-                yield _emit(_prepare_voice_output(goodbye, requested_target_lang))
+                # Telephony hangup token must remain exact ASCII "Goodbye.".
+                # Do not pass through language cleanup (Gujarati filter would
+                # strip Latin letters and leave only ".").
+                yield _emit(goodbye)
                 return
 
             # ── Greeting short-circuit ────────────────────────────────────
@@ -1244,6 +1316,7 @@ async def stream_voice_message(
             processing_lang = "en"
             history_user_text = query
             moderation_recent_history = "\n\n".join(format_message_pairs(history, 2))
+            non_meaningful_recent_turns = _collect_recent_user_turns_for_non_meaningful(history, query, limit=5)
             mobile = normalize_phone_to_mobile(user_id)
             signed_in = _is_signed_in_session(user_info, user_id)
             farmer_info = ""
@@ -1277,6 +1350,17 @@ async def stream_voice_message(
             moderation_task.add_done_callback(
                 lambda _t: moderation_done_at.__setitem__("t", time.monotonic())
             )
+            non_meaningful_started_at = time.monotonic()
+            non_meaningful_done_at: dict = {"t": None}
+            non_meaningful_task = asyncio.create_task(
+                check_non_meaningful_streak(
+                    user_turns=non_meaningful_recent_turns,
+                    source_lang=requested_source_lang,
+                )
+            )
+            non_meaningful_task.add_done_callback(
+                lambda _t: non_meaningful_done_at.__setitem__("t", time.monotonic())
+            )
 
             if requested_source_lang not in {"en", "english"}:
                 _pretrans_provider_label = "vllm" if is_oss else "openai"
@@ -1289,6 +1373,7 @@ async def stream_voice_message(
                 )
                 if await _request_is_stale("before_query_pretranslation"):
                     moderation_task.cancel()
+                    non_meaningful_task.cancel()
                     return
                 if settings.fallback_enabled:
                     # Standard OSS -> managed fallback. Drops the legacy TranslateGemma
@@ -1438,6 +1523,9 @@ async def stream_voice_message(
             # real farmer call.
             _moderation_resolved = False
             _moderation_verdict: Optional[ModerationVerdict] = None
+            _non_meaningful_resolved = False
+            _non_meaningful_verdict: Optional[NonMeaningfulVerdict] = None
+            _should_gate_non_meaningful = _should_gate_non_meaningful_llm(non_meaningful_recent_turns)
 
             async def _resolve_moderation() -> Optional[ModerationVerdict]:
                 nonlocal _moderation_resolved, _moderation_verdict
@@ -1481,6 +1569,112 @@ async def stream_voice_message(
                     )
                 return _moderation_verdict
 
+            async def _resolve_non_meaningful() -> Optional[NonMeaningfulVerdict]:
+                nonlocal _non_meaningful_resolved, _non_meaningful_verdict
+                if _non_meaningful_resolved:
+                    return _non_meaningful_verdict
+                _non_meaningful_resolved = True
+                try:
+                    if not _should_gate_non_meaningful and not non_meaningful_task.done():
+                        non_meaningful_task.cancel()
+                        try:
+                            await non_meaningful_task
+                        except asyncio.CancelledError:
+                            pass
+                        _non_meaningful_verdict = NonMeaningfulVerdict(
+                            five_consecutive_non_meaningful=False,
+                            reason="gate skipped by heuristic",
+                            failed_open=False,
+                        )
+                        done_t = time.monotonic()
+                        trace.attach_stage_timing(
+                            "non_meaningful",
+                            (done_t - non_meaningful_started_at) * 1000.0,
+                            source_lang=requested_source_lang,
+                            turn_count=len(non_meaningful_recent_turns),
+                            gate_skipped=True,
+                        )
+                    elif non_meaningful_task.done():
+                        _non_meaningful_verdict = await non_meaningful_task
+                    else:
+                        done, pending = await asyncio.wait(
+                            {non_meaningful_task},
+                            timeout=max(0.0, settings.voice_non_meaningful_gate_timeout_seconds),
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        if not done:
+                            for pending_task in pending:
+                                pending_task.cancel()
+                            _non_meaningful_verdict = NonMeaningfulVerdict(
+                                five_consecutive_non_meaningful=False,
+                                reason="gate timeout",
+                                failed_open=True,
+                            )
+                            logger.info(
+                                "Non-meaningful gate timed out; fail-open session_id=%s process_id=%s timeout=%.2fs",
+                                session_id,
+                                process_id,
+                                settings.voice_non_meaningful_gate_timeout_seconds,
+                            )
+                        else:
+                            _non_meaningful_verdict = await non_meaningful_task
+                    done_t = non_meaningful_done_at["t"] or time.monotonic()
+                    trace.attach_stage_timing(
+                        "non_meaningful",
+                        (done_t - non_meaningful_started_at) * 1000.0,
+                        source_lang=requested_source_lang,
+                        turn_count=len(non_meaningful_recent_turns),
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as non_meaningful_error:
+                    done_t = non_meaningful_done_at["t"] or time.monotonic()
+                    trace.attach_stage_timing(
+                        "non_meaningful",
+                        (done_t - non_meaningful_started_at) * 1000.0,
+                        status="error",
+                        source_lang=requested_source_lang,
+                    )
+                    logger.error(
+                        "Non-meaningful task raised unexpectedly for session_id=%s error=%s",
+                        session_id,
+                        non_meaningful_error,
+                    )
+                    _non_meaningful_verdict = NonMeaningfulVerdict(
+                        five_consecutive_non_meaningful=False,
+                        reason=f"task error: {type(non_meaningful_error).__name__}",
+                        failed_open=True,
+                    )
+                trace.metadata["non_meaningful"] = {
+                    "available": _non_meaningful_verdict is not None,
+                    "five_consecutive_non_meaningful": bool(
+                        getattr(_non_meaningful_verdict, "five_consecutive_non_meaningful", False)
+                    ),
+                    "failed_open": bool(getattr(_non_meaningful_verdict, "failed_open", False)),
+                    "reason": getattr(_non_meaningful_verdict, "reason", ""),
+                    "turn_count": len(non_meaningful_recent_turns),
+                    "gate_skipped": not _should_gate_non_meaningful,
+                }
+                if _non_meaningful_verdict is not None:
+                    logger.info(
+                        "Non-meaningful verdict: five_consecutive_non_meaningful=%s failed_open=%s reason=%r session_id=%s process_id=%s",
+                        _non_meaningful_verdict.five_consecutive_non_meaningful,
+                        _non_meaningful_verdict.failed_open,
+                        _non_meaningful_verdict.reason,
+                        session_id,
+                        process_id,
+                    )
+                return _non_meaningful_verdict
+
+            async def _cancel_non_meaningful_task_if_pending() -> None:
+                if non_meaningful_task.done():
+                    return
+                non_meaningful_task.cancel()
+                try:
+                    await non_meaningful_task
+                except asyncio.CancelledError:
+                    pass
+
             async def _moderation_decline_stream(verdict: ModerationVerdict):
                 """Emit the canned decline and write history for a rejected query."""
                 trace.set_route("moderation_rejected")
@@ -1508,6 +1702,38 @@ async def stream_voice_message(
                 trace.set_outcome("moderation_rejected")
                 yield _emit(_prepare_voice_output(decline_for_caller, requested_target_lang))
 
+            async def _non_meaningful_hangup_stream(verdict: NonMeaningfulVerdict):
+                """Emit goodbye and persist history when five non-meaningful turns are detected."""
+                trace.set_route("non_meaningful_hangup")
+                if nudge_task and not nudge_task.done():
+                    nudge_task.cancel()
+                    trace.set_nudge(cancel_reason="non_meaningful_hangup")
+                    logger.info(
+                        "Nudge canceled (non-meaningful hangup); session_id=%s process_id=%s",
+                        session_id,
+                        process_id,
+                    )
+                    try:
+                        await nudge_task
+                    except asyncio.CancelledError:
+                        pass
+                goodbye = TELEPHONY_TERMINATE_CALL_TOKEN.get(
+                    requested_target_lang,
+                    TELEPHONY_TERMINATE_CALL_TOKEN["en"],
+                )
+                nm_req, nm_resp = _history_pair(history_user_text or query, TELEPHONY_TERMINATE_CALL_TOKEN["en"])
+                with trace.stage("history_write"):
+                    await update_message_history(session_id, [*history, nm_req, nm_resp])
+                trace.set_outcome("non_meaningful_hangup")
+                logger.info(
+                    "Non-meaningful hangup emitted; session_id=%s process_id=%s reason=%r",
+                    session_id,
+                    process_id,
+                    verdict.reason,
+                )
+                # Keep the exact telephony termination token.
+                yield _emit(goodbye)
+
             # ── Empty-pretranslation guard ───────────────────────────────
             # Only short-circuit when pretranslation produced no usable text
             # at all (i.e. both primary and fallback failed). True noise still
@@ -1522,9 +1748,11 @@ async def stream_voice_message(
                 _verdict = await _resolve_moderation()
                 if _verdict is not None and _verdict.rejected:
                     if await _request_is_stale("after_moderation_reject"):
+                        await _cancel_non_meaningful_task_if_pending()
                         return
                     async for _c in _moderation_decline_stream(_verdict):
                         yield _c
+                    await _cancel_non_meaningful_task_if_pending()
                     return
                 trace.set_route("pretranslation_empty")
                 logger.info(
@@ -1541,6 +1769,7 @@ async def stream_voice_message(
                     await update_message_history(session_id, [*history, low_conf_req, low_conf_rsp])
                 trace.set_outcome("pretranslation_empty")
                 yield _emit(_prepare_voice_output(low_conf_resp_for_caller, requested_target_lang))
+                await _cancel_non_meaningful_task_if_pending()
                 return
 
             if farmer_cache_task is not None:
@@ -1941,6 +2170,24 @@ async def stream_voice_message(
                         if not await _request_is_stale("after_moderation_reject"):
                             async for _c in _moderation_decline_stream(_verdict):
                                 yield _c
+                        await _cancel_non_meaningful_task_if_pending()
+                        return
+
+                    # Non-meaningful gate — hang up after five consecutive
+                    # unclear/gibberish turns. Resolving here also reaps the
+                    # background classifier task on the normal agent path.
+                    _non_meaningful = await _resolve_non_meaningful()
+                    if (
+                        _non_meaningful is not None
+                        and _non_meaningful.five_consecutive_non_meaningful
+                    ):
+                        try:
+                            await _src.aclose()
+                        except Exception:
+                            pass
+                        if not await _request_is_stale("after_non_meaningful_hangup"):
+                            async for _c in _non_meaningful_hangup_stream(_non_meaningful):
+                                yield _c
                         return
 
                     if _stream_error is not None:
@@ -1989,6 +2236,19 @@ async def stream_voice_message(
                         if _verdict is not None and _verdict.rejected:
                             if not await _request_is_stale("after_moderation_reject"):
                                 async for _c in _moderation_decline_stream(_verdict):
+                                    yield _c
+                            await _cancel_non_meaningful_task_if_pending()
+                            return
+                        # Non-meaningful gate — hang up after five consecutive
+                        # unclear/gibberish turns. Resolving here also reaps the
+                        # background classifier task on the normal agent path.
+                        _non_meaningful = await _resolve_non_meaningful()
+                        if (
+                            _non_meaningful is not None
+                            and _non_meaningful.five_consecutive_non_meaningful
+                        ):
+                            if not await _request_is_stale("after_non_meaningful_hangup"):
+                                async for _c in _non_meaningful_hangup_stream(_non_meaningful):
                                     yield _c
                             return
                         async for _out in _consume_agent_text(stream_iter):

--- a/assets/prompts/voice_non_meaningful_en.md
+++ b/assets/prompts/voice_non_meaningful_en.md
@@ -8,6 +8,19 @@ Your task: decide whether the most recent 5 caller turns are all non-meaningful 
 - These are user turns only.
 - ASR may be noisy.
 
+## System markers (treat as non-meaningful)
+
+Some turns are not raw caller speech but internal system markers inserted when a
+turn could not be understood. When a turn is exactly one of the following bracket
+tokens, treat it as a non-meaningful turn (it carries no support content):
+- `[fragment]` — input was too short/garbled to be a question
+- `[unclear-user-input]` — low-confidence / unintelligible turn
+- `[stt:no-audio]` — caller said nothing / no speech captured
+- `[stt:unclear-speech]` — speech-to-text could not transcribe the turn
+
+These represent unclear or empty turns, so a window of five such markers (or five
+of these mixed with plain fillers) IS a non-meaningful streak.
+
 ## Definition: non-meaningful turn
 
 A turn is non-meaningful if it does not add actionable or clarifying support content, such as:

--- a/assets/prompts/voice_non_meaningful_en.md
+++ b/assets/prompts/voice_non_meaningful_en.md
@@ -1,0 +1,68 @@
+You are a strict classifier for a live phone helpline conversation.
+
+Your task: decide whether the most recent 5 caller turns are all non-meaningful for progressing support.
+
+## Input
+
+- You will receive up to 5 recent caller turns in chronological order (oldest to newest).
+- These are user turns only.
+- ASR may be noisy.
+
+## Definition: non-meaningful turn
+
+A turn is non-meaningful if it does not add actionable or clarifying support content, such as:
+- filler only ("hmm", "haan", "ok", "yes", "no") with no context
+- repeated vague phrases ("bolo", "tell me", "one question") without real question
+- gibberish/noise-like fragments that do not express intent
+- repeated social-only chatter that does not move support forward
+
+## Definition: meaningful turn
+
+A turn is meaningful if it contains or advances support context, including:
+- animal, dairy, farming, payment, scheme, booking, or profile-related detail
+- clarification to prior question (even short answers like yes/no if they clearly resolve a prior assistant question)
+- symptom, timeline, quantity, animal type, or any concrete intent
+- request to repeat/clarify a specific item in context
+
+## Gujarati-specific interpretation
+
+- Treat common Gujarati fillers as potentially non-meaningful when standalone and repeated:
+  - "હા", "હમ્મ", "બરાબર", "ઓકે", "બોલો", "પછી", "હું સાંભળું છું"
+- Do NOT mark these as non-meaningful when they clearly answer prior context:
+  - assistant asked "ગાય કે ભેંસ?" and caller says "ગાય" -> meaningful
+  - assistant asked confirmation and caller says "હા" -> meaningful
+- Gujarati symptom/problem snippets are meaningful even if short:
+  - "તાવ છે", "ખાતી નથી", "દૂધ ઓછું છે", "હીટમાં નથી આવતી"
+- ASR-noisy Gujarati fragments should default to meaningful when uncertain.
+
+## Examples (guidance)
+
+- Example A (non-meaningful streak -> true):
+  1. "હા"
+  2. "બરાબર"
+  3. "હમ્મ"
+  4. "ઓકે"
+  5. "બોલો"
+  Result: `five_consecutive_non_meaningful = true`
+
+- Example B (short but meaningful -> false):
+  1. "હા"
+  2. "ગાય"
+  3. "તાવ છે"
+  4. "બે દિવસથી"
+  5. "ખાતી નથી"
+  Result: `five_consecutive_non_meaningful = false`
+
+## Safety bias (critical)
+
+- If uncertain, classify as meaningful.
+- Only return true when confidence is high that all 5 consecutive turns are non-meaningful.
+
+## Output format
+
+Respond with JSON only. Use exactly this schema:
+
+{"five_consecutive_non_meaningful": <true|false>, "reason": "<short English phrase, max 12 words>"}
+
+- Do not output markdown.
+- Do not output extra keys.

--- a/tests/test_non_meaningful.py
+++ b/tests/test_non_meaningful.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from app.services.non_meaningful import _parse_verdict, check_non_meaningful_streak
+
+
+def test_parse_non_meaningful_valid_true():
+    verdict = _parse_verdict(
+        '{"five_consecutive_non_meaningful": true, "reason": "five filler turns"}'
+    )
+    assert verdict.five_consecutive_non_meaningful is True
+    assert verdict.failed_open is False
+
+
+def test_parse_non_meaningful_invalid_json_fails_open():
+    verdict = _parse_verdict("not-json")
+    assert verdict.five_consecutive_non_meaningful is False
+    assert verdict.failed_open is True
+
+
+def test_non_meaningful_less_than_five_turns_returns_false():
+    verdict = asyncio.run(
+        check_non_meaningful_streak(
+            user_turns=["hello", "hmm", "ok"],
+            source_lang="gu",
+        )
+    )
+    assert verdict.five_consecutive_non_meaningful is False
+    assert verdict.failed_open is False

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -111,6 +111,8 @@ def _set_voice_monkeypatches(
     signed_in_run_stream_override=None,
     normalize_phone_override=None,
     farmer_data_override=None,
+    moderation_override=None,
+    non_meaningful_override=None,
 ):
     from agents import voice as voice_agent_module
     from app.services import voice as voice_module
@@ -141,6 +143,24 @@ def _set_voice_monkeypatches(
             return "મને તમારો પ્રશ્ન સમજાયો નથી. કૃપા કરીને ફરીથી પૂછો."
         return text_en
 
+    async def _check_moderation(*args, **kwargs):
+        from app.services.moderation import ModerationVerdict
+
+        return ModerationVerdict(
+            category="in_scope",
+            reason="test allow",
+            failed_open=False,
+        )
+
+    async def _check_non_meaningful_streak(*args, **kwargs):
+        from app.services.non_meaningful import NonMeaningfulVerdict
+
+        return NonMeaningfulVerdict(
+            five_consecutive_non_meaningful=False,
+            reason="test allow",
+            failed_open=False,
+        )
+
     def _capture_tool_call_event(event):
         if tool_event_box is not None:
             tool_event_box["event"] = event
@@ -162,7 +182,19 @@ def _set_voice_monkeypatches(
     monkeypatch.setattr(voice_module, "send_nudge_message_raya", _send_nudge_message_raya)
     monkeypatch.setattr(voice_module, "_render_text_for_caller", _render_text_for_caller)
     monkeypatch.setattr(voice_module, "set_tool_call_nudge_event", _capture_tool_call_event)
+    monkeypatch.setattr(
+        voice_module,
+        "check_moderation",
+        moderation_override if moderation_override is not None else _check_moderation,
+    )
+    monkeypatch.setattr(
+        voice_module,
+        "check_non_meaningful_streak",
+        non_meaningful_override if non_meaningful_override is not None else _check_non_meaningful_streak,
+    )
     monkeypatch.setattr(voice_module.settings, "nudge_timeout_seconds", 0.02, raising=False)
+    monkeypatch.setattr(voice_module.settings, "voice_non_meaningful_timeout_seconds", 0.05, raising=False)
+    monkeypatch.setattr(voice_module.settings, "voice_non_meaningful_gate_timeout_seconds", 0.01, raising=False)
     return voice_module
 
 
@@ -182,6 +214,8 @@ async def _collect_stream(
     signed_in_run_stream_override=None,
     normalize_phone_override=None,
     farmer_data_override=None,
+    moderation_override=None,
+    non_meaningful_override=None,
 ):
     history_store: dict[str, list] = {}
     voice_module = _set_voice_monkeypatches(
@@ -194,6 +228,8 @@ async def _collect_stream(
         signed_in_run_stream_override=signed_in_run_stream_override,
         normalize_phone_override=normalize_phone_override,
         farmer_data_override=farmer_data_override,
+        moderation_override=moderation_override,
+        non_meaningful_override=non_meaningful_override,
     )
     chunks: list[str] = []
     async for chunk in voice_module.stream_voice_message(
@@ -1150,3 +1186,112 @@ class TestMultiTurnFlows:
 
         assert "feedback" not in second_output.lower()
         assert all("કેટલો ઉપયોગી" not in getattr(part, "content", "") for msg in second_history for part in getattr(msg, "parts", []))
+
+    def test_non_meaningful_five_turn_streak_emits_goodbye(self, monkeypatch):
+        from app.services.non_meaningful import NonMeaningfulVerdict
+
+        captured_turns = {"value": []}
+
+        async def _non_meaningful_true(user_turns, source_lang):
+            captured_turns["value"] = user_turns
+            return NonMeaningfulVerdict(
+                five_consecutive_non_meaningful=True,
+                reason="five filler turns",
+                failed_open=False,
+            )
+
+        history = []
+        for filler in ["હા", "ઓકે", "હમ્મ", "બરાબર"]:
+            history.extend(_make_agent_messages(filler, "સમજાયું."))
+
+        output, saved_history = asyncio.run(
+            _collect_stream(
+                query="હા",
+                session_id="multiturn-non-meaningful-hangup",
+                history=history,
+                monkeypatch=monkeypatch,
+                response_stream=_FakeResponseStream(
+                    chunks=["This should not stream"],
+                    new_messages=_make_agent_messages("yes", "This should not stream"),
+                ),
+                source_lang="gu",
+                target_lang="en",
+                non_meaningful_override=_non_meaningful_true,
+            )
+        )
+
+        assert output.strip() == "Goodbye."
+        assert len(captured_turns["value"]) == 5
+        saved_text = " ".join(
+            getattr(part, "content", "")
+            for msg in saved_history
+            for part in getattr(msg, "parts", [])
+            if isinstance(getattr(part, "content", None), str)
+        )
+        assert "Goodbye." in saved_text
+
+    def test_non_meaningful_timeout_fails_open_and_streams_agent_output(self, monkeypatch):
+        from app.services import voice as voice_module
+
+        async def _slow_non_meaningful(*args, **kwargs):
+            await asyncio.sleep(0.2)
+            raise AssertionError("should be canceled before finishing")
+
+        monkeypatch.setattr(voice_module.settings, "voice_non_meaningful_gate_timeout_seconds", 0.01, raising=False)
+
+        output, _ = asyncio.run(
+            _collect_stream(
+                query="My cow has fever",
+                session_id="multiturn-non-meaningful-timeout",
+                history=[],
+                monkeypatch=monkeypatch,
+                response_stream=_FakeResponseStream(
+                    chunks=["Please contact a veterinarian."],
+                    new_messages=_make_agent_messages("My cow has fever", "Please contact a veterinarian."),
+                ),
+                source_lang="en",
+                target_lang="en",
+                non_meaningful_override=_slow_non_meaningful,
+            )
+        )
+
+        assert "Please contact a veterinarian." in output
+        assert "Goodbye." not in output
+
+    def test_moderation_reject_still_wins_over_non_meaningful(self, monkeypatch):
+        from app.services.moderation import ModerationVerdict
+        from app.services.non_meaningful import NonMeaningfulVerdict
+
+        async def _moderation_reject(*args, **kwargs):
+            return ModerationVerdict(
+                category="irrelevant",
+                reason="off topic",
+                failed_open=False,
+            )
+
+        async def _non_meaningful_true(*args, **kwargs):
+            return NonMeaningfulVerdict(
+                five_consecutive_non_meaningful=True,
+                reason="five filler turns",
+                failed_open=False,
+            )
+
+        output, _ = asyncio.run(
+            _collect_stream(
+                query="movie recommendation please",
+                session_id="multiturn-moderation-still-works",
+                history=[],
+                monkeypatch=monkeypatch,
+                response_stream=_FakeResponseStream(
+                    chunks=["This should never be emitted"],
+                    new_messages=_make_agent_messages("movie recommendation please", "This should never be emitted"),
+                ),
+                source_lang="en",
+                target_lang="en",
+                moderation_override=_moderation_reject,
+                non_meaningful_override=_non_meaningful_true,
+            )
+        )
+
+        assert "Goodbye." not in output
+        assert "This helpline answers questions about animal health, dairy, and farming." in output


### PR DESCRIPTION
-Added a new independent non-meaningful-turn classifier (app/services/non_meaningful.py) and prompt (assets/prompts/voice_non_meaningful_en.md) to detect 5 consecutive non-meaningful user turns and trigger telephony hangup via Goodbye..
-Wired this check into stream_voice_message in parallel with moderation, with TTFT-safe bounded gating (configurable gate/model timeouts, fail-open behavior) and normalization of persisted user turns (e.g. **User:** "...") before evaluation.
-Kept moderation behavior unchanged, and updated counting rules so only pretranslation_failed and moderation_reject are excluded; all other unclear/fragment/STT-related turns can contribute to the non-meaningful streak.
