### PR TITLE
Voice: per-animal AI/breeding history in farmer context (zero turn latency)

### DIFF
--- a/agents/models/farmer.py
+++ b/agents/models/farmer.py
@@ -3,7 +3,7 @@ Typed models for farmer and animal data from PashuGPT APIs.
 Used throughout both chat and voice backends for consistent data handling.
 """
 from datetime import datetime, timezone
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -19,8 +19,11 @@ class AnimalRecord(BaseModel):
     pregnancyStage: Optional[str] = None
     dateOfBirth: Optional[str] = None
     lactationNo: Optional[Union[int, str]] = None
-    lastBreedingActivity: Optional[str] = None
-    lastHealthActivity: Optional[str] = None
+    # amulpashudhan returns these as nested objects (AI date + bull id, etc.);
+    # herdman returns flat strings. Accept either so the breeding/AI history
+    # survives the cache round-trip intact.
+    lastBreedingActivity: Optional[Any] = None
+    lastHealthActivity: Optional[Any] = None
     lastPD: Optional[str] = None
     lastCalvingDate: Optional[str] = None
     farmerComplaint: Optional[str] = None
@@ -38,6 +41,10 @@ class FarmerRecord(BaseModel):
     totalAnimals: Optional[int] = None
     tagNo: Optional[str] = None
     tagNumbers: Optional[str] = None
+    # Per-animal records (incl. lastBreedingActivity = AI date + bull id),
+    # populated on the cache-refresh path so the voice agent can answer
+    # historical AI questions without an on-request fetch.
+    animals: List[AnimalRecord] = []
 
 
 class FarmerSummary(BaseModel):

--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -19,11 +19,16 @@ from typing import Optional
 from app.core.cache import cache, redis_client, build_cache_key
 from app.config import settings
 from app.observability import start_observation
-from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
+from agents.models.farmer import AnimalRecord, FarmerDataEnvelope, FarmerRecord
 from agents.tools.farmer_animal_backends import (
     GetAITechniciansBySocietyQueryParams,
     get_ai_technicians_by_society_api,
+    fetch_animal_amulpashudhan,
+    fetch_animal_herdman,
+    merge_animal_data,
+    normalize_tag,
     fetch_reason,
+    current_fetch_reason,
 )
 from helpers.utils import get_logger
 
@@ -37,6 +42,10 @@ FARMER_COLD_FETCH_TIMEOUT = 4.0  # bounded blocking fetch for a cold/never-cache
 # Beyond this age a cached record is too stale to serve: the read blocks on a
 # bounded API call instead (falls back to the stale record only if that fails).
 FARMER_MAX_SERVE_STALE_SECONDS = settings.farmer_max_serve_stale_seconds
+# Cap concurrent per-animal API fetches during a background enrichment so a large
+# herd (or a multi-record phone) can't fan out into hundreds of simultaneous
+# outbound calls (socket exhaustion / 429s).
+FARMER_ANIMAL_FETCH_CONCURRENCY = 8
 FARMER_CACHE_NAMESPACE = "farmer"
 FARMER_REFRESH_LOCK_NAMESPACE = "farmer-refresh"
 FARMER_REFRESH_QUEUE_NAMESPACE = "farmer-refresh-queue"
@@ -47,6 +56,19 @@ FARMER_REFRESH_QUEUE_KEY = build_cache_key("pending", namespace=FARMER_REFRESH_Q
 def _cache_key(phone: str) -> str:
     """Build cache key from phone number hash."""
     return hashlib.sha256(phone.encode()).hexdigest()
+
+
+def _record_tags(record: FarmerRecord) -> list[str]:
+    """Raw (unmasked) animal tags from a farmer record."""
+    raw = record.tagNumbers or record.tagNo or ""
+    return [t.strip() for t in str(raw).split(",") if t.strip()]
+
+
+def _record_needs_animals(record: FarmerRecord) -> bool:
+    """True when a farmer has tags but no per-animal records cached yet — e.g. an
+    envelope written before animal enrichment existed. Used to force one
+    background refresh that backfills the breeding/AI history."""
+    return bool(_record_tags(record)) and not record.animals
 
 
 def _refresh_lock_key(phone: str) -> str:
@@ -105,6 +127,12 @@ async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             if envelope.farmers and "aiTechnicians" not in raw:
                 envelope.stale = True
                 envelope.staleReason = "missing_ai_technicians"
+                envelope.refreshAfter = datetime.now(timezone.utc).isoformat()
+            elif any(_record_needs_animals(f) for f in envelope.farmers):
+                # Backfill per-animal records (incl. AI history) for envelopes
+                # cached before animal enrichment existed.
+                envelope.stale = True
+                envelope.staleReason = "missing_animals"
                 envelope.refreshAfter = datetime.now(timezone.utc).isoformat()
             return envelope
     except Exception as e:
@@ -170,6 +198,7 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
     """
     lock_key = _refresh_lock_key(phone)
     acquired = False
