### PR TITLE
Add hold message rejection logic in voice agent

### DIFF
--- a/agents/voice.py
+++ b/agents/voice.py
@@ -1,4 +1,5 @@
-from pydantic_ai import Agent, RunContext
+import re
+from pydantic_ai import Agent, ModelRetry, RunContext
 from helpers.utils import get_prompt, get_today_date_str
 from agents.models import LLM_AGRINET_MODEL
 from agents.tools import TOOLS
@@ -8,6 +9,19 @@ from pydantic import BaseModel, Field
 from pydantic_ai import NativeOutput
 import logging
 logger = logging.getLogger(__name__)
+
+# Gemma sometimes narrates a tool call ("I will check the details. One moment
+# please.") and ends the turn without calling the tool, so the caller hears a
+# promise that never resolves. Only short replies are checked: a real answer
+# can legitimately contain words like "wait" ("wait two days after spraying").
+_HOLD_MESSAGE_RE = re.compile(
+    r"\b(one|a) moment\b|please wait|hold on|bear with me"
+    r"|(i will|let me) (check|find|fetch|get|look|retrieve|provide|pull|share)"
+    r"|एक (क्षण|पल)|कृपया प्रतीक्षा|प्रतीक्षा करें|रुकिए|इंतज़ार करें|इंतजार करें"
+    r"|मैं .{0,20}(देखती|खोजती|निकालती|लाती) हूं",
+    re.IGNORECASE,
+)
+_HOLD_MESSAGE_MAX_LEN = 200
 
 class VoiceOutput(BaseModel):
     """Assistant's response to the user's query."""
@@ -33,6 +47,22 @@ voice_agent = Agent(
         timeout=30,
     )
 )
+
+@voice_agent.output_validator
+def reject_hold_messages(ctx: RunContext[FarmerContext], output: VoiceOutput) -> VoiceOutput:
+    audio = (output.audio or "").strip()
+    if len(audio) <= _HOLD_MESSAGE_MAX_LEN and _HOLD_MESSAGE_RE.search(audio):
+        logger.warning(f"Rejected hold-message reply, retrying: {audio!r}")
+        raise ModelRetry(
+            "Your reply was only a promise to check and made the caller wait for an "
+            "answer that never comes. Do not say you will check or ask the user to "
+            "wait. Call the required tool now and answer with the actual information "
+            "in this same response. Keep the conversation context: if a scheme or "
+            "topic was already being discussed, answer for that same scheme or topic "
+            "— do not ask the user to repeat it."
+        )
+    return output
+
 
 @voice_agent.instructions
 def get_voice_system_prompt(ctx: RunContext[FarmerContext]):


### PR DESCRIPTION
- Introduced a regex pattern to identify and reject hold messages that promise to check details without providing actual information.
- Implemented an output validator in the voice agent to ensure responses do not contain phrases that imply waiting or checking, enhancing user experience by delivering timely answers.
- Updated logging to warn when hold messages are rejected, prompting a retry for more informative responses.