### PR TITLE
Refactor Langfuse observation handling to clarify tag usage

### DIFF
--- a/app/observability/langfuse_client.py
+++ b/app/observability/langfuse_client.py
@@ -68,9 +68,10 @@ def safe_start_observation(
     input: Any = None,
     output: Any = None,
     metadata: Optional[Dict[str, Any]] = None,
-    tags: Optional[list[str]] = None,
     model: Optional[str] = None,
 ):
+    # Note: Langfuse observations do not support tags — tags are trace-level only.
+    # Use safe_propagate_attributes(tags=...) instead.
     client = get_langfuse()
     if client is None:
         return nullcontext(None)
@@ -82,7 +83,6 @@ def safe_start_observation(
                 input=input,
                 output=output,
                 metadata=metadata,
-                tags=tags,
                 model=model,
             )
         )
@@ -128,9 +128,11 @@ def safe_start_agent_observation(
     name: str,
     input: Any = None,
     metadata: Optional[Dict[str, Any]] = None,
-    tags: Optional[list[str]] = None,
 ):
-    """Langfuse ``agent`` observation; children include PydanticAI OTEL spans (invoke_agent, execute_tool, …)."""
+    """Langfuse ``agent`` observation; children include PydanticAI OTEL spans (invoke_agent, execute_tool, …).
+
+    Tags are trace-level only in Langfuse; use safe_propagate_attributes(tags=...) for those.
+    """
     client = get_langfuse()
     if client is None:
         return nullcontext(None)
@@ -141,7 +143,6 @@ def safe_start_agent_observation(
                 name=name,
                 input=input,
                 metadata=metadata,
-                tags=tags,
             )
         )
     except Exception:

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -35,8 +35,7 @@ async def generate_openai_stream(
     with safe_start_observation(
         as_type="span",
         name="voice.chat_completions.stream",
-        input={"query": query, "target_lang": target_lang, "model": request.model},
-        tags=langfuse_tags,
+        input={"query": query, "target_lang": target_lang},
     ) as root_obs:
         with safe_propagate_attributes(
             user_id=user_id,
@@ -120,8 +119,7 @@ async def generate_openai_response(
     with safe_start_observation(
         as_type="span",
         name="voice.chat_completions",
-        input={"query": query, "target_lang": target_lang, "model": request.model},
-        tags=langfuse_tags,
+        input={"query": query, "target_lang": target_lang},
     ) as root_obs:
         with safe_propagate_attributes(
             user_id=user_id,

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -17,7 +17,7 @@ from helpers.telemetry import (
 from helpers.utils import get_logger
 from app.utils import update_message_history, trim_history
 from app.core.cache import cache
-from app.observability.langfuse_client import safe_start_agent_observation
+from app.observability.langfuse_client import safe_propagate_attributes, safe_start_agent_observation
 from app.observability.voice import safe_update_observation
 
 logger = get_logger(__name__)
@@ -104,7 +104,11 @@ async def stream_voice_message(
     new_messages = None
 
     agent_slug = (voice_agent.name or "voice").replace(" ", "_").lower()
-    with safe_start_agent_observation(
+    # Tags are trace-level in Langfuse, so they go through propagate_attributes;
+    # observations only carry metadata.
+    with safe_propagate_attributes(
+        tags=["voice", "pydantic_ai", f"agent:{agent_slug}", f"model_route:{model_route}", f"model:{model_name}"],
+    ), safe_start_agent_observation(
         name=f"agent.{agent_slug}",
         input={
             "query": query,
@@ -119,7 +123,6 @@ async def stream_voice_message(
             "model_route": model_route,
             "model_name": model_name,
         },
-        tags=["voice", "pydantic_ai", f"agent:{agent_slug}", f"model_route:{model_route}", f"model:{model_name}"],
     ) as agent_obs:
         for attempt_index, (attempt_model, attempt_route) in enumerate(candidates):
             text_buffer = ""
@@ -167,12 +170,14 @@ async def stream_voice_message(
             if attempt_route != model_route:
                 model_route = attempt_route
                 model_name = getattr(attempt_model, "model_name", "unknown")
-                logger.info(f"Session {session_id} recovered via runtime fallback to model_route={model_route}")
+                # Tag the active agent span so the trace is filterable by the route
+                # actually served, not just the one initially selected.
+                with safe_propagate_attributes(
+                    tags=[f"model_route:{model_route}", f"model:{model_name}"],
+                ):
+                    logger.info(f"Session {session_id} recovered via runtime fallback to model_route={model_route}")
                 try:
-                    agent_obs.update(
-                        metadata={"model_route": model_route, "model_name": model_name},
-                        tags=["voice", "pydantic_ai", f"agent:{agent_slug}", f"model_route:{model_route}", f"model:{model_name}"],
-                    )
+                    agent_obs.update(metadata={"model_route": model_route, "model_name": model_name})
                 except (TypeError, AttributeError):
                     pass
             break


### PR DESCRIPTION
- Removed tag parameters from `safe_start_observation` and `safe_start_agent_observation` functions, noting that tags are trace-level only in Langfuse.
- Updated relevant calls in `openai_service.py` and `voice.py` to align with the new tagging approach, utilizing `safe_propagate_attributes` for tag management.
- Enhanced documentation to guide users on the correct usage of tags in observations.