+    enqueue_backfill_after_unlock = False
     try:
         acquired = await redis_client.set(lock_key, "1", ex=FARMER_REFRESH_LOCK_TTL, nx=True)
         if not acquired:
@@ -191,7 +220,23 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
         if records:
             envelope = FarmerDataEnvelope.from_records(records, source="api", lookup_status="found")
             envelope.aiTechnicians = await _fetch_ai_technicians(records)
+            # Per-animal enrichment (breeding/AI history) is fetched ONLY in the
+            # background worker — it makes N extra API calls and must never be on
+            # a voice turn. A cold/request-path refresh caches farmer-level data
+            # immediately, then enqueues a background refresh to backfill the
+            # animal records so they are present on the next turn (rather than
+            # waiting for a later read to notice "missing_animals" staleness).
+            if current_fetch_reason() == "background_refresh":
+                await _enrich_records_with_animals(envelope.farmers)
             await set_cached_farmer_data(phone, envelope)
+            # Defer the backfill enqueue until AFTER our refresh lock is released
+            # (see finally): enqueuing while still holding the lock lets a worker
+            # spop the phone, hit the lock-busy branch, and return the
+            # missing_animals envelope without enriching — dropping the job.
+            if current_fetch_reason() != "background_refresh" and any(
+                _record_needs_animals(f) for f in envelope.farmers
+            ):
+                enqueue_backfill_after_unlock = True
             return envelope
 
         # Upstream returned nothing. Never let a transient empty response wipe
@@ -226,6 +271,10 @@ async def refresh_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
                 await redis_client.delete(lock_key)
             except Exception:
                 pass
+        # Lock is now released — safe to enqueue the backfill: a worker that
+        # picks it up will acquire the lock cleanly and run enrichment.
+        if enqueue_backfill_after_unlock:
+            await enqueue_farmer_refresh(phone)
 
 
 async def get_farmer_data_cached_only(phone: str) -> Optional[FarmerDataEnvelope]:
@@ -313,6 +362,72 @@ async def drain_farmer_refresh_queue_once(batch: int = 20) -> int:
         except Exception:
             logger.exception("Background farmer refresh failed for a queued phone")
     return processed
+
+
+async def _fetch_one_animal(tag: str, token1: Optional[str], token3: Optional[str]) -> Optional[AnimalRecord]:
+    """Fetch + merge a single animal (amulpashudhan primary, herdman fallback)."""
+    norm = normalize_tag(tag)
+    if not norm:
+        return None
+    primary = None
+    fallback = None
+    if token1:
+        try:
+            primary = await fetch_animal_amulpashudhan(norm, token1)
+        except Exception as e:
+            logger.warning("amulpashudhan animal fetch failed for tag %s: %s", norm, e)
+    if token3:
+        try:
+            fallback = await fetch_animal_herdman(norm, token3)
+        except Exception as e:
+            logger.warning("herdman animal fetch failed for tag %s: %s", norm, e)
+    merged = merge_animal_data(primary, fallback)
+    if not merged:
+        return None
+    try:
+        return AnimalRecord.model_validate(merged)
+    except Exception as e:
+        logger.warning("Failed to validate animal record for tag %s: %s", norm, e)
+        return None
+
+
+async def _enrich_records_with_animals(records: list[FarmerRecord]) -> None:
+    """Populate each farmer record's `animals` list with per-animal data
+    (incl. lastBreedingActivity = AI date + bull id). Runs only on the background
+    refresh path — never on a voice turn. Mutates `records` in place; best-effort."""
+    token1 = os.getenv("PASHUGPT_TOKEN")
+    token3 = os.getenv("PASHUGPT_TOKEN_3")
+    if not token1 and not token3:
+        return
+
+    # One flat gather across all farmers × tags so the worker fetches the whole
+    # herd concurrently rather than farmer-by-farmer — bounded by a semaphore so
+    # a large herd can't open hundreds of sockets at once.
+    jobs: list[tuple[FarmerRecord, str]] = []
+    for record in records:
+        for tag in _record_tags(record):
+            jobs.append((record, tag))
+    if not jobs:
+        return
+
+    sem = asyncio.Semaphore(FARMER_ANIMAL_FETCH_CONCURRENCY)
+
+    async def _bounded(tag: str) -> Optional[AnimalRecord]:
+        async with sem:
+            return await _fetch_one_animal(tag, token1, token3)
+
+    results = await asyncio.gather(
+        *(_bounded(tag) for _, tag in jobs),
+        return_exceptions=True,
+    )
+    by_record: dict[int, list[AnimalRecord]] = {}
+    for (record, _tag), result in zip(jobs, results):
+        if isinstance(result, AnimalRecord):
+            by_record.setdefault(id(record), []).append(result)
+    for record in records:
+        animals = by_record.get(id(record))
+        if animals:
+            record.animals = animals
 
 
 async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1,6 +1,7 @@
 import asyncio
 from contextlib import nullcontext
 from functools import lru_cache
