### PR TITLE
promote: remove bare 'સર' strip (PR #175) to prod

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -167,8 +167,10 @@ GU_GENDER_NEUTRAL_POST: list[tuple[re.Pattern, str]] = [
     (re.compile(r"(?<![^\s,।.!?])બ(?:હેન|ેન)(?=\s*[,।!?]|\s|$)"), ""),
     # "સાહેબ" as caller address
     (re.compile(r"(?<![^\s,।.!?])સ(?:ા)?હ(?:ે)?બ(?=\s*[,।!?]|\s|$)"), ""),
-    # "સર" as caller address
-    (re.compile(r"(?<![^\s,।.!?])સર(?=\s*[,।!?]|\s|$)"), ""),
+    # NOTE: do NOT add a bare "સર" strip here. TranslateGemma transliterates
+    # Sarlaben with a space ("સર લાબેન"), so any standalone-સર pattern clobbers
+    # her name and TTS speaks only "લાબેન" (removed in #127, regressed in #154).
+    # The translation prompt rules already discourage 'સર' as a caller label.
     # "મેડમ" / "મૅડમ" / "મૅડ" as caller address
     (re.compile(r"(?<![^\s,।.!?])મ(?:ે|ૅ|ૅ)ડ(?:મ|)(?=\s*[,।!?]|\s|$)"), ""),
 ]
@@ -280,7 +282,7 @@ def _post_normalize_gu_translation(
     out = re.sub(rf"([:：]\s*){_GU_PLACEHOLDER_RE}(?=\s|$)", r"\1", out)
 
     # -- Gender-neutral caller-address guard --------------------------------
-    # Strip gendered address terms (ભાઈ, બહેન, સાહેબ, મેડમ, સર) directed at
+    # Strip gendered address terms (ભાઈ, બહેન, સાહેબ, મેડમ) directed at
     # the caller before the text reaches TTS.
     for pat, repl in GU_GENDER_NEUTRAL_POST:
         out = pat.sub(repl, out)

--- a/tests/test_translation_vocabulary.py
+++ b/tests/test_translation_vocabulary.py
@@ -545,6 +545,20 @@ class TestSarlabenFeminineSelfReference:
         assert "શકતી નથી" in result
         assert "શકું નથી" not in result
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # TranslateGemma transliterates Sarlaben with a space/comma; any
+            # bare-સર strip clobbers her name and TTS speaks only "લાબેન"
+            # (removed in #127, regressed in #154 — do not re-add).
+            "નમસ્તે, હું સર લાબેન છું.",
+            "સર લાબેન તમારી મદદ કરશે.",
+            "સર, તમારા પશુ વિશે જણાવો.",
+        ],
+    )
+    def test_sir_is_never_stripped(self, text):
+        assert "સર" in normalize_gu(text)
+
 
 class TestCalfTerminologyDisambiguation:
     """Protect buffalo calf wording from over-normalization."""


### PR DESCRIPTION
Promotes a9be7d1 from amul-dev (PR #175) to prod.

PR #154 re-added the standalone 'સર' caller-address strip that #127 removed, without the lookahead — TranslateGemma transliterates Sarlaben spaced ('સર લાબેન'), so prod TTS currently drops 'સર' from her own name. This removes the strip (ભાઈ/બહેન/સાહેબ/મેડમ unchanged, #154's feminine guard intact) and pins behavior with test_sir_is_never_stripped.

Dev-validated on VM5: સર preserved in all 3 cases, મેડમ strip + feminine guard still pass, live in-container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)