### PR TITLE
OSS fallback follow-ups: enforce streaming TTFT timeout + cleanup

### DIFF
--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -10,13 +10,19 @@ falling back on infrastructure errors, and recording every failure for the
 Gated by ``settings.fallback_enabled`` (default off): when disabled, callers keep
 their existing code path, so merging this changes nothing until it is flipped on.
 
-Streaming core-chat fallback (``stream_with_fallback``, first-token commit) is a
-later increment and intentionally not implemented here.
+Core-chat streaming uses ``stream_with_fallback`` (first-token commit): an OSS
+failure *before* the first token swaps to managed transparently; once the first
+token has reached the caller a swap is impossible, so the error propagates.
+``with_first_token_deadline`` bounds time-to-first-token only (it disarms after the
+first token, so mid-stream tool round-trips / slow generation are unaffected) —
+the streaming path cannot use an external ``anyio.fail_after`` (see the note in
+``stream_with_fallback``).
 """
 
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 
 import anyio
@@ -320,6 +326,35 @@ async def execute_with_fallback(
                 raise
 
 
+async def with_first_token_deadline(attempt: Attempt, agen: AsyncIterator[Any]) -> AsyncIterator[Any]:
+    """Wrap an agent token stream with a *time-to-first-token* deadline.
+
+    ``attempt.timeout`` bounds only the wait for the FIRST item; the deadline is
+    disarmed the moment the first item is yielded, so legitimate mid-stream gaps
+    (tool round-trips, slow generation) are NOT aborted — that is why we cannot
+    just shorten the model's httpx read-timeout, which can't tell a silent
+    pre-first-token hang from a normal inter-token gap.
+
+    Raises ``TimeoutError`` if the first item does not arrive in time (which
+    ``classify`` maps to ``TIMEOUT`` -> fallbackable, so ``stream_with_fallback``
+    swaps to the next tier before any token reached the caller). No-op when
+    ``attempt.timeout`` is None (fallback disabled).
+
+    Implemented as a cancel scope in the SAME task as ``agen`` (an ``async for``,
+    not a wrapping task), so pydantic-ai's internal ``run_stream`` cancel scope
+    unwinds in order — see the note in ``stream_with_fallback``.
+    """
+    ttft = attempt.timeout
+    with anyio.move_on_after(ttft if ttft is not None else math.inf) as scope:
+        async for item in agen:
+            scope.deadline = math.inf  # first token in — disarm; let the rest stream freely
+            yield item
+    if scope.cancelled_caught:
+        raise TimeoutError(
+            f"OSS first-token deadline exceeded ({ttft}s) [{attempt.kind}/{attempt.endpoint}]"
+        )
+
+
 async def _aclose(agen) -> None:
     close = getattr(agen, "aclose", None)
     if close is not None:
@@ -365,8 +400,9 @@ async def stream_with_fallback(
         # that stays open across the `yield`, so any external timeout/task wrapper
         # unwinds the scopes out of order ("cancel scope in a different task" /
         # "not the current task's cancel scope"). `async for` lets Python manage the
-        # generator lifecycle in this task. A first-token deadline, if wanted, is
-        # applied INSIDE make_stream (same frame as run_stream).
+        # generator lifecycle in this task. The time-to-first-token deadline is
+        # applied by callers wrapping make_stream in `with_first_token_deadline`
+        # (a cancel scope in this same task, disarmed after the first token).
         try:
             async for chunk in make_stream(attempt):
                 committed = True
@@ -418,10 +454,6 @@ async def stream_with_fallback(
                 continue
             raise
 
-    if last_exc is not None:
-        raise last_exc
-        return
-
-    # All tiers failed before commit.
+    # All tiers failed before commit (every fallbackable tier swapped, last raised).
     if last_exc is not None:
         raise last_exc

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -55,7 +55,7 @@ from app.services.stt_signals import (
     count_consecutive_stt_signals,
 )
 from app.services.moderation import ModerationVerdict, check_moderation
-from app.services.fallback import execute_with_fallback, stream_with_fallback
+from app.services.fallback import execute_with_fallback, stream_with_fallback, with_first_token_deadline
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
@@ -1889,7 +1889,7 @@ async def stream_voice_message(
                     # driven from a single task (see below) for anyio task-affinity.
                     _fb_holder: dict = {}
 
-                    async def _make_stream(attempt):
+                    async def _raw_stream(attempt):
                         async with active_agent.run_stream(
                             user_prompt=user_message,
                             message_history=model_input_history,
@@ -1900,6 +1900,14 @@ async def stream_voice_message(
                             async for _c in rs.stream_text(delta=True, debounce_by=0):
                                 yield _c
                             _fb_holder["new_messages"] = rs.new_messages()
+
+                    async def _make_stream(attempt):
+                        # Bound time-to-first-token (attempt.timeout) so a silent OSS
+                        # hang swaps to managed before the caller hears anything; the
+                        # deadline disarms after the first token, so a long mid-stream
+                        # gap (tool round-trip) keeps the model's 600s read-timeout.
+                        async for _c in with_first_token_deadline(attempt, _raw_stream(attempt)):
+                            yield _c
 
                     _src = stream_with_fallback(
                         pipeline="chat",

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -237,3 +237,70 @@ def test_stream_precommit_bad_output_does_not_swap(oss_enabled):
             pipeline="chat", session_id="s", variant="oss", make_stream=make_stream)))
     assert len(oss_enabled) == 1
     assert oss_enabled[0].committed is False and oss_enabled[0].fell_back is False
+
+
+# ── with_first_token_deadline() (time-to-first-token bound) ──────────────────
+
+def _attempt(timeout):
+    return fb.Attempt(kind="oss", model=object(), model_name="gemma-test",
+                      provider="vllm", endpoint="http://oss:8020/v1", timeout=timeout)
+
+
+def test_ttft_slow_first_token_raises_timeout():
+    """First token later than the deadline -> TimeoutError (classify -> TIMEOUT)."""
+    async def raw(attempt):
+        await asyncio.sleep(0.20)
+        yield "late"
+
+    async def drive():
+        return await _collect(fb.with_first_token_deadline(_attempt(0.05), raw(None)))
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(drive())
+    assert classify(TimeoutError("x")) is FallbackReason.TIMEOUT
+
+
+def test_ttft_disarmed_after_first_token_allows_long_gap():
+    """The deadline must bound ONLY time-to-first-token: a long gap AFTER the
+    first token (e.g. a tool round-trip) must not abort the stream."""
+    async def raw(attempt):
+        yield "first"                 # arrives immediately, well within deadline
+        await asyncio.sleep(0.15)     # > deadline, but post-first-token -> allowed
+        yield "second"
+
+    out = asyncio.run(_collect(fb.with_first_token_deadline(_attempt(0.05), raw(None))))
+    assert out == ["first", "second"]
+
+
+def test_ttft_none_is_noop():
+    """timeout=None (fallback disabled) -> no deadline, slow first token is fine."""
+    async def raw(attempt):
+        await asyncio.sleep(0.05)
+        yield "ok"
+
+    out = asyncio.run(_collect(fb.with_first_token_deadline(_attempt(None), raw(None))))
+    assert out == ["ok"]
+
+
+def test_ttft_timeout_triggers_fallback_to_managed(oss_enabled):
+    """End to end: a silent OSS first-token hang swaps to managed before commit."""
+    async def make_stream(attempt):
+        async for c in fb.with_first_token_deadline(attempt, _raw(attempt)):
+            yield c
+
+    async def _raw(attempt):
+        if attempt.kind == "oss":
+            await asyncio.sleep(0.30)     # exceeds the oss attempt timeout
+            yield "oss-never"             # pragma: no cover
+        else:
+            yield "managed:ok"
+
+    oss_enabled  # fixture active
+    import app.config as _cfg
+    _cfg.settings.fallback_chat_oss_timeout_ms = 50
+    chunks = asyncio.run(_collect(fb.stream_with_fallback(
+        pipeline="chat", session_id="s", variant="oss", make_stream=make_stream)))
+    assert chunks == ["managed:ok"]
+    reasons = [e.reason for e in oss_enabled]
+    assert FallbackReason.TIMEOUT in reasons
+    assert oss_enabled[0].fell_back is True and oss_enabled[0].committed is False


### PR DESCRIPTION
Follow-ups to #157. All still behind `FALLBACK_ENABLED` (default off); the kill-switch path is byte-identical. Mirrors the amul-oan-api change.

## 1. Enforce the streaming OSS time-to-first-token timeout (the one that matters)
`attempt.timeout` was set per-pipeline but **never enforced in the voice streaming path** — `stream_with_fallback` consumes with a plain `async for` (it must: an external `anyio.fail_after`/task wrapper unwinds pydantic-ai's `run_stream` cancel scope out of order). So a **silent vLLM hang** (connection up, no tokens) would never fall back, and the caller would just wait.

Fix: `with_first_token_deadline(attempt, agen)` — a cancel scope in the **same task** as the agent generator that bounds **only time-to-first-token** and **disarms after the first token**. A pre-first-token timeout raises `TimeoutError` → `TIMEOUT` → swaps to managed before the caller hears anything.

This matters even more in voice: `_capture_http_client()` deliberately pins a **600s** read-timeout, with a comment that a short read-timeout "would abort long streaming agent runs (multi-second generation + tool round-trips) under load." A short httpx read-timeout is therefore the wrong lever — it can't tell a silent pre-first-token hang from a normal inter-token gap. The TTFT deadline disarms after the first token, leaving the rest of the stream on the 600s read-timeout.

Wired into voice `_make_stream` (the eager-first-token-pull path).

## 2 & 3. Docstring fix + dead-code removal in `fallback.py` (same as amul).

## Tests
`test_fallback.py` +4 TTFT cases (slow-first → timeout; **disarm-after-first allows a long mid-stream gap**; `None` no-op; end-to-end OSS hang → managed). The file is byte-identical to amul-oan-api's, where the suite passes 19 → 23. Local execution here is blocked by a stale shared pyenv (`pydantic_ai 0.2.4`, missing `OpenAIChatModel`; repo pins `1.102.0`) — same limitation noted on #157. The cancel-scope mechanics (incl. the nested `run_stream` scope) were validated in isolation on pydantic-ai 1.50.0/anyio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)