+import json
 import time
 from typing import AsyncGenerator, Optional, Literal
 import re
@@ -679,6 +680,41 @@ def _extract_farmer_tags(records: list[FarmerRecord]) -> list[str]:
     return tags
 
 
+def _render_breeding_value(value) -> str:
+    """Compact, model-readable form of lastBreedingActivity (amulpashudhan returns
+    a nested object with the AI date + bull id; herdman returns a flat string)."""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _append_animal_records(lines: list[str], envelope: FarmerDataEnvelope) -> None:
+    """Per-animal records (incl. last AI date + bull id) for breeding/AI-history
+    questions. Tags are masked (last 4 digits) so TTS never reads a full tag aloud.
+    Populated by the background cache refresh — absent on a brand-new caller's
+    first turn, present from the next turn on."""
+    blocks: list[str] = []
+    for record in envelope.farmers:
+        for animal in getattr(record, "animals", None) or []:
+            data = animal.model_dump()
+            masked = mask_tag_identifier(data.get("tagNumber") or "")
+            if not masked:
+                continue
+            parts = [f"tag ending {masked}"]
+            if data.get("animalType"):
+                parts.append(f"type={data['animalType']}")
+            breeding = data.get("lastBreedingActivity")
+            if breeding:
+                parts.append(f"last AI/breeding={_render_breeding_value(breeding)}")
+            else:
+                parts.append("no AI records available")
+            blocks.append("- " + ", ".join(parts))
+    if blocks:
+        lines.append("")
+        lines.append("### Per-animal AI / breeding history")
+        lines.extend(blocks)
+
+
 def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
     if envelope is None or not envelope.farmers:
         return ""
@@ -746,6 +782,8 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
             f"- Farmer option {index}: name={farmer_name}, society_name={society_name}, "
             f"farmer_code={farmer_code}, union_code={union_code}, society_code={society_code}"
         )
+
+    _append_animal_records(lines, envelope)
 
     return "\n".join(lines)
 


### PR DESCRIPTION

Voice now answers historical AI questions (last AI date + bull id per animal) by enriching the SWR farmer cache with per-animal records in the BACKGROUND worker only — never on a voice turn.

- models/farmer.py: FarmerRecord.animals; lastBreedingActivity/lastHealthActivity str->Any.
- farmer_cache.py: _enrich_records_with_animals (semaphore-bounded fan-out), gated to background_refresh; cold path caches farmer-level immediately and defers a backfill enqueue until after the refresh lock is released; missing_animals staleness backstop.
- voice.py: _append_animal_records emits per-animal AI/breeding lines with TTS-safe masked tags.

Reviewed by Codex (3 rounds): cold-path enqueue timing, bounded concurrency, and a lock-ordering race all addressed; final review clean. Verified end-to-end on dev VM5.


(cherry picked from commit 76e0ddeada82555af168066e864224dfd43f585a)