### PR TITLE
loan: drop pilot disclaimer + milk-statement requirement (voice)

### DIFF
--- a/agents/tools/loan.py
+++ b/agents/tools/loan.py
@@ -64,9 +64,8 @@ def _message_for(result: "le.LoanResult") -> str:
             f"APPROVED. Confirm to the farmer that their KDCC Bank micro loan of up to ₹{amt:,} has been "
             f"approved/processed. Their loan reference code is {result.code}, and it has been sent to "
             f"their registered mobile number by SMS. They should visit their KDCC cooperative bank branch "
-            f"and present this code, and must carry their Aadhaar card, their milk cooperative society "
-            f"membership certificate, and a one-month milk deposit transaction statement. Also briefly "
-            f"tell them this micro-loan facility is currently in a pilot phase."
+            f"and present this code, and must carry only two documents: their Aadhaar card and their "
+            f"proof of milk cooperative society membership."
         )
     if result.outcome == le.ALREADY_ISSUED:
         return (
@@ -79,8 +78,7 @@ def _message_for(result: "le.LoanResult") -> str:
             "NOT ELIGIBLE. Tell the farmer they are not eligible for the micro loan on this platform. "
             "If they ask where to go for a loan, direct them to their NEAREST cooperative bank branch — "
             "do NOT name KDCC Bank or any specific bank, and do NOT refer them to the KDCC micro-loan "
-            "facility. Do NOT disclose the specific reason for ineligibility. Also briefly tell them "
-            "this micro-loan facility is currently in a pilot phase."
+            "facility. Do NOT disclose the specific reason for ineligibility."
         )
     if result.outcome == le.NO_PHONE:
         return (

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -581,8 +581,7 @@ For general husbandry concepts established in standard practice, answer briefly 
 - Loan facility information — share this when the farmer asks what the loan is or what documents are needed:
   - Facility: A micro loan provided by KDCC Bank for livestock farmers (pashupalaks) who are milk cooperative society members. Do NOT describe it as a Kisan Credit Card (KCC) or a government scheme — it is a KDCC Bank micro loan.
   - Maximum loan amount: up to Rupees {{ loan_max_amount }}.
-  - Required documents: Aadhaar card, the certificate of being a member of the milk cooperative society, and a one-month milk deposit transaction statement.
+  - Required documents (only these two): Aadhaar card and proof of milk cooperative society membership.
   - Terms: The loan carries {{ loan_interest_rate_pct }}% annual interest, which is waived if the loan is repaid regularly. It is a KDCC Bank micro loan — NOT a government or KCC scheme.
-- Whenever you share an approval or reference code with an eligible farmer, tell them to carry their Aadhaar card, milk cooperative society membership certificate, and one-month milk deposit transaction statement to the KDCC bank branch along with the code.
+- Whenever you share an approval or reference code with an eligible farmer, tell them to carry only two documents — their Aadhaar card and proof of milk cooperative society membership — to the KDCC bank branch along with the code.
 - If the farmer is NOT eligible and asks where they should go for a loan, direct them to their nearest cooperative bank branch — do NOT name KDCC Bank or point them at the KDCC micro-loan facility.
-- PILOT DISCLAIMER: This micro-loan facility is currently in a pilot phase — briefly convey this to the farmer whenever you discuss the loan.

--- a/assets/prompts/voice_system_translation_pipeline_gemma4_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_gemma4_en.md
@@ -259,8 +259,7 @@ Assistant: All right. You can call again if you need help.
 - Loan facility information — share this when the farmer asks what the loan is or what documents are needed:
   - Facility: A micro loan provided by KDCC Bank for livestock farmers (pashupalaks) who are milk cooperative society members. Do NOT describe it as a Kisan Credit Card (KCC) or a government scheme — it is a KDCC Bank micro loan.
   - Maximum loan amount: up to Rupees {{ loan_max_amount }}.
-  - Required documents: Aadhaar card, the certificate of being a member of the milk cooperative society, and a one-month milk deposit transaction statement.
+  - Required documents (only these two): Aadhaar card and proof of milk cooperative society membership.
   - Terms: The loan carries {{ loan_interest_rate_pct }}% annual interest, which is waived if the loan is repaid regularly. It is a KDCC Bank micro loan — NOT a government or KCC scheme.
-- Whenever you share an approval or reference code with an eligible farmer, tell them to carry their Aadhaar card, milk cooperative society membership certificate, and one-month milk deposit transaction statement to the KDCC bank branch along with the code.
+- Whenever you share an approval or reference code with an eligible farmer, tell them to carry only two documents — their Aadhaar card and proof of milk cooperative society membership — to the KDCC bank branch along with the code.
 - If the farmer is NOT eligible and asks where they should go for a loan, direct them to their nearest cooperative bank branch — do NOT name KDCC Bank or point them at the KDCC micro-loan facility.
-- PILOT DISCLAIMER: This micro-loan facility is currently in a pilot phase — briefly convey this to the farmer whenever you discuss the loan.

--- a/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
@@ -269,8 +269,7 @@ Assistant: All right. You can call again if you need help.
 - Loan facility information — share this when the farmer asks what the loan is or what documents are needed:
   - Facility: A micro loan provided by KDCC Bank for livestock farmers (pashupalaks) who are milk cooperative society members. Do NOT describe it as a Kisan Credit Card (KCC) or a government scheme — it is a KDCC Bank micro loan.
   - Maximum loan amount: up to Rupees {{ loan_max_amount }}.
-  - Required documents: Aadhaar card, the certificate of being a member of the milk cooperative society, and a one-month milk deposit transaction statement.
+  - Required documents (only these two): Aadhaar card and proof of milk cooperative society membership.
   - Terms: The loan carries {{ loan_interest_rate_pct }}% annual interest, which is waived if the loan is repaid regularly. It is a KDCC Bank micro loan — NOT a government or KCC scheme.
-- Whenever you share an approval or reference code with an eligible farmer, tell them to carry their Aadhaar card, milk cooperative society membership certificate, and one-month milk deposit transaction statement to the KDCC bank branch along with the code.
+- Whenever you share an approval or reference code with an eligible farmer, tell them to carry only two documents — their Aadhaar card and proof of milk cooperative society membership — to the KDCC bank branch along with the code.
 - If the farmer is NOT eligible and asks where they should go for a loan, direct them to their nearest cooperative bank branch — do NOT name KDCC Bank or point them at the KDCC micro-loan facility.
-- PILOT DISCLAIMER: This micro-loan facility is currently in a pilot phase — briefly convey this to the farmer whenever you discuss the loan.


### PR DESCRIPTION
Voice-side companion to amul-oan-api #133/#135, targeting `sarlaben_profile` since the loan feature isn't on voice `main` yet:

- Removes the **pilot-phase disclaimer** from the APPROVED / NOT ELIGIBLE tool messages and the PILOT DISCLAIMER rule in all three voice system prompts.
- Drops the **one-month milk deposit transaction statement** from the required-documents list (now only Aadhaar + proof of society membership), matching the chat backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)