### PR TITLE
fix(tools): hide get_union_scheme_data for unsupported unions (backport to amul-dev)

### DIFF
--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -13,7 +13,7 @@ from agents.tools.health_call import create_health_call
 from agents.tools.conversation_state import signal_conversation_state
 from agents.tools.farmer_cached import get_farmer_profile, get_herd_summary, list_animal_tags
 from agents.tools.common import fire_tool_call_nudge
-from agents.tools.union_schemes import get_union_scheme_data
+from agents.tools.union_schemes import get_union_scheme_data, prepare_get_union_scheme_data
 
 
 def _with_nudge_signal(func):
@@ -101,6 +101,7 @@ SIGNED_IN_FARMER_TOOLS = [
         takes_ctx=True,
         docstring_format='auto',
         require_parameter_descriptions=False,
+        prepare=prepare_get_union_scheme_data,
     ),
 ]
 

--- a/agents/tools/union_schemes.py
+++ b/agents/tools/union_schemes.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from pydantic_ai import RunContext
+from pydantic_ai.tools import ToolDefinition
 
 from agents.deps import FarmerContext
 from app.models.union import UnionName, canonical_union_name
@@ -20,6 +21,25 @@ SUPPORTED_SCHEME_UNIONS = {
 }
 
 logger = get_logger(__name__)
+
+
+async def prepare_get_union_scheme_data(
+    ctx: RunContext[FarmerContext], tool_def: ToolDefinition
+) -> ToolDefinition | None:
+    """Hide get_union_scheme_data from the LLM unless the farmer is in a supported union.
+
+    Prevents wasted tool calls and the misleading "union could not be determined"
+    bail-out for farmers from unions whose scheme catalog isn't ingested
+    (e.g., dudhsagar). The LLM won't see the tool in its schema this turn, so it can't call it.
+    """
+    farmer_unions = [u.strip().lower() for u in (ctx.deps.farmer_unions or []) if u]
+    if any(u in SUPPORTED_SCHEME_UNIONS for u in farmer_unions):
+        return tool_def
+    logger.info(
+        "Hiding get_union_scheme_data tool because farmer_unions=%s has no supported union",
+        farmer_unions,
+    )
+    return None
 
 
 def _filter_scheme_records(records: list[dict[str, Any]], scheme_name: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
Backport of the union-aware tool gating fix (already merged to `amul-prod`) onto the dev branch `amul-dev`, so dev and prod don't drift.

Cherry-picked clean from Karun's original commit. Adds a pydantic-ai `prepare` callback that hides `get_union_scheme_data` from the LLM unless the farmer's union is in `SUPPORTED_SCHEME_UNIONS` ({banas, kutch}).

Prod PRs: amul-oan-api #86 / voice-oan-api #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)