### PR TITLE
Add Gemma canary model and routing logic for voice sessions

### DIFF
--- a/agents/models.py
+++ b/agents/models.py
@@ -49,3 +49,20 @@ else:
 
 # Alias for backward compatibility (used by voice agent and agents.__init__)
 LLM_AGRINET_MODEL = LLM_MODEL
+
+# Gemma canary model (self-hosted vLLM). Built independently of LLM_PROVIDER above -
+# this is only used for a percentage of sessions via agents.routing, with the model
+# above (Azure/OpenAI) always available as the fallback. None if not configured.
+AGRINET_GEMMA_BASE_URL = os.getenv('AGRINET_GEMMA_BASE_URL')
+AGRINET_GEMMA_MODEL_NAME = os.getenv('AGRINET_GEMMA_MODEL_NAME')
+
+if AGRINET_GEMMA_BASE_URL and AGRINET_GEMMA_MODEL_NAME:
+    GEMMA_MODEL = OpenAIModel(
+        AGRINET_GEMMA_MODEL_NAME,
+        provider=OpenAIProvider(
+            base_url=AGRINET_GEMMA_BASE_URL,
+            api_key=os.getenv('AGRINET_GEMMA_API_KEY', 'not-required'),
+        ),
+    )
+else:
+    GEMMA_MODEL = None

--- a/agents/routing.py
+++ b/agents/routing.py
@@ -1,0 +1,100 @@
+"""
+Session-sticky canary routing between the Gemma vLLM model and the default
+(Azure/OpenAI) model.
+
+A session is deterministically bucketed into the canary group by hashing its
+session_id (stable across requests and worker processes, unlike Python's
+salted built-in hash()). Sessions in the canary group are routed to Gemma
+only while its vLLM engine has spare capacity (per /metrics); otherwise, and
+for all other sessions, requests go to the default model.
+"""
+import hashlib
+import logging
+import os
+import re
+
+import httpx
+from dotenv import load_dotenv
+
+from agents.models import GEMMA_MODEL, LLM_AGRINET_MODEL
+from app.core.cache import cache
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+GEMMA_CANARY_PERCENT = int(os.getenv('GEMMA_CANARY_PERCENT', '10'))
+GEMMA_MAX_CONCURRENCY = int(os.getenv('AGRINET_GEMMA_MAX_CONCURRENCY', '10'))
+GEMMA_METRICS_URL = os.getenv(
+    'AGRINET_GEMMA_METRICS_URL',
+    re.sub(r'/v1/?$', '', os.getenv('AGRINET_GEMMA_BASE_URL') or '') + '/metrics',
+)
+GEMMA_METRICS_CACHE_TTL = int(os.getenv('AGRINET_GEMMA_METRICS_CACHE_TTL', '2'))
+GEMMA_METRICS_CACHE_KEY = 'gemma_concurrency'
+
+_NUM_RE = re.compile(r'^(vllm:num_requests_running|vllm:num_requests_waiting)\{.*\}\s+([\d.eE+-]+)$')
+
+
+def is_gemma_candidate(session_id: str) -> bool:
+    """Deterministically decide whether a session is in the canary bucket."""
+    digest = hashlib.sha256(session_id.encode()).hexdigest()
+    return (int(digest, 16) % 100) < GEMMA_CANARY_PERCENT
+
+
+async def _fetch_gemma_concurrency() -> int | None:
+    """Sum of running + waiting requests on the Gemma vLLM engine(s), or None on failure."""
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(GEMMA_METRICS_URL)
+            response.raise_for_status()
+    except (httpx.HTTPError, httpx.TimeoutException) as e:
+        logger.warning(f"Failed to fetch Gemma metrics from {GEMMA_METRICS_URL}: {e}")
+        return None
+
+    total = 0
+    for line in response.text.splitlines():
+        match = _NUM_RE.match(line)
+        if match:
+            total += int(float(match.group(2)))
+    return total
+
+
+async def get_gemma_concurrency() -> int | None:
+    """Cached (short-TTL, shared via Redis) read of Gemma's current concurrency.
+
+    Redis errors are swallowed - a cache outage should degrade to a direct
+    metrics fetch per request, not break routing (and therefore voice turns).
+    """
+    try:
+        cached = await cache.get(GEMMA_METRICS_CACHE_KEY)
+    except Exception as e:
+        logger.warning(f"Gemma concurrency cache read failed: {e}")
+        cached = None
+
+    if cached is not None:
+        return cached
+
+    concurrency = await _fetch_gemma_concurrency()
+    if concurrency is not None:
+        try:
+            await cache.set(GEMMA_METRICS_CACHE_KEY, concurrency, ttl=GEMMA_METRICS_CACHE_TTL)
+        except Exception as e:
+            logger.warning(f"Gemma concurrency cache write failed: {e}")
+    return concurrency
+
+
+async def select_model_for_session(session_id: str):
+    """Return (model, route_label) for this turn.
+
+    route_label is one of: 'azure' (not in canary bucket, or Gemma unconfigured),
+    'gemma' (canary bucket + capacity available), 'azure_fallback' (canary bucket
+    but Gemma is at/over capacity or its metrics couldn't be read).
+    """
+    if GEMMA_MODEL is None or not session_id or not is_gemma_candidate(session_id):
+        return LLM_AGRINET_MODEL, 'azure'
+
+    concurrency = await get_gemma_concurrency()
+    if concurrency is not None and concurrency < GEMMA_MAX_CONCURRENCY:
+        return GEMMA_MODEL, 'gemma'
+
+    return LLM_AGRINET_MODEL, 'azure_fallback'

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -5,6 +5,8 @@ import os
 import re
 from agents.voice import voice_agent
 from agents.deps import FarmerContext
+from agents.models import LLM_AGRINET_MODEL
+from agents.routing import select_model_for_session
 from agents.tools.language import LANGUAGE_CACHE_SUFFIX
 from helpers.telemetry import (
     TelemetryRequest,
@@ -86,10 +88,20 @@ async def stream_voice_message(
     # Use effective_lang for recording message so it matches the frozen session language
     recording_prefix = _get_recording_message(effective_lang) if is_first_message else ""
 
+    model, model_route = await select_model_for_session(session_id)
+    model_name = getattr(model, "model_name", "unknown")
+    logger.info(f"Routing session {session_id} to model_route={model_route} model={model_name}")
+
+    # Runtime fallback: if the Gemma canary call errors/times out before any audio has
+    # been streamed to the client, retry once against the default (Azure/OpenAI) model.
+    # Once any output has been sent, a retry can't be done cleanly (the client already
+    # heard part of the response), so failures past that point just propagate.
+    candidates = [(model, model_route)]
+    if model_route == 'gemma':
+        candidates.append((LLM_AGRINET_MODEL, 'gemma_runtime_fallback'))
+
     final_output = None
     new_messages = None
-    text_buffer = ""
-    prev_audio = ""
 
     agent_slug = (voice_agent.name or "voice").replace(" ", "_").lower()
     with safe_start_agent_observation(
@@ -104,35 +116,66 @@ async def stream_voice_message(
             "agent_name": voice_agent.name,
             "voice_qid": voice_qid,
             "user_id": user_id,
+            "model_route": model_route,
+            "model_name": model_name,
         },
-        tags=["voice", "pydantic_ai", f"agent:{agent_slug}"],
+        tags=["voice", "pydantic_ai", f"agent:{agent_slug}", f"model_route:{model_route}", f"model:{model_name}"],
     ) as agent_obs:
-        async for event in voice_agent.run_stream_events(
-            user_prompt=user_message,
-            message_history=trimmed_history,
-            deps=deps
-        ):
-            kind = getattr(event, 'event_kind', '')
+        for attempt_index, (attempt_model, attempt_route) in enumerate(candidates):
+            text_buffer = ""
+            prev_audio = ""
+            any_chunk_yielded = False
+            is_last_attempt = attempt_index == len(candidates) - 1
+            try:
+                async for event in voice_agent.run_stream_events(
+                    user_prompt=user_message,
+                    message_history=trimmed_history,
+                    deps=deps,
+                    model=attempt_model,
+                ):
+                    kind = getattr(event, 'event_kind', '')
 
-            if kind == 'part_delta':
-                delta = event.delta
-                if getattr(delta, 'part_delta_kind', '') == 'text':
-                    text_buffer += delta.content_delta
-                    audio = _extract_audio_from_partial_json(text_buffer)
-                    if audio and audio != prev_audio:
-                        prev_audio = audio
-                        output_dict = _voice_output_dict(recording_prefix + audio, False, target_lang)
-                        yield json.dumps(output_dict, ensure_ascii=False)
+                    if kind == 'part_delta':
+                        delta = event.delta
+                        if getattr(delta, 'part_delta_kind', '') == 'text':
+                            text_buffer += delta.content_delta
+                            audio = _extract_audio_from_partial_json(text_buffer)
+                            if audio and audio != prev_audio:
+                                any_chunk_yielded = True
+                                prev_audio = audio
+                                output_dict = _voice_output_dict(recording_prefix + audio, False, target_lang)
+                                yield json.dumps(output_dict, ensure_ascii=False)
 
-            elif kind == 'function_tool_result':
-                # Reset text buffer for next model turn
-                text_buffer = ""
-                prev_audio = ""
+                    elif kind == 'function_tool_result':
+                        # Reset text buffer for next model turn
+                        text_buffer = ""
+                        prev_audio = ""
 
-            elif kind == 'agent_run_result':
-                agent_result = event.result
-                final_output = agent_result.output
-                new_messages = agent_result.new_messages()
+                    elif kind == 'agent_run_result':
+                        agent_result = event.result
+                        final_output = agent_result.output
+                        new_messages = agent_result.new_messages()
+            except Exception as e:
+                if any_chunk_yielded or is_last_attempt:
+                    raise
+                logger.warning(
+                    f"model_route={attempt_route} call failed before streaming any output "
+                    f"(session={session_id}): {e}. Retrying with fallback model."
+                )
+                continue
+
+            if attempt_route != model_route:
+                model_route = attempt_route
+                model_name = getattr(attempt_model, "model_name", "unknown")
+                logger.info(f"Session {session_id} recovered via runtime fallback to model_route={model_route}")
+                try:
+                    agent_obs.update(
+                        metadata={"model_route": model_route, "model_name": model_name},
+                        tags=["voice", "pydantic_ai", f"agent:{agent_slug}", f"model_route:{model_route}", f"model:{model_name}"],
+                    )
+                except (TypeError, AttributeError):
+                    pass
+            break
 
         if final_output is not None:
             if isinstance(final_output, dict):


### PR DESCRIPTION
- Introduced a new self-hosted Gemma model for session-based routing, allowing a percentage of sessions to utilize this model while maintaining Azure/OpenAI as a fallback.
- Implemented routing logic in `agents/routing.py` to determine model selection based on session ID and concurrency metrics.
- Updated voice service to integrate the new routing mechanism, enabling runtime fallbacks and improved logging for model selection during voice message streaming.