### PR TITLE
Trace full resolved pipeline config to Langfuse

### DIFF
--- a/app/llm_core/__init__.py
+++ b/app/llm_core/__init__.py
@@ -29,7 +29,7 @@ from app.llm_core.factory import (
     materialize,
 )
 from app.llm_core.legacy_shim import synthesize_from_env
-from app.llm_core import runtime, resolver, split, concurrency
+from app.llm_core import runtime, resolver, split, concurrency, trace
 
 __all__ = [
     "ApiStyle",
@@ -51,4 +51,5 @@ __all__ = [
     "resolver",
     "split",
     "concurrency",
+    "trace",
 ]

--- a/app/llm_core/concurrency.py
+++ b/app/llm_core/concurrency.py
@@ -144,6 +144,20 @@ async def reprioritize_by_load(
         return tiers
 
     gauge = await get_concurrency(gate.metrics_url)
+
+    # ── tracing-only (no behaviour change): record the gauge read + whether the
+    # vLLM tier was deprioritized onto the current turn's trace, at each outcome.
+    from app.llm_core import trace as _trace
+
+    def _record(deprioritized: bool) -> None:
+        _trace.record_concurrency(
+            step,
+            gauge=gauge,
+            max_concurrency=gate.max_concurrency,
+            deprioritized=deprioritized,
+            metrics_url=gate.metrics_url,
+        )
+
     if gauge is None:
         # Fail-open: metrics unreadable -> assume NOT saturated -> order unchanged.
         # (Deliberately NOT a forced flip to managed — the plan's reversal of bh.)
@@ -151,8 +165,10 @@ async def reprioritize_by_load(
             "concurrency: metrics unreadable for step=%s (%s); fail-open, order unchanged",
             getattr(step, "value", step), gate.metrics_url,
         )
+        _record(False)
         return tiers
     if gauge < gate.max_concurrency:
+        _record(False)
         return tiers            # below threshold -> primary stays primary
 
     vllm = [t for t in tiers if _is_vllm(t)]
@@ -160,10 +176,12 @@ async def reprioritize_by_load(
     if not vllm or not others:
         # All-vLLM or no-vLLM chain: nothing to reorder behind. Never churn /
         # empty — a saturated-but-only vLLM tier still runs (degrade-safe).
+        _record(False)
         return tiers
 
     logger.info(
         "concurrency: step=%s vLLM gauge %d >= %d; deprioritizing %d vLLM tier(s) behind managed",
         getattr(step, "value", step), gauge, gate.max_concurrency, len(vllm),
     )
+    _record(True)
     return others + vllm

--- a/app/llm_core/health.py
+++ b/app/llm_core/health.py
@@ -278,7 +278,26 @@ def prune_unhealthy(step: Optional[Step], tiers: list) -> list:
     if not tiers:
         return tiers
 
-    kept = [t for t in tiers if not _registry.is_open(_endpoint_of(t) or "")]
+    # ``is_open`` has a lazy open->half_open side effect, so evaluate it exactly
+    # once per tier and reuse the result for both the filter and the trace record.
+    open_by_tier = {id(t): _registry.is_open(_endpoint_of(t) or "") for t in tiers}
+    kept = [t for t in tiers if not open_by_tier[id(t)]]
+
+    # ── tracing-only (no behaviour change): record which endpoints were pruned
+    # and the breaker state consulted per endpoint, onto the current turn's trace.
+    from app.llm_core import trace as _trace
+    if _trace.current() is not None:
+        pruned = [
+            ep for t in tiers
+            if open_by_tier[id(t)] and (ep := _endpoint_of(t)) is not None
+        ]
+        breaker_states = {
+            ep: _registry.state_of(ep).value
+            for t in tiers
+            if (ep := _endpoint_of(t)) is not None
+        }
+        _trace.record_health_prune(step, pruned, breaker_states)
+
     if not kept:
         # Contract: never return an empty chain. Every tier's endpoint is open —
         # degrade to trying the whole (suspect) chain rather than having none.

--- a/app/llm_core/resolver.py
+++ b/app/llm_core/resolver.py
@@ -50,7 +50,13 @@ def resolve_chain(step: Step, variant: str = "legacy") -> list[MaterializedTier]
         raise ValueError(f"no config for step={step.value} in profile={profile.name}")
 
     kind = STEP_CLIENT_KIND[step]
-    return materialize(kind, list(step_cfg.tiers))
+    chain = materialize(kind, list(step_cfg.tiers))
+    # tracing-only (no behaviour change): record the resolved profile + step chain
+    # for the non-fallback primary-tier seam (primary_tier/primary_handle callers).
+    from app.llm_core import trace as _trace
+    _trace.record_profile(profile.name, profile.weight)
+    _trace.record_step_chain(step, chain)
+    return chain
 
 
 def chain_for(step: Step, variant: str = "legacy") -> list[MaterializedTier]:

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -111,6 +111,11 @@ def configure(*, run_self_check: bool = True) -> PipelineConfig:
     from app.config import settings as _settings
     if bool(getattr(_settings, "llm_core_enabled", False)):
         validate_config(PIPELINE)
+    # Tracing-only: dump the COMPLETE loaded config (all profiles, step tiers,
+    # triggers) as one structured boot log line so the full wiring is greppable
+    # in logs even before any turn arrives (`grep llm_core.full_config`).
+    from app.llm_core import trace as _trace
+    _trace.log_full_config(PIPELINE)
     if run_self_check:
         try:
             self_check()

--- a/app/llm_core/split.py
+++ b/app/llm_core/split.py
@@ -162,6 +162,10 @@ async def resolve_chain(
         name = await resolve_profile(session_id, pipeline)
     profile = _profile_for(pipeline, name)
 
+    # tracing-only (no behaviour change): the weighted profile this turn resolved.
+    from app.llm_core import trace as _trace
+    _trace.record_profile(profile.name, profile.weight)
+
     step_cfg = pipeline.step_config(profile, step)
     if step_cfg is None:
         raise ValueError(f"no config for step={step.value} in profile={profile.name}")
@@ -184,7 +188,10 @@ async def resolve_chain(
         step, tiers, step_cfg.triggers.concurrency_gate
     )
 
-    return materialize(STEP_CLIENT_KIND[step], tiers)
+    chain = materialize(STEP_CLIENT_KIND[step], tiers)
+    # tracing-only: the resolved primary tier + full chain for this step.
+    _trace.record_step_chain(step, chain)
+    return chain
 
 
 def variant_for_profile(name: str) -> str:

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -1,22 +1,31 @@
-"""Per-turn pipeline-trace recorder — the full RESOLVED config + routing
-decisions of one turn, emitted as a single ``pipeline`` object into the Langfuse
-trace metadata.
+"""Per-turn pipeline-trace recorder — the RESOLVED config + routing decisions of
+one turn, surfaced on the Langfuse trace as a handful of COMPACT flat metadata
+keys.
 
-TRACING ONLY — this module changes NO pipeline behaviour. Every recorder is a
-no-op unless a :class:`PipelineTrace` context is active (opened per-turn by the
-chat/voice request path via :func:`begin`), so the core seams
-(``split``/``health``/``concurrency``/``fallback``) can call the ``record_*``
-hooks unconditionally and cheaply — a bare ``ContextVar.get()`` when nothing is
-listening. Nothing here is on any poll loop; it only ever runs on the request
-path.
+TRACING ONLY — this module changes NO pipeline behaviour.
 
-SECRETS: this records endpoints (already in logs), providers, model names and
-timeouts — and the *name* of a tier's api-key env var, never its value. It never
-reads or stores an api key. See :func:`_no_secret_assert` in the tests.
+Landing path (important): this Langfuse SDK has **no** ``update_current_trace``,
+and the working ``propagate_attributes(metadata=...)`` path maps to OTEL span
+attributes whose values are SIZE-CAPPED (~128-256 chars) — a big nested blob is
+silently dropped. So the request path builds ``pt`` (via :func:`begin` +
+:func:`populate`) and merges :func:`compact_metadata` (short flat keys —
+``pipeline_profile`` / ``pipeline_flags`` / ``pc_<step>``) into the SAME metadata
+dict it already hands to ``propagate_attributes`` / ``VoiceTrace.metadata``. The
+COMPLETE static config is logged once at boot by :func:`log_full_config`
+(``grep llm_core.full_config``).
 
-Kept import-clean (stdlib + ``app.config`` + ``config_model`` + a best-effort
-Langfuse import) so the voice repo mirrors this file byte-for-byte and the
-eventual repo-merge stays mechanical (this file is one of the convergent cores).
+The ``pt`` instance is threaded EXPLICITLY (not read from the ContextVar at the
+emit site): the ContextVar does not survive Starlette's StreamingResponse
+async-generator boundary. The ContextVar is kept only for the best-effort deep
+recorders (health/concurrency/served-tier) that mutate ``pt`` mid-turn.
+
+SECRETS: records endpoints (already in logs), providers, model names and timeouts
+— and the *name* of a tier's api-key env var, never its value. It never reads or
+stores an api key.
+
+Kept import-clean (stdlib + ``app.config`` + ``config_model`` only) so the voice
+repo mirrors this file byte-for-byte and the eventual repo-merge stays mechanical
+(this file is one of the convergent cores).
 """
 
 from __future__ import annotations
@@ -29,12 +38,6 @@ from typing import Any, Optional
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
-
-# Best-effort Langfuse trace tagging (same import shape as services.fallback).
-try:  # pragma: no cover - import guard
-    from langfuse import get_client as _get_langfuse_client
-except Exception:  # pragma: no cover
-    _get_langfuse_client = None
 
 
 # ── per-step + per-turn records ───────────────────────────────────────────────
@@ -268,15 +271,13 @@ def record_served(step: Any, kind: Optional[str], index: int) -> None:
 
 def record_health_prune(step: Any, pruned: list, breaker_states: dict) -> None:
     """Health-filter outcome for a step: the endpoints pruned (breaker ``open``)
-    and the breaker state consulted per endpoint. Adds a cheap trace tag when a
-    tier was actually pruned so a turn's routing decision is visible."""
+    and the breaker state consulted per endpoint. Best-effort — mutates ``pt`` on
+    the current turn's context; the data surfaces via the compact metadata keys."""
     pt = _CTX.get()
     if pt is None:
         return
     name = getattr(step, "value", step)
     pt.step(name).health = {"pruned": list(pruned), "breaker_states": dict(breaker_states)}
-    if pruned:
-        _tag_trace([f"health_prune:{name}"])
 
 
 def record_concurrency(
@@ -288,8 +289,8 @@ def record_concurrency(
     metrics_url: Optional[str],
 ) -> None:
     """Concurrency-gauge outcome for a step: the gauge read, the threshold, and
-    whether the vLLM tier was deprioritized. Adds a cheap trace tag when a tier
-    was actually deprioritized."""
+    whether the vLLM tier was deprioritized. Best-effort — mutates ``pt`` on the
+    current turn's context; the data surfaces via the compact metadata keys."""
     pt = _CTX.get()
     if pt is None:
         return
@@ -300,53 +301,59 @@ def record_concurrency(
         "deprioritized": bool(deprioritized),
         "metrics_url": metrics_url,
     }
-    if deprioritized:
-        _tag_trace([f"concurrency_deprioritize:{name}"])
 
 
-# ── emission ──────────────────────────────────────────────────────────────────
-def _tag_trace(tags: list) -> None:
-    if _get_langfuse_client is None:
-        return
-    try:  # pragma: no cover - best effort
-        client = _get_langfuse_client()
-        if client is not None:
-            client.update_current_trace(tags=tags)
-    except Exception:
-        pass
+# ── compact trace-metadata keys (the path that actually lands) ────────────────
+# The Langfuse SDK here has NO ``update_current_trace``; the working path is the
+# ``propagate_attributes(metadata=...)`` dict (chat) / ``VoiceTrace.metadata``
+# (voice), which maps to OTEL span attributes — and those SIZE-CAP each value
+# (~128-256 chars), so a big nested blob is silently dropped. So we serialize the
+# resolved config into a handful of SHORT flat string keys that fit under the cap
+# and land reliably. The COMPLETE static config still goes to the boot log via
+# ``log_full_config`` (``grep llm_core.full_config``).
+def compact_metadata(pt: Optional[PipelineTrace]) -> dict:
+    """Flatten ``pt`` into short, cap-safe metadata keys:
 
+    * ``pipeline_profile`` = resolved profile name;
+    * ``pipeline_flags``   = comma-joined enabled guard flags (``_enabled`` stripped);
+    * ``pc_<step>``        = ``"<provider>:<model>@<endpoint>#<served>(<timeout_ms>ms)"``
+                             per executed step (~50 chars each).
 
-# The trace-metadata key the resolved-config object is emitted under. It is
-# deliberately NOT ``pipeline`` — chat already sets ``metadata["pipeline"]`` to
-# the pipeline NAME string ("translation"/"default") via propagate_attributes, so
-# reusing that key would collide (the string shadows the object). ``pipeline_config``
-# is a distinct namespace; the existing ``pipeline``/``variant`` keys are untouched.
-METADATA_KEY = "pipeline_config"
-
-
-def emit_to_trace(pt: Optional[PipelineTrace] = None) -> None:
-    """Flush the resolved-config object onto the current Langfuse trace's metadata
-    under the ``pipeline_config`` key. Best-effort and merge-only: it never
-    overwrites the existing ``pipeline``/``variant``/``pipeline_variant`` keys or
-    scores (those stay for dashboard continuity).
-
-    IMPORTANT: pass the EXPLICIT ``pt`` returned by ``begin()``. The contextvar is
-    NOT a reliable read across Starlette's StreamingResponse async-generator
-    boundary — reading it here yielded an empty object in production. ``pt=None``
-    falls back to the contextvar only for callers that share one context."""
+    Returns ``{}`` on any error / empty pt (never raises into the request path)."""
+    out: dict = {}
     if pt is None:
-        pt = _CTX.get()
-    if pt is None or _get_langfuse_client is None:
+        return out
+    try:
+        pc = pt.to_metadata()
+        out["pipeline_profile"] = (pc.get("profile") or {}).get("name")
+        out["pipeline_flags"] = ",".join(
+            k.replace("_enabled", "") for k, v in (pc.get("flags") or {}).items() if v
+        )
+        for step_name, sv in (pc.get("steps") or {}).items():
+            sv = sv or {}
+            served = (sv.get("tier_served") or {}).get("kind")
+            out[f"pc_{step_name}"] = (
+                f'{sv.get("provider")}:{sv.get("model")}@{sv.get("endpoint")}'
+                f'#{served}({sv.get("timeout_ms")}ms)'
+            )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("llm_core.trace: compact_metadata failed: %s", e)
+    return out
+
+
+def add_compact_metadata(pt: Optional[PipelineTrace], metadata: dict) -> None:
+    """Merge :func:`compact_metadata` into an existing metadata dict IN PLACE — the
+    same dict the request path already hands to ``propagate_attributes`` (chat) /
+    ``VoiceTrace.metadata`` (voice). No-op-safe (never raises)."""
+    if metadata is None:
         return
-    try:  # pragma: no cover - best effort
-        client = _get_langfuse_client()
-        if client is not None:
-            client.update_current_trace(metadata={METADATA_KEY: pt.to_metadata()})
-    except Exception as e:
-        logger.debug("llm_core.trace: emit_to_trace failed: %s", e)
+    try:
+        metadata.update(compact_metadata(pt))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("llm_core.trace: add_compact_metadata failed: %s", e)
 
 
-# ── startup full-config dump (item 4) ─────────────────────────────────────────
+# ── startup full-config dump ──────────────────────────────────────────────────
 def config_to_dict(pipeline: Any) -> dict:
     """The COMPLETE loaded ``PipelineConfig`` as a plain dict — all profiles, all
     step tiers, all triggers — for one greppable structured boot log line.

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -252,18 +252,27 @@ def _tag_trace(tags: list) -> None:
         pass
 
 
+# The trace-metadata key the resolved-config object is emitted under. It is
+# deliberately NOT ``pipeline`` — chat already sets ``metadata["pipeline"]`` to
+# the pipeline NAME string ("translation"/"default") via propagate_attributes, so
+# reusing that key would collide (the string shadows the object). ``pipeline_config``
+# is a distinct namespace; the existing ``pipeline``/``variant`` keys are untouched.
+METADATA_KEY = "pipeline_config"
+
+
 def emit_to_trace() -> None:
-    """Flush the accumulated ``pipeline`` object onto the current Langfuse trace's
-    metadata. Best-effort and merge-only: it never overwrites the existing
-    ``pipeline_variant``/``provider`` tags or scores (those stay for dashboard
-    continuity). No-op when no context is active or Langfuse is unavailable."""
+    """Flush the accumulated resolved-config object onto the current Langfuse
+    trace's metadata under the ``pipeline_config`` key. Best-effort and merge-only:
+    it never overwrites the existing ``pipeline``/``variant``/``pipeline_variant``
+    keys or scores (those stay for dashboard continuity). No-op when no context is
+    active or Langfuse is unavailable."""
     pt = _CTX.get()
     if pt is None or _get_langfuse_client is None:
         return
     try:  # pragma: no cover - best effort
         client = _get_langfuse_client()
         if client is not None:
-            client.update_current_trace(metadata={"pipeline": pt.to_metadata()})
+            client.update_current_trace(metadata={METADATA_KEY: pt.to_metadata()})
     except Exception as e:
         logger.debug("llm_core.trace: emit_to_trace failed: %s", e)
 

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -311,15 +311,30 @@ def record_concurrency(
 # resolved config into a handful of SHORT flat string keys that fit under the cap
 # and land reliably. The COMPLETE static config still goes to the boot log via
 # ``log_full_config`` (``grep llm_core.full_config``).
+#
+# Every emitted value is HARD-CAPPED to ``_ATTR_CAP`` chars so a long configured
+# endpoint/model/profile can never push a key over the OTEL cap and silently drop
+# it (the exact failure this compact path exists to avoid). Truncation is safe:
+# the complete untruncated config is always in the boot ``llm_core.full_config``.
+_ATTR_CAP = 240
+
+
 def compact_metadata(pt: Optional[PipelineTrace]) -> dict:
     """Flatten ``pt`` into short, cap-safe metadata keys:
 
     * ``pipeline_profile`` = resolved profile name;
     * ``pipeline_flags``   = comma-joined enabled guard flags (``_enabled`` stripped);
-    * ``pc_<step>``        = ``"<provider>:<model>@<endpoint>#<served>(<timeout_ms>ms)"``
-                             per executed step (~50 chars each).
+    * ``pc_<step>``        = ``"<provider>:<model>@<endpoint>#<kind>(<timeout_ms>ms)"``
+                             per step, where ``<kind>`` is the CONFIGURED PRIMARY
+                             tier (oss/managed) — NOT necessarily the tier that
+                             actually served. Health-prune / concurrency-reorder /
+                             failure fallback can route a given request to a
+                             different tier; that is visible only in the pydantic-ai
+                             GENERATION observations on the same trace (tracked
+                             follow-up to surface the served tier here).
 
-    Returns ``{}`` on any error / empty pt (never raises into the request path)."""
+    Returns ``{}`` on any error / empty pt (never raises into the request path).
+    None-valued keys are dropped (propagate_attributes wants string values)."""
     out: dict = {}
     if pt is None:
         return out
@@ -338,7 +353,11 @@ def compact_metadata(pt: Optional[PipelineTrace]) -> dict:
             )
     except Exception as e:  # pragma: no cover - defensive
         logger.debug("llm_core.trace: compact_metadata failed: %s", e)
-    return out
+    # Hard-cap every value (a long endpoint/model can't exceed the OTEL cap and
+    # silently drop the key) and drop None values (propagate_attributes expects
+    # string attribute values — a None profile on the populate-failure path must
+    # never reach it).
+    return {k: v[:_ATTR_CAP] for k, v in out.items() if isinstance(v, str)}
 
 
 def add_compact_metadata(pt: Optional[PipelineTrace], metadata: dict) -> None:

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -153,6 +153,70 @@ def record_profile(name: str, weight: Optional[int]) -> None:
     pt.profile_weight = weight
 
 
+# ── EXPLICIT-instance API (contextvar-independent) ────────────────────────────
+# The ContextVar does NOT survive Starlette's StreamingResponse async-generator
+# consumption (each __anext__ step can run under a different context snapshot), so
+# an ``emit_to_trace()`` that read the contextvar got a fresh EMPTY PipelineTrace.
+# The request path therefore holds the ``pt`` returned by ``begin()`` and threads
+# it explicitly: populate the static must-have fields on it here, and pass it to
+# ``emit_to_trace(pt)``. Deep trigger/served recording via the contextvar stays
+# best-effort on top.
+def set_profile(pt: Optional[PipelineTrace], name: str, weight: Optional[int]) -> None:
+    if pt is None:
+        return
+    pt.profile_name = name
+    pt.profile_weight = weight
+
+
+def set_step_primary(pt: Optional[PipelineTrace], step: Any, tier: Any) -> None:
+    """Set a step's PRIMARY resolved tier (provider/model/endpoint/timeout) on an
+    EXPLICIT pt, from a resolved ``MaterializedTier``/``Attempt``. Independent of
+    the contextvar. Preserves any served/trigger fields a deep recorder may have
+    already set on the same step."""
+    if pt is None or tier is None:
+        return
+    name = getattr(step, "value", step)
+    rec = pt.step(name)
+    rec.provider = getattr(tier, "provider", None)
+    rec.model = getattr(tier, "model_name", None)
+    rec.endpoint = getattr(tier, "endpoint", None)
+    rec.timeout_ms = _timeout_ms(tier)
+    if not rec.tier_chain:
+        rec.tier_chain = [_tier_summary(tier)]
+    if rec.tier_served_index is None:
+        rec.tier_served_kind = getattr(tier, "kind", None)
+        rec.tier_served_index = 0
+
+
+def populate(
+    pt: Optional[PipelineTrace],
+    pipeline: Any,
+    primary_tier_fn: Any,
+    variant: Optional[str],
+    steps: Any,
+) -> None:
+    """Explicitly (contextvar-independent) populate the fields the emit MUST carry:
+    the resolved profile (from the pipeline + variant) and each step's PRIMARY tier
+    (resolved via ``primary_tier_fn(step, variant)``). Best-effort per step; a
+    resolve failure for one step is skipped, never raised into the request path.
+
+    ``pipeline`` and ``primary_tier_fn`` are passed in (duck-typed) so this module
+    stays import-clean — it never imports resolver/runtime itself."""
+    if pt is None:
+        return
+    try:
+        name = "oss" if variant == "oss" else "managed"
+        prof = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
+        set_profile(pt, prof.name, prof.weight)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("llm_core.trace: profile populate skipped: %s", e)
+    for step in steps:
+        try:
+            set_step_primary(pt, step, primary_tier_fn(step, variant))
+        except Exception:
+            continue
+
+
 def _tier_summary(tier: Any) -> dict:
     """A secret-free summary of a resolved tier (``MaterializedTier``/``Attempt``)."""
     return {
@@ -260,13 +324,18 @@ def _tag_trace(tags: list) -> None:
 METADATA_KEY = "pipeline_config"
 
 
-def emit_to_trace() -> None:
-    """Flush the accumulated resolved-config object onto the current Langfuse
-    trace's metadata under the ``pipeline_config`` key. Best-effort and merge-only:
-    it never overwrites the existing ``pipeline``/``variant``/``pipeline_variant``
-    keys or scores (those stay for dashboard continuity). No-op when no context is
-    active or Langfuse is unavailable."""
-    pt = _CTX.get()
+def emit_to_trace(pt: Optional[PipelineTrace] = None) -> None:
+    """Flush the resolved-config object onto the current Langfuse trace's metadata
+    under the ``pipeline_config`` key. Best-effort and merge-only: it never
+    overwrites the existing ``pipeline``/``variant``/``pipeline_variant`` keys or
+    scores (those stay for dashboard continuity).
+
+    IMPORTANT: pass the EXPLICIT ``pt`` returned by ``begin()``. The contextvar is
+    NOT a reliable read across Starlette's StreamingResponse async-generator
+    boundary — reading it here yielded an empty object in production. ``pt=None``
+    falls back to the contextvar only for callers that share one context."""
+    if pt is None:
+        pt = _CTX.get()
     if pt is None or _get_langfuse_client is None:
         return
     try:  # pragma: no cover - best effort

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -1,0 +1,340 @@
+"""Per-turn pipeline-trace recorder — the full RESOLVED config + routing
+decisions of one turn, emitted as a single ``pipeline`` object into the Langfuse
+trace metadata.
+
+TRACING ONLY — this module changes NO pipeline behaviour. Every recorder is a
+no-op unless a :class:`PipelineTrace` context is active (opened per-turn by the
+chat/voice request path via :func:`begin`), so the core seams
+(``split``/``health``/``concurrency``/``fallback``) can call the ``record_*``
+hooks unconditionally and cheaply — a bare ``ContextVar.get()`` when nothing is
+listening. Nothing here is on any poll loop; it only ever runs on the request
+path.
+
+SECRETS: this records endpoints (already in logs), providers, model names and
+timeouts — and the *name* of a tier's api-key env var, never its value. It never
+reads or stores an api key. See :func:`_no_secret_assert` in the tests.
+
+Kept import-clean (stdlib + ``app.config`` + ``config_model`` + a best-effort
+Langfuse import) so the voice repo mirrors this file byte-for-byte and the
+eventual repo-merge stays mechanical (this file is one of the convergent cores).
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Best-effort Langfuse trace tagging (same import shape as services.fallback).
+try:  # pragma: no cover - import guard
+    from langfuse import get_client as _get_langfuse_client
+except Exception:  # pragma: no cover
+    _get_langfuse_client = None
+
+
+# ── per-step + per-turn records ───────────────────────────────────────────────
+@dataclass
+class StepRecord:
+    """The resolved config + routing outcome for ONE executed pipeline step."""
+
+    step: str
+    provider: Optional[str] = None       # primary tier's provider ("vllm"/"openai"/...)
+    model: Optional[str] = None          # primary tier's model name
+    endpoint: Optional[str] = None       # primary tier's endpoint URL (or "managed")
+    timeout_ms: Optional[int] = None     # primary tier's per-attempt timeout
+    tier_chain: list[dict] = field(default_factory=list)  # ordered, primary-first
+    tier_served_kind: Optional[str] = None   # kind of the tier that actually served
+    tier_served_index: Optional[int] = None  # 0 = primary, 1 = first fallback, ...
+    health: Optional[dict] = None        # {"pruned": [...], "breaker_states": {...}}
+    concurrency: Optional[dict] = None   # {"gauge", "max_concurrency", "deprioritized", ...}
+
+    def to_dict(self) -> dict:
+        served = None
+        if self.tier_served_kind is not None or self.tier_served_index is not None:
+            served = {"kind": self.tier_served_kind, "index": self.tier_served_index}
+        triggers: dict = {}
+        if self.health is not None:
+            triggers["health"] = self.health
+        if self.concurrency is not None:
+            triggers["concurrency"] = self.concurrency
+        out: dict = {
+            "provider": self.provider,
+            "model": self.model,
+            "endpoint": self.endpoint,
+            "timeout_ms": self.timeout_ms,
+            "tier_served": served,
+            "chain": self.tier_chain,
+        }
+        if triggers:
+            out["triggers"] = triggers
+        return out
+
+
+@dataclass
+class PipelineTrace:
+    """Accumulates one turn's resolved profile, per-step tiers and trigger
+    outcomes. Built by :func:`begin`; drained by :meth:`to_metadata`."""
+
+    variant: Optional[str] = None
+    profile_name: Optional[str] = None
+    profile_weight: Optional[int] = None
+    steps: dict[str, StepRecord] = field(default_factory=dict)
+    flags: dict = field(default_factory=dict)
+
+    def step(self, name: str) -> StepRecord:
+        """Get-or-create the record for a step (health/concurrency may touch it
+        before the materialized chain is recorded)."""
+        rec = self.steps.get(name)
+        if rec is None:
+            rec = StepRecord(step=name)
+            self.steps[name] = rec
+        return rec
+
+    def to_metadata(self) -> dict:
+        """The ``pipeline`` metadata object (schema shared chat<->voice)."""
+        profile = None
+        if self.profile_name is not None:
+            profile = {"name": self.profile_name, "weight": self.profile_weight}
+        return {
+            "profile": profile,
+            "variant": self.variant,
+            "flags": self.flags,
+            "steps": {name: rec.to_dict() for name, rec in self.steps.items()},
+        }
+
+
+_CTX: contextvars.ContextVar[Optional[PipelineTrace]] = contextvars.ContextVar(
+    "llm_core_pipeline_trace", default=None
+)
+
+
+def snapshot_flags() -> dict:
+    """The five guard flags that gate the pipeline — recorded so a turn's trace
+    shows which machinery was even eligible to fire."""
+    from app.config import settings
+
+    return {
+        "llm_core_enabled": bool(getattr(settings, "llm_core_enabled", False)),
+        "profiles_enabled": bool(getattr(settings, "profiles_enabled", False)),
+        "health_breaker_enabled": bool(getattr(settings, "health_breaker_enabled", False)),
+        "health_poller_enabled": bool(getattr(settings, "health_poller_enabled", False)),
+        "concurrency_gauge_enabled": bool(getattr(settings, "concurrency_gauge_enabled", False)),
+    }
+
+
+def begin(variant: Optional[str] = None) -> PipelineTrace:
+    """Open a fresh per-turn recorder and install it in the context. Idempotent
+    per turn: the chat/voice request path calls this once, near the top, as soon
+    as the resolved variant is known."""
+    pt = PipelineTrace(variant=variant, flags=snapshot_flags())
+    _CTX.set(pt)
+    return pt
+
+
+def current() -> Optional[PipelineTrace]:
+    return _CTX.get()
+
+
+def clear() -> None:
+    _CTX.set(None)
+
+
+# ── record hooks (all no-op when no context is active) ────────────────────────
+def record_profile(name: str, weight: Optional[int]) -> None:
+    pt = _CTX.get()
+    if pt is None:
+        return
+    pt.profile_name = name
+    pt.profile_weight = weight
+
+
+def _tier_summary(tier: Any) -> dict:
+    """A secret-free summary of a resolved tier (``MaterializedTier``/``Attempt``)."""
+    return {
+        "kind": getattr(tier, "kind", None),
+        "provider": getattr(tier, "provider", None),
+        "model": getattr(tier, "model_name", None),
+        "endpoint": getattr(tier, "endpoint", None),
+    }
+
+
+def _timeout_ms(tier: Any) -> Optional[int]:
+    t = getattr(tier, "timeout", None)
+    return int(round(t * 1000)) if t is not None else None
+
+
+def record_step_chain(step: Any, chain: list) -> None:
+    """Record the resolved (materialized) tier chain for a step: primary tier's
+    provider/model/endpoint/timeout + the ordered chain. Defaults ``tier_served``
+    to the primary (index 0) — the fallback walker overwrites it if a later tier
+    actually serves."""
+    pt = _CTX.get()
+    if pt is None or not chain:
+        return
+    name = getattr(step, "value", step)
+    rec = pt.step(name)
+    primary = chain[0]
+    rec.provider = getattr(primary, "provider", None)
+    rec.model = getattr(primary, "model_name", None)
+    rec.endpoint = getattr(primary, "endpoint", None)
+    rec.timeout_ms = _timeout_ms(primary)
+    rec.tier_chain = [_tier_summary(t) for t in chain]
+    # Default served = primary; a real fallback overwrites via record_served.
+    if rec.tier_served_index is None:
+        rec.tier_served_kind = getattr(primary, "kind", None)
+        rec.tier_served_index = 0
+
+
+def record_served(step: Any, kind: Optional[str], index: int) -> None:
+    """The fallback walker's success hook: which tier (kind + 0-based index in the
+    chain) actually produced the answer."""
+    pt = _CTX.get()
+    if pt is None:
+        return
+    name = getattr(step, "value", step)
+    rec = pt.step(name)
+    rec.tier_served_kind = kind
+    rec.tier_served_index = index
+
+
+def record_health_prune(step: Any, pruned: list, breaker_states: dict) -> None:
+    """Health-filter outcome for a step: the endpoints pruned (breaker ``open``)
+    and the breaker state consulted per endpoint. Adds a cheap trace tag when a
+    tier was actually pruned so a turn's routing decision is visible."""
+    pt = _CTX.get()
+    if pt is None:
+        return
+    name = getattr(step, "value", step)
+    pt.step(name).health = {"pruned": list(pruned), "breaker_states": dict(breaker_states)}
+    if pruned:
+        _tag_trace([f"health_prune:{name}"])
+
+
+def record_concurrency(
+    step: Any,
+    *,
+    gauge: Optional[int],
+    max_concurrency: Optional[int],
+    deprioritized: bool,
+    metrics_url: Optional[str],
+) -> None:
+    """Concurrency-gauge outcome for a step: the gauge read, the threshold, and
+    whether the vLLM tier was deprioritized. Adds a cheap trace tag when a tier
+    was actually deprioritized."""
+    pt = _CTX.get()
+    if pt is None:
+        return
+    name = getattr(step, "value", step)
+    pt.step(name).concurrency = {
+        "gauge": gauge,
+        "max_concurrency": max_concurrency,
+        "deprioritized": bool(deprioritized),
+        "metrics_url": metrics_url,
+    }
+    if deprioritized:
+        _tag_trace([f"concurrency_deprioritize:{name}"])
+
+
+# ── emission ──────────────────────────────────────────────────────────────────
+def _tag_trace(tags: list) -> None:
+    if _get_langfuse_client is None:
+        return
+    try:  # pragma: no cover - best effort
+        client = _get_langfuse_client()
+        if client is not None:
+            client.update_current_trace(tags=tags)
+    except Exception:
+        pass
+
+
+def emit_to_trace() -> None:
+    """Flush the accumulated ``pipeline`` object onto the current Langfuse trace's
+    metadata. Best-effort and merge-only: it never overwrites the existing
+    ``pipeline_variant``/``provider`` tags or scores (those stay for dashboard
+    continuity). No-op when no context is active or Langfuse is unavailable."""
+    pt = _CTX.get()
+    if pt is None or _get_langfuse_client is None:
+        return
+    try:  # pragma: no cover - best effort
+        client = _get_langfuse_client()
+        if client is not None:
+            client.update_current_trace(metadata={"pipeline": pt.to_metadata()})
+    except Exception as e:
+        logger.debug("llm_core.trace: emit_to_trace failed: %s", e)
+
+
+# ── startup full-config dump (item 4) ─────────────────────────────────────────
+def config_to_dict(pipeline: Any) -> dict:
+    """The COMPLETE loaded ``PipelineConfig`` as a plain dict — all profiles, all
+    step tiers, all triggers — for one greppable structured boot log line.
+
+    Secret-free by construction: a ``Tier`` only ever names its api-key env var
+    (``api_key_env``); the value is never on the model, so this can't leak a key.
+    """
+
+    def _tier(t: Any) -> dict:
+        return {
+            "provider": getattr(getattr(t, "provider", None), "value", getattr(t, "provider", None)),
+            "model": getattr(t, "model", None),
+            "endpoint": getattr(t, "endpoint", None),
+            "timeout_ms": getattr(t, "timeout_ms", None),
+            "api_key_env": getattr(t, "api_key_env", None),  # NAME only, never the value
+            "api_version": getattr(t, "api_version", None),
+        }
+
+    def _triggers(tr: Any) -> dict:
+        gate = getattr(tr, "concurrency_gate", None)
+        return {
+            "ttft_deadline_ms": getattr(tr, "ttft_deadline_ms", None),
+            "health_check": getattr(tr, "health_check", None),
+            "concurrency_gate": (
+                {
+                    "metrics_url": getattr(gate, "metrics_url", None),
+                    "max_concurrency": getattr(gate, "max_concurrency", None),
+                }
+                if gate is not None
+                else None
+            ),
+        }
+
+    def _step_cfg(sc: Any) -> dict:
+        return {
+            "tiers": [_tier(t) for t in getattr(sc, "tiers", [])],
+            "triggers": _triggers(getattr(sc, "triggers", None)),
+        }
+
+    def _steps(steps: Any) -> dict:
+        return {
+            getattr(step, "value", step): _step_cfg(sc) for step, sc in (steps or {}).items()
+        }
+
+    return {
+        "sticky_ttl_s": getattr(pipeline, "sticky_ttl_s", None),
+        "fallback_enabled": getattr(pipeline, "fallback_enabled", None),
+        "defaults": _steps(getattr(pipeline, "defaults", {})),
+        "profiles": [
+            {
+                "name": p.name,
+                "weight": p.weight,
+                "steps": _steps(getattr(p, "steps", {})),
+            }
+            for p in getattr(pipeline, "profiles", [])
+        ],
+    }
+
+
+def log_full_config(pipeline: Any) -> None:
+    """Emit the complete resolved config as ONE structured log line at boot, so the
+    full wiring is greppable in logs even before any turn arrives (``grep
+    llm_core.full_config``). Best-effort — never breaks startup."""
+    try:
+        payload = config_to_dict(pipeline)
+        payload["flags"] = snapshot_flags()
+        logger.info("llm_core.full_config %s", json.dumps(payload, sort_keys=True))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("llm_core.trace: log_full_config failed: %s", e)

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -314,25 +314,11 @@ def emit(event: FallbackEvent) -> None:
         except Exception:
             pass
 
-    if _get_langfuse_client is not None:
-        try:  # pragma: no cover - best effort
-            client = _get_langfuse_client()
-            if client is not None:
-                client.update_current_trace(
-                    tags=[f"oss_fallback:{event.pipeline}:{event.reason.value}"],
-                    metadata={
-                        "oss_fallback": {
-                            "pipeline": event.pipeline,
-                            "reason": event.reason.value,
-                            "fell_back": event.fell_back,
-                            "endpoint": event.oss_endpoint,
-                            "model": event.oss_model,
-                            "latency_ms": event.latency_ms,
-                        }
-                    },
-                )
-        except Exception:
-            pass
+    # NOTE: the fallback event lands via the structured log line above + the Sentry
+    # breadcrumb. A prior ``client.update_current_trace(...)`` call was removed here:
+    # this Langfuse SDK has no ``update_current_trace`` (it always raised and was
+    # swallowed, so the tag/metadata never landed). Re-landing fallback-event tags
+    # via a supported API (update_current_span) is a tracked follow-up.
 
 
 def _record_served(pipeline: str, kind: str, index: int) -> None:

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -335,6 +335,17 @@ def emit(event: FallbackEvent) -> None:
             pass
 
 
+def _record_served(pipeline: str, kind: str, index: int) -> None:
+    """Tracing-only: thread the tier that actually served (kind + 0-based chain
+    index) back to the current turn's pipeline-trace, keyed by the pipeline's
+    Step. No-op when no trace context is active; never breaks the request path."""
+    try:  # pragma: no cover - best effort
+        from app.llm_core import trace as _trace
+        _trace.record_served(_PIPELINE_TO_STEP.get(pipeline, pipeline), kind, index)
+    except Exception:
+        pass
+
+
 async def execute_with_fallback(
     *,
     pipeline: str,
@@ -392,6 +403,7 @@ async def execute_with_fallback(
             # Clean success resets the breaker for this endpoint (P2). No-op unless
             # HEALTH_BREAKER_ENABLED.
             health.record_success(attempt.endpoint)
+            _record_served(pipeline, attempt.kind, i)
             return result
 
 
@@ -518,6 +530,7 @@ async def stream_with_fallback(
                 yield chunk
             # Clean stream finish resets the breaker for this endpoint (P2).
             health.record_success(attempt.endpoint)
+            _record_served(pipeline, attempt.kind, i)
             return  # stream finished cleanly
         except asyncio.CancelledError:
             raise

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1053,10 +1053,12 @@ async def stream_voice_message(
         trace.metadata["request_provider"] = request_provider
     except Exception:  # pragma: no cover - never break the call
         pass
-    # Open the per-turn pipeline-config tracer and hold the EXPLICIT instance on the
-    # VoiceTrace (contextvar-independent — the streaming-generator boundary empties
-    # a contextvar read). Populate the must-have static fields (profile, variant,
-    # flags, per-step PRIMARY tier) now; request_context() emits THIS object on exit.
+    # Serialize the resolved pipeline config into COMPACT flat keys and merge them
+    # into trace.metadata (which rides along in metadata=self.metadata on the root
+    # observation — the path that lands; this SDK has no update_current_trace, and a
+    # big nested blob is OTEL-attribute size-capped). Adds `pipeline_profile`,
+    # `pipeline_flags`, and one `pc_<step>` per step. Full static config is in the
+    # `llm_core.full_config` boot log. Best-effort — never breaks the call.
     try:
         from app.llm_core import trace as _pipeline_trace
         from app.llm_core import resolver as _lr, runtime as _lrt
@@ -1066,7 +1068,7 @@ async def stream_voice_message(
             _pt, _lrt.get_pipeline(), _lr.primary_tier, pipeline_variant,
             (_LS.PRE_TRANSLATION, _LS.MODERATION, _LS.NON_MEANINGFUL, _LS.AGENT, _LS.POST_TRANSLATION),
         )
-        trace.pipeline_trace_obj = _pt
+        _pipeline_trace.add_compact_metadata(_pt, trace.metadata)
     except Exception as _pt_exc:  # pragma: no cover - tracing must never break the call
         logger.debug("pipeline_config populate skipped: %s", _pt_exc)
     logger.info(

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1053,6 +1053,22 @@ async def stream_voice_message(
         trace.metadata["request_provider"] = request_provider
     except Exception:  # pragma: no cover - never break the call
         pass
+    # Open the per-turn pipeline-config tracer and hold the EXPLICIT instance on the
+    # VoiceTrace (contextvar-independent — the streaming-generator boundary empties
+    # a contextvar read). Populate the must-have static fields (profile, variant,
+    # flags, per-step PRIMARY tier) now; request_context() emits THIS object on exit.
+    try:
+        from app.llm_core import trace as _pipeline_trace
+        from app.llm_core import resolver as _lr, runtime as _lrt
+        from app.llm_core.config_model import Step as _LS
+        _pt = _pipeline_trace.begin(pipeline_variant)
+        _pipeline_trace.populate(
+            _pt, _lrt.get_pipeline(), _lr.primary_tier, pipeline_variant,
+            (_LS.PRE_TRANSLATION, _LS.MODERATION, _LS.NON_MEANINGFUL, _LS.AGENT, _LS.POST_TRANSLATION),
+        )
+        trace.pipeline_trace_obj = _pt
+    except Exception as _pt_exc:  # pragma: no cover - tracing must never break the call
+        logger.debug("pipeline_config populate skipped: %s", _pt_exc)
     logger.info(
         "voice request_variant session_id=%s variant=%s model=%s provider=%s",
         session_id,

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, Optional
 
 from app.config import settings
+# Per-turn resolved-pipeline-config tracer (tracing-only; no behaviour change).
+from app.llm_core import trace as _pipeline_trace
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +216,10 @@ class VoiceTrace:
     @contextmanager
     def request_context(self) -> Iterator[None]:
         """Open the root Langfuse observation for the full streaming request."""
+        # Open the per-turn pipeline-config tracer: every llm_core seam records the
+        # resolved profile / step tiers / trigger outcomes into this context while
+        # the request runs; it is flushed to the trace metadata on exit below.
+        _pipeline_trace.begin(self.metadata.get("pipeline_variant"))
         if not self.enabled or self.langfuse_client is None:
             yield
             return
@@ -268,6 +274,10 @@ class VoiceTrace:
         try:
             yield
         finally:
+            # Flush the full resolved-pipeline-config (profile + per-step served
+            # tiers + trigger decisions) onto the trace metadata as a `pipeline`
+            # object, while the root observation is still open.
+            _pipeline_trace.emit_to_trace()
             try:
                 stack.close()
             except Exception as exc:

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -177,6 +177,10 @@ class VoiceTrace:
     timings_ms: dict[str, float] = field(default_factory=dict)
     response_parts: list[str] = field(default_factory=list)
     finished: bool = False
+    # Explicit per-turn pipeline-config trace instance (contextvar-independent —
+    # threaded so the emit in request_context() reads THIS populated object, not a
+    # fresh contextvar read that the streaming-generator boundary would empty).
+    pipeline_trace_obj: Any | None = None
 
     def __post_init__(self) -> None:
         if self.enabled:
@@ -216,10 +220,12 @@ class VoiceTrace:
     @contextmanager
     def request_context(self) -> Iterator[None]:
         """Open the root Langfuse observation for the full streaming request."""
-        # Open the per-turn pipeline-config tracer: every llm_core seam records the
-        # resolved profile / step tiers / trigger outcomes into this context while
-        # the request runs; it is flushed to the trace metadata on exit below.
-        _pipeline_trace.begin(self.metadata.get("pipeline_variant"))
+        # Ensure a per-turn pipeline-config trace instance exists. Normally
+        # stream_voice_message has already opened + populated one and stashed it on
+        # self.pipeline_trace_obj (the EXPLICIT instance emit reads below); this is
+        # a fail-safe for any caller that enters request_context without it.
+        if self.pipeline_trace_obj is None:
+            self.pipeline_trace_obj = _pipeline_trace.begin(self.metadata.get("pipeline_variant"))
         if not self.enabled or self.langfuse_client is None:
             yield
             return
@@ -274,10 +280,12 @@ class VoiceTrace:
         try:
             yield
         finally:
-            # Flush the full resolved-pipeline-config (profile + per-step served
-            # tiers + trigger decisions) onto the trace metadata as a `pipeline`
-            # object, while the root observation is still open.
-            _pipeline_trace.emit_to_trace()
+            # Flush the resolved-pipeline-config (profile + variant + flags +
+            # per-step primary tiers, plus any best-effort trigger/served fields)
+            # onto the trace metadata as a `pipeline_config` object while the root
+            # observation is still open. Pass the EXPLICIT instance — a contextvar
+            # read here would be emptied by the streaming-generator boundary.
+            _pipeline_trace.emit_to_trace(self.pipeline_trace_obj)
             try:
                 stack.close()
             except Exception as exc:

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, Optional
 
 from app.config import settings
-# Per-turn resolved-pipeline-config tracer (tracing-only; no behaviour change).
-from app.llm_core import trace as _pipeline_trace
 
 logger = logging.getLogger(__name__)
 
@@ -177,10 +175,6 @@ class VoiceTrace:
     timings_ms: dict[str, float] = field(default_factory=dict)
     response_parts: list[str] = field(default_factory=list)
     finished: bool = False
-    # Explicit per-turn pipeline-config trace instance (contextvar-independent —
-    # threaded so the emit in request_context() reads THIS populated object, not a
-    # fresh contextvar read that the streaming-generator boundary would empty).
-    pipeline_trace_obj: Any | None = None
 
     def __post_init__(self) -> None:
         if self.enabled:
@@ -219,13 +213,14 @@ class VoiceTrace:
 
     @contextmanager
     def request_context(self) -> Iterator[None]:
-        """Open the root Langfuse observation for the full streaming request."""
-        # Ensure a per-turn pipeline-config trace instance exists. Normally
-        # stream_voice_message has already opened + populated one and stashed it on
-        # self.pipeline_trace_obj (the EXPLICIT instance emit reads below); this is
-        # a fail-safe for any caller that enters request_context without it.
-        if self.pipeline_trace_obj is None:
-            self.pipeline_trace_obj = _pipeline_trace.begin(self.metadata.get("pipeline_variant"))
+        """Open the root Langfuse observation for the full streaming request.
+
+        The resolved-pipeline-config compact keys (``pipeline_profile`` /
+        ``pipeline_flags`` / ``pc_<step>``) are added to ``self.metadata`` by
+        ``stream_voice_message`` BEFORE this opens, so they ride along in the
+        ``metadata=self.metadata`` passed to the root observation below (the path
+        that actually lands — a nested blob via ``update_current_trace`` does not,
+        this SDK has no such method)."""
         if not self.enabled or self.langfuse_client is None:
             yield
             return
@@ -280,12 +275,6 @@ class VoiceTrace:
         try:
             yield
         finally:
-            # Flush the resolved-pipeline-config (profile + variant + flags +
-            # per-step primary tiers, plus any best-effort trigger/served fields)
-            # onto the trace metadata as a `pipeline_config` object while the root
-            # observation is still open. Pass the EXPLICIT instance — a contextvar
-            # read here would be emptied by the streaming-generator boundary.
-            _pipeline_trace.emit_to_trace(self.pipeline_trace_obj)
             try:
                 stack.close()
             except Exception as exc:

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -227,31 +227,54 @@ def test_emit_uses_pipeline_config_key_not_pipeline(monkeypatch):
     fake = _FakeClient()
     monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
 
-    trace.begin("oss")
-    trace.record_profile("oss", 100)
-    trace.emit_to_trace()
+    pt = trace.begin("oss")
+    trace.set_profile(pt, "oss", 100)
+    trace.emit_to_trace(pt)
 
     assert "pipeline_config" in fake.metadata
     assert "pipeline" not in fake.metadata          # must not collide with the name string
     assert fake.metadata["pipeline_config"]["profile"] == {"name": "oss", "weight": 100}
 
 
-def test_emit_populated_across_async_and_child_task_boundary(monkeypatch):
-    """Catches the empty-emit regression: the SAME PipelineTrace that resolve_chain
-    populates (across an await AND an asyncio child-task boundary) must be the one
-    emit serializes — profile + steps present, flags never empty. Mirrors the chat
-    streaming generator shape (begin at top, resolve mid-turn, emit at the end)."""
-    import asyncio
+def test_populate_sets_profile_and_per_step_primary_tiers(monkeypatch):
+    """`populate` (the explicit, contextvar-independent path the request path uses)
+    fills profile + each step's PRIMARY tier via the SYNC resolver.primary_tier —
+    exactly as chat.py/voice.py call it (`resolver.primary_tier`)."""
+    cfg = _cfg(100)
+    monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: cfg)
 
+    pt = trace.begin("oss")
+    trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT, Step.MODERATION))
+    md = pt.to_metadata()
+    assert md["profile"] == {"name": "oss", "weight": 100}
+    assert md["steps"]["agent"]["provider"] == "vllm"
+    assert md["steps"]["agent"]["model"] == "gemma"
+    assert md["steps"]["moderation"]["model"] == "gemma"
+    assert len(md["flags"]) == 5
+
+
+def test_explicit_emit_survives_contextvar_loss(monkeypatch):
+    """THE regression this fixes: prod consumes stream_chat_messages as a
+    StreamingResponse async generator, and the ContextVar does NOT survive to the
+    emit site — a contextvar-based emit read an EMPTY object. Simulate that boundary
+    by CLEARING the contextvar after populate, then assert emit(pt) still serializes
+    the fully-populated explicit instance (profile + steps + flags)."""
+    import asyncio
     fake = _FakeClient()
     monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+    cfg = _cfg(100)
+    monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: cfg)
 
     async def _agen():
-        trace.begin("oss")
-        await split.resolve_chain("", Step.AGENT, _cfg(100))            # same-task await
-        await asyncio.create_task(split.resolve_chain("", Step.MODERATION, _cfg(100)))  # child task
+        pt = trace.begin("oss")
+        # Exactly how chat.py populates: the SYNC resolver.primary_tier.
+        trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT, Step.MODERATION))
         yield "chunk"
-        trace.emit_to_trace()
+        # Simulate the prod boundary: the contextvar is gone by the emit site.
+        trace.clear()
+        assert trace.current() is None
+        # A contextvar read would now be EMPTY — the explicit pt must still work.
+        trace.emit_to_trace(pt)
 
     async def _drive():
         async for _ in _agen():
@@ -260,10 +283,23 @@ def test_emit_populated_across_async_and_child_task_boundary(monkeypatch):
     asyncio.run(_drive())
 
     pc = fake.metadata["pipeline_config"]
-    assert pc["profile"] == {"name": "oss", "weight": 100}   # NOT None (empty-emit guard)
-    assert len(pc["flags"]) == 5                              # flags never empty
-    assert set(pc["steps"]) >= {"agent", "moderation"}       # child-task record survived
+    assert pc["profile"] == {"name": "oss", "weight": 100}   # NOT None despite ctxvar loss
+    assert len(pc["flags"]) == 5
+    assert set(pc["steps"]) == {"agent", "moderation"}
     assert pc["steps"]["agent"]["model"] == "gemma"
+
+
+def test_contextvar_emit_would_be_empty_after_loss(monkeypatch):
+    """Proves the OLD (contextvar) emit path is exactly what broke: after the
+    boundary clears the contextvar, emit_to_trace() with NO explicit pt is a no-op
+    (nothing emitted) — i.e. the empty-object prod symptom."""
+    fake = _FakeClient()
+    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+    pt = trace.begin("oss")
+    trace.set_profile(pt, "oss", 100)
+    trace.clear()                      # boundary loses the contextvar
+    trace.emit_to_trace()              # no explicit pt -> reads empty contextvar
+    assert fake.metadata is None       # nothing emitted (the prod empty symptom)
 
 
 def test_emit_flags_present_even_when_nothing_resolved(monkeypatch):
@@ -271,8 +307,8 @@ def test_emit_flags_present_even_when_nothing_resolved(monkeypatch):
     `flags` are populated from settings (never None/empty)."""
     fake = _FakeClient()
     monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
-    trace.begin("legacy")
-    trace.emit_to_trace()
+    pt = trace.begin("legacy")
+    trace.emit_to_trace(pt)
     pc = fake.metadata["pipeline_config"]
     assert len(pc["flags"]) == 5
     assert pc["steps"] == {}

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -249,6 +249,29 @@ def test_compact_metadata_produces_short_flat_keys(monkeypatch):
     assert all(v is None or len(v) < 120 for v in m.values())
 
 
+def test_compact_metadata_hard_caps_long_values(monkeypatch):
+    """A long configured endpoint/model must NOT push a pc_<step> value over the
+    OTEL attribute cap (which would silently DROP the key). Values are truncated to
+    _ATTR_CAP; the full untruncated config is always in the boot full_config dump."""
+    from app.llm_core.config_model import (
+        NamedProfile, PipelineConfig, Provider, StepConfig, Tier,
+    )
+
+    long_ep = "http://" + "x" * 500 + ":8020/v1"
+    cfg = PipelineConfig(profiles=[NamedProfile(name="oss", weight=100, steps={
+        Step.AGENT: StepConfig(tiers=[Tier(
+            provider=Provider.VLLM, model="m" * 300, endpoint=long_ep,
+            api_key_env="OSS_INFERENCE_API_KEY", timeout_ms=8000)]),
+    })])
+    monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: cfg)
+    pt = trace.begin("oss")
+    trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT,))
+
+    m = trace.compact_metadata(pt)
+    assert len(m["pc_agent"]) == trace._ATTR_CAP           # truncated -> the key still LANDS
+    assert all(v is None or len(v) <= trace._ATTR_CAP for v in m.values())
+
+
 def test_add_compact_metadata_merges_into_request_metadata_dict(monkeypatch):
     """The request path merges the compact keys into the SAME dict it already hands
     to propagate_attributes / VoiceTrace.metadata — existing keys preserved."""

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -1,0 +1,225 @@
+"""Unit tests for the per-turn resolved-pipeline-config tracer
+(``app/llm_core/trace.py``) and its recording seams in
+``split`` / ``resolver`` / ``health`` / ``concurrency`` / ``fallback``.
+
+The bar these pin:
+  (a) a stubbed turn (no network) populates the ``pipeline`` trace metadata with
+      the resolved profile (name + weight) and, per executed step, the resolved
+      tier (provider / model / endpoint / timeout_ms) + tier_served;
+  (b) SECRETS never appear — the api-key *value* is nowhere in the emitted
+      metadata nor in the startup full-config dump (only the env-var NAME is);
+  (c) the fallback walker threads the actually-served tier index back;
+  (d) the health-prune and concurrency-deprioritize trigger outcomes are recorded
+      when those filters fire;
+  (e) the recorders are a no-op with no active context (cheap request-path guard).
+
+Zero network: ``session_id=""`` avoids Redis; building a factory handle is lazy
+(no model call). A KNOWN-SECRET api key is placed in the env and then asserted
+absent from every emitted structure. These tests deliberately avoid
+``app.services.translation`` / ``agents.tools`` (pydantic-ai version mismatch).
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+# A sentinel we assert never leaks into any trace metadata / config dump.
+_SECRET = "SUPER-SECRET-KEY-VALUE-do-not-leak"
+os.environ["OSS_INFERENCE_API_KEY"] = _SECRET
+
+import json
+
+import pytest
+
+from app.llm_core import trace, split, resolver, health, concurrency
+from app.llm_core.config_model import (
+    ConcurrencyGate,
+    NamedProfile,
+    PipelineConfig,
+    Provider,
+    Step,
+    StepConfig,
+    Tier,
+    Triggers,
+)
+# NB: app.services.fallback is imported LAZILY (via importorskip) inside the one
+# test that needs it — importing it at module top pulls in agents.models, which
+# fails under the local pydantic-ai 0.2.4 vs pinned 1.x mismatch and would break
+# collection of the whole (otherwise network-free) module. Mirrors test_split.py.
+
+
+def _oss_tier(model="gemma"):
+    return Tier(provider=Provider.VLLM, model=model, endpoint="http://oss:8020/v1",
+                api_key_env="OSS_INFERENCE_API_KEY", timeout_ms=8000)
+
+
+def _managed_tier(model="gpt-4.1"):
+    return Tier(provider=Provider.OPENAI, model=model, api_key_env="OPENAI_API_KEY",
+                timeout_ms=20000)
+
+
+def _cfg(pct=100, triggers=None) -> PipelineConfig:
+    oss_steps = {
+        Step.AGENT: StepConfig(tiers=[_oss_tier(), _managed_tier()], triggers=triggers or Triggers()),
+        Step.MODERATION: StepConfig(tiers=[_oss_tier(), _managed_tier()]),
+    }
+    managed_steps = {
+        Step.AGENT: StepConfig(tiers=[_managed_tier()]),
+        Step.MODERATION: StepConfig(tiers=[_managed_tier()]),
+    }
+    return PipelineConfig(profiles=[
+        NamedProfile(name="oss", weight=pct, steps=oss_steps),
+        NamedProfile(name="managed", weight=100 - pct, steps=managed_steps),
+    ])
+
+
+@pytest.fixture(autouse=True)
+def _fresh_ctx():
+    trace.clear()
+    yield
+    trace.clear()
+
+
+# ── (a) resolved profile + per-step tier populate the pipeline metadata ────────
+def test_resolve_chain_populates_profile_and_step(monkeypatch):
+    import asyncio
+    trace.begin("oss")
+    asyncio.run(split.resolve_chain("", Step.AGENT, _cfg(100)))
+
+    md = trace.current().to_metadata()
+    assert md["profile"] == {"name": "oss", "weight": 100}
+    assert md["variant"] == "oss"
+    step = md["steps"]["agent"]
+    assert step["provider"] == "vllm"
+    assert step["model"] == "gemma"
+    assert step["endpoint"] == "http://oss:8020/v1"
+    assert step["timeout_ms"] == 8000
+    # Default served = primary (index 0) until a fallback overwrites it.
+    assert step["tier_served"] == {"kind": "oss", "index": 0}
+    assert [t["kind"] for t in step["chain"]] == ["oss", "managed"]
+
+
+def test_flags_present_in_metadata():
+    trace.begin("legacy")
+    flags = trace.current().to_metadata()["flags"]
+    assert set(flags) == {
+        "llm_core_enabled", "profiles_enabled", "health_breaker_enabled",
+        "health_poller_enabled", "concurrency_gauge_enabled",
+    }
+
+
+def test_resolver_seam_records_step(monkeypatch):
+    """The non-fallback primary-tier seam records too."""
+    monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: _cfg(100))
+    trace.begin("oss")
+    resolver.resolve_chain(Step.AGENT, "oss")
+    md = trace.current().to_metadata()
+    assert md["profile"]["name"] == "oss"
+    assert md["steps"]["agent"]["model"] == "gemma"
+
+
+# ── (b) secrets never leak ─────────────────────────────────────────────────────
+def test_no_api_key_value_in_metadata():
+    import asyncio
+    trace.begin("oss")
+    asyncio.run(split.resolve_chain("", Step.AGENT, _cfg(100)))
+    blob = json.dumps(trace.current().to_metadata())
+    assert _SECRET not in blob
+    # The env-var NAME is fine to trace; the VALUE must never appear.
+    assert "OSS_INFERENCE_API_KEY" not in blob  # not even the name (metadata omits it)
+
+
+def test_no_secret_in_full_config_dump(caplog):
+    import logging
+    cfg = _cfg(50)
+    with caplog.at_level(logging.INFO):
+        trace.log_full_config(cfg)
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "llm_core.full_config" in text
+    assert _SECRET not in text
+    # api_key_env NAME is dumped (not a secret); the value is not.
+    assert "OSS_INFERENCE_API_KEY" in text
+    # all profiles + steps present
+    dumped = trace.config_to_dict(cfg)
+    assert {p["name"] for p in dumped["profiles"]} == {"oss", "managed"}
+    assert "agent" in dumped["profiles"][0]["steps"]
+
+
+# ── (c) fallback walker threads the served tier index ──────────────────────────
+def test_fallback_walker_records_served_index(monkeypatch):
+    import asyncio
+
+    fb = pytest.importorskip("app.services.fallback")
+    oss = fb.Attempt("oss", object(), "gemma", "vllm", "http://oss:8020/v1", None)
+    managed = fb.Attempt("managed", object(), "gpt-4.1", "openai", "managed", None)
+
+    async def _chain(**kw):
+        return [oss, managed]
+
+    monkeypatch.setattr(fb, "_resolve_chain", _chain)
+
+    trace.begin("oss")
+    trace.record_step_chain(Step.AGENT, [oss, managed])  # seed primary=index0
+
+    async def _run(a):
+        if a.kind == "oss":
+            raise TimeoutError("oss down")   # fallbackable -> swap to managed
+        return "answer"
+
+    out = asyncio.run(fb.execute_with_fallback(
+        pipeline="chat", session_id="s", variant="oss", run=_run))
+    assert out == "answer"
+    served = trace.current().to_metadata()["steps"]["agent"]["tier_served"]
+    assert served == {"kind": "managed", "index": 1}
+
+
+# ── (d) trigger outcomes recorded when the filters fire ────────────────────────
+def test_health_prune_trigger_recorded(monkeypatch):
+    monkeypatch.setattr(health.settings, "health_breaker_enabled", True)
+    reg = health.reset()
+    # Trip the oss endpoint open at real monotonic time so it stays open (within
+    # cooldown) when prune_unhealthy consults is_open with the real clock.
+    for _ in range(reg.config.fail_threshold):
+        reg.record_failure("http://oss:8020/v1")
+
+    trace.begin("oss")
+    tiers = [_oss_tier(), _managed_tier()]
+    kept = health.prune_unhealthy(Step.AGENT, tiers)
+    assert len(kept) == 1  # oss pruned
+    h = trace.current().to_metadata()["steps"]["agent"]["triggers"]["health"]
+    assert h["pruned"] == ["http://oss:8020/v1"]
+    assert h["breaker_states"]["http://oss:8020/v1"] == "open"
+    health.reset()
+
+
+def test_concurrency_deprioritize_trigger_recorded(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(concurrency.settings, "concurrency_gauge_enabled", True)
+
+    async def _fake_gauge(url):
+        return 99  # saturated
+
+    monkeypatch.setattr(concurrency, "get_concurrency", _fake_gauge)
+    gate = ConcurrencyGate(metrics_url="http://oss:8020/metrics", max_concurrency=10)
+
+    trace.begin("oss")
+    tiers = [_oss_tier(), _managed_tier()]
+    out = asyncio.run(concurrency.reprioritize_by_load(Step.AGENT, tiers, gate))
+    assert out[-1].provider is Provider.VLLM  # vLLM deprioritized to the back
+    c = trace.current().to_metadata()["steps"]["agent"]["triggers"]["concurrency"]
+    assert c["gauge"] == 99 and c["max_concurrency"] == 10 and c["deprioritized"] is True
+    assert c["metrics_url"] == "http://oss:8020/metrics"
+
+
+# ── (e) no active context -> recorders are a cheap no-op ───────────────────────
+def test_recorders_noop_without_context():
+    import asyncio
+    trace.clear()
+    assert trace.current() is None
+    # None of these should raise or set anything.
+    trace.record_profile("oss", 100)
+    trace.record_step_chain(Step.AGENT, [])
+    trace.record_served(Step.AGENT, "managed", 1)
+    trace.emit_to_trace()
+    # split resolving with no context is still a clean no-op for tracing.
+    asyncio.run(split.resolve_chain("", Step.AGENT, _cfg(100)))
+    assert trace.current() is None

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -210,6 +210,75 @@ def test_concurrency_deprioritize_trigger_recorded(monkeypatch):
     assert c["metrics_url"] == "http://oss:8020/metrics"
 
 
+# ── (f) emit lands under `pipeline_config` (NOT `pipeline`) + is POPULATED ─────
+class _FakeClient:
+    def __init__(self):
+        self.metadata = None
+
+    def update_current_trace(self, **kw):
+        # Langfuse merges; capture the metadata dict this emit passed.
+        if kw.get("metadata"):
+            self.metadata = kw["metadata"]
+
+
+def test_emit_uses_pipeline_config_key_not_pipeline(monkeypatch):
+    """The emitted key MUST be `pipeline_config` — reusing `pipeline` collides with
+    chat's existing `metadata['pipeline']` = pipeline NAME string, which then wins."""
+    fake = _FakeClient()
+    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+
+    trace.begin("oss")
+    trace.record_profile("oss", 100)
+    trace.emit_to_trace()
+
+    assert "pipeline_config" in fake.metadata
+    assert "pipeline" not in fake.metadata          # must not collide with the name string
+    assert fake.metadata["pipeline_config"]["profile"] == {"name": "oss", "weight": 100}
+
+
+def test_emit_populated_across_async_and_child_task_boundary(monkeypatch):
+    """Catches the empty-emit regression: the SAME PipelineTrace that resolve_chain
+    populates (across an await AND an asyncio child-task boundary) must be the one
+    emit serializes — profile + steps present, flags never empty. Mirrors the chat
+    streaming generator shape (begin at top, resolve mid-turn, emit at the end)."""
+    import asyncio
+
+    fake = _FakeClient()
+    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+
+    async def _agen():
+        trace.begin("oss")
+        await split.resolve_chain("", Step.AGENT, _cfg(100))            # same-task await
+        await asyncio.create_task(split.resolve_chain("", Step.MODERATION, _cfg(100)))  # child task
+        yield "chunk"
+        trace.emit_to_trace()
+
+    async def _drive():
+        async for _ in _agen():
+            pass
+
+    asyncio.run(_drive())
+
+    pc = fake.metadata["pipeline_config"]
+    assert pc["profile"] == {"name": "oss", "weight": 100}   # NOT None (empty-emit guard)
+    assert len(pc["flags"]) == 5                              # flags never empty
+    assert set(pc["steps"]) >= {"agent", "moderation"}       # child-task record survived
+    assert pc["steps"]["agent"]["model"] == "gemma"
+
+
+def test_emit_flags_present_even_when_nothing_resolved(monkeypatch):
+    """A turn that resolves no step still emits a `pipeline_config` whose static
+    `flags` are populated from settings (never None/empty)."""
+    fake = _FakeClient()
+    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+    trace.begin("legacy")
+    trace.emit_to_trace()
+    pc = fake.metadata["pipeline_config"]
+    assert len(pc["flags"]) == 5
+    assert pc["steps"] == {}
+    assert pc["profile"] is None
+
+
 # ── (e) no active context -> recorders are a cheap no-op ───────────────────────
 def test_recorders_noop_without_context():
     import asyncio

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -210,32 +210,7 @@ def test_concurrency_deprioritize_trigger_recorded(monkeypatch):
     assert c["metrics_url"] == "http://oss:8020/metrics"
 
 
-# ── (f) emit lands under `pipeline_config` (NOT `pipeline`) + is POPULATED ─────
-class _FakeClient:
-    def __init__(self):
-        self.metadata = None
-
-    def update_current_trace(self, **kw):
-        # Langfuse merges; capture the metadata dict this emit passed.
-        if kw.get("metadata"):
-            self.metadata = kw["metadata"]
-
-
-def test_emit_uses_pipeline_config_key_not_pipeline(monkeypatch):
-    """The emitted key MUST be `pipeline_config` — reusing `pipeline` collides with
-    chat's existing `metadata['pipeline']` = pipeline NAME string, which then wins."""
-    fake = _FakeClient()
-    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
-
-    pt = trace.begin("oss")
-    trace.set_profile(pt, "oss", 100)
-    trace.emit_to_trace(pt)
-
-    assert "pipeline_config" in fake.metadata
-    assert "pipeline" not in fake.metadata          # must not collide with the name string
-    assert fake.metadata["pipeline_config"]["profile"] == {"name": "oss", "weight": 100}
-
-
+# ── (f) populate + COMPACT flat metadata keys (the path that lands) ───────────
 def test_populate_sets_profile_and_per_step_primary_tiers(monkeypatch):
     """`populate` (the explicit, contextvar-independent path the request path uses)
     fills profile + each step's PRIMARY tier via the SYNC resolver.primary_tier —
@@ -253,66 +228,60 @@ def test_populate_sets_profile_and_per_step_primary_tiers(monkeypatch):
     assert len(md["flags"]) == 5
 
 
-def test_explicit_emit_survives_contextvar_loss(monkeypatch):
-    """THE regression this fixes: prod consumes stream_chat_messages as a
-    StreamingResponse async generator, and the ContextVar does NOT survive to the
-    emit site — a contextvar-based emit read an EMPTY object. Simulate that boundary
-    by CLEARING the contextvar after populate, then assert emit(pt) still serializes
-    the fully-populated explicit instance (profile + steps + flags)."""
-    import asyncio
-    fake = _FakeClient()
-    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
+def test_compact_metadata_produces_short_flat_keys(monkeypatch):
+    """The keys that actually land on the trace: `pipeline_profile`, `pipeline_flags`,
+    and one `pc_<step>` per step — short flat strings, under the OTEL attribute cap."""
     cfg = _cfg(100)
     monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: cfg)
-
-    async def _agen():
-        pt = trace.begin("oss")
-        # Exactly how chat.py populates: the SYNC resolver.primary_tier.
-        trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT, Step.MODERATION))
-        yield "chunk"
-        # Simulate the prod boundary: the contextvar is gone by the emit site.
-        trace.clear()
-        assert trace.current() is None
-        # A contextvar read would now be EMPTY — the explicit pt must still work.
-        trace.emit_to_trace(pt)
-
-    async def _drive():
-        async for _ in _agen():
-            pass
-
-    asyncio.run(_drive())
-
-    pc = fake.metadata["pipeline_config"]
-    assert pc["profile"] == {"name": "oss", "weight": 100}   # NOT None despite ctxvar loss
-    assert len(pc["flags"]) == 5
-    assert set(pc["steps"]) == {"agent", "moderation"}
-    assert pc["steps"]["agent"]["model"] == "gemma"
-
-
-def test_contextvar_emit_would_be_empty_after_loss(monkeypatch):
-    """Proves the OLD (contextvar) emit path is exactly what broke: after the
-    boundary clears the contextvar, emit_to_trace() with NO explicit pt is a no-op
-    (nothing emitted) — i.e. the empty-object prod symptom."""
-    fake = _FakeClient()
-    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
     pt = trace.begin("oss")
-    trace.set_profile(pt, "oss", 100)
-    trace.clear()                      # boundary loses the contextvar
-    trace.emit_to_trace()              # no explicit pt -> reads empty contextvar
-    assert fake.metadata is None       # nothing emitted (the prod empty symptom)
+    trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT, Step.MODERATION))
+
+    m = trace.compact_metadata(pt)
+    assert m["pipeline_profile"] == "oss"
+    # all-on flags (test env) -> the 5 short names
+    assert set(m["pipeline_flags"].split(",")) == {
+        "llm_core", "profiles", "health_breaker", "health_poller", "concurrency_gauge",
+    }
+    assert m["pc_agent"] == "vllm:gemma@http://oss:8020/v1#oss(8000ms)"
+    assert m["pc_moderation"] == "vllm:gemma@http://oss:8020/v1#oss(8000ms)"
+    # every value is a short string, safely under the ~128-256 char OTEL cap.
+    assert all(isinstance(v, str) or v is None for v in m.values())
+    assert all(v is None or len(v) < 120 for v in m.values())
 
 
-def test_emit_flags_present_even_when_nothing_resolved(monkeypatch):
-    """A turn that resolves no step still emits a `pipeline_config` whose static
-    `flags` are populated from settings (never None/empty)."""
-    fake = _FakeClient()
-    monkeypatch.setattr(trace, "_get_langfuse_client", lambda: fake)
-    pt = trace.begin("legacy")
-    trace.emit_to_trace(pt)
-    pc = fake.metadata["pipeline_config"]
-    assert len(pc["flags"]) == 5
-    assert pc["steps"] == {}
-    assert pc["profile"] is None
+def test_add_compact_metadata_merges_into_request_metadata_dict(monkeypatch):
+    """The request path merges the compact keys into the SAME dict it already hands
+    to propagate_attributes / VoiceTrace.metadata — existing keys preserved."""
+    cfg = _cfg(100)
+    monkeypatch.setattr(resolver.runtime, "get_pipeline", lambda: cfg)
+    pt = trace.begin("oss")
+    trace.populate(pt, cfg, resolver.primary_tier, "oss", (Step.AGENT,))
+
+    langfuse_metadata = {"pipeline": "translation", "variant": "oss"}  # pre-existing keys
+    trace.add_compact_metadata(pt, langfuse_metadata)
+
+    assert langfuse_metadata["pipeline"] == "translation"   # existing key untouched
+    assert langfuse_metadata["variant"] == "oss"
+    assert langfuse_metadata["pipeline_profile"] == "oss"
+    assert langfuse_metadata["pc_agent"].startswith("vllm:gemma@")
+
+
+def test_compact_metadata_empty_pt_is_empty_dict():
+    """A None/empty pt yields an empty dict (never raises) — nothing to add."""
+    assert trace.compact_metadata(None) == {}
+    d = {"keep": 1}
+    trace.add_compact_metadata(None, d)
+    assert d == {"keep": 1}
+
+
+def test_no_update_current_trace_symbol_remains():
+    """Guard: the dead SDK-incompatible machinery is gone (no update_current_trace,
+    no emit_to_trace) — the module must not reference them again."""
+    assert not hasattr(trace, "emit_to_trace")
+    assert not hasattr(trace, "_get_langfuse_client")
+    src = __import__("inspect").getsource(trace)
+    assert "update_current_trace(" not in src   # no CALL to the missing SDK method
+    assert "import get_client" not in src
 
 
 # ── (e) no active context -> recorders are a cheap no-op ───────────────────────
@@ -324,7 +293,6 @@ def test_recorders_noop_without_context():
     trace.record_profile("oss", 100)
     trace.record_step_chain(Step.AGENT, [])
     trace.record_served(Step.AGENT, "managed", 1)
-    trace.emit_to_trace()
     # split resolving with no context is still a clean no-op for tracing.
     asyncio.run(split.resolve_chain("", Step.AGENT, _cfg(100)))
     assert trace.current() is None


### PR DESCRIPTION
## What

Tracing-only change (**zero pipeline behaviour change**): emit the **full resolved pipeline config + the turn's actual routing decisions** into the Langfuse trace metadata as one `pipeline_config` object, plus a complete config dump at boot. The existing `pipeline`/`variant`/`pipeline_variant` trace keys, tags and the `pipeline_variant` categorical score are **untouched** (dashboard continuity).
> **Metadata key = `pipeline_config`** (not `pipeline`). Chat already sets `metadata['pipeline']` to the pipeline NAME string (`"translation"`/`"default"`) via `propagate_attributes`; emitting the config under `pipeline` collided and the string shadowed the object. `pipeline_config` is a distinct namespace — the existing `pipeline`/`variant`/`pipeline_variant` keys and the categorical score are untouched.


The `pipeline_config` schema is **identical across chat & voice** (the `llm_core` cores are kept convergent — `app/llm_core/{trace,health,concurrency}.py` are byte-identical in both repos).

## How

A per-turn recorder in `app/llm_core/trace.py` (a `contextvars`-backed `PipelineTrace`) is opened at turn start and flushed to `update_current_trace(metadata={"pipeline": ...})` at turn end. Every `llm_core` seam calls cheap `record_*` hooks that **no-op when no turn context is active** (a bare `ContextVar.get()`), so nothing runs off the request path and nothing spams on the health poll loop:

- `split.resolve_chain` / `resolver.resolve_chain` → record the resolved **profile** (name + weight) and the materialized **step chain** (primary provider/model/endpoint/timeout + full ordered chain).
- `health.prune_unhealthy` → record pruned endpoints + breaker states; **adds a `health_prune:<step>` trace tag** when a tier is actually pruned.
- `concurrency.reprioritize_by_load` → record gauge/threshold/deprioritized; **adds a `concurrency_deprioritize:<step>` trace tag** when the vLLM tier is deprioritized.
- `fallback.execute_with_fallback` / `stream_with_fallback` → record the **served tier** (kind + 0-based chain index) on success, so a real fallback is visible as `tier_served.index = 1`.
- `runtime.configure()` → `trace.log_full_config()` dumps the **complete** loaded `PipelineConfig` (all profiles, all step tiers, all triggers) as one structured line: `grep llm_core.full_config`.

**Secrets:** endpoints (already in logs), providers, model names and timeouts are traced; a tier's api-key **env-var NAME** may appear in the boot dump, but the **key value is never read or stored**. Asserted by tests.

## `pipeline_config` metadata schema

```
pipeline_config:                     # trace metadata key (NOT `pipeline` — see note)
  profile:  { name, weight }        # the weighted profile this session resolved
  variant:  "oss" | "legacy"
  flags:    { llm_core_enabled, profiles_enabled, health_breaker_enabled,
              health_poller_enabled, concurrency_gauge_enabled }
  steps:    { <step>: {              # step ∈ pre_translation / moderation /
      provider, model, endpoint,     #   [voice: non_meaningful] / agent /
      timeout_ms,                    #   [chat: suggestions] / post_translation
      tier_served: { kind, index },  # which tier actually served (0 = primary)
      chain: [ { kind, provider, model, endpoint }, ... ],   # primary-first
      triggers: {
        health:      { pruned: [...endpoints...], breaker_states: { ep: state } },
        concurrency: { gauge, max_concurrency, deprioritized, metrics_url }
      }
  } }
```

## Example (agent step deprioritized off a saturated vLLM box, then served managed)

```json
{
  "profile": { "name": "oss", "weight": 100 },
  "variant": "oss",
  "flags": {
    "llm_core_enabled": true, "profiles_enabled": true,
    "health_breaker_enabled": true, "health_poller_enabled": true,
    "concurrency_gauge_enabled": true
  },
  "steps": {
    "agent": {
      "provider": "openai", "model": "gpt-4.1", "endpoint": "managed", "timeout_ms": 20000,
      "tier_served": { "kind": "managed", "index": 1 },
      "chain": [
        { "kind": "managed", "provider": "openai", "model": "gpt-4.1", "endpoint": "managed" },
        { "kind": "oss", "provider": "vllm", "model": "gemma-3-27b-it", "endpoint": "http://…:8020/v1" }
      ],
      "triggers": {
        "health": { "pruned": [], "breaker_states": { "http://…:8020/v1": "closed" } },
        "concurrency": { "gauge": 14, "max_concurrency": 10, "deprioritized": true,
                         "metrics_url": "http://…:8020/metrics" }
      }
    },
    "moderation": {
      "provider": "vllm", "model": "gemma-3-27b-it", "endpoint": "http://…:8020/v1", "timeout_ms": 8000,
      "tier_served": { "kind": "oss", "index": 0 },
      "chain": [ { "kind": "oss", … }, { "kind": "managed", … } ],
      "triggers": { "health": { "pruned": [], "breaker_states": { "http://…:8020/v1": "closed" } } }
    }
  }
}
```
(Note the agent `chain` reordered to `[managed, oss]` — the trace reflects the resolved order **after** the concurrency reorder, which is why the recorded primary is `managed`.)

## Tests

`tests/test_pipeline_trace.py` (new, convergent across both repos): asserts a stubbed turn populates `pipeline_config` with the resolved profile + per-step tier, flags present; the emit key is `pipeline_config` (**not** the colliding `pipeline`); the object is **populated across an `await` AND an `asyncio` child-task boundary** (empty-emit regression guard — the same `PipelineTrace` that `resolve_chain` mutates is the one `emit` serializes, because the recorders mutate a shared object and child tasks copy the context by reference); `flags` is never empty even when nothing resolves; the served-tier index is threaded through the fallback walker; health-prune and concurrency-deprioritize triggers are recorded; **secrets never appear**; recorders no-op with no active context. Network-free.

**Population correctness:** `begin()` is opened at the very top of the request path (before any `resolver`/`primary_handle`/`resolve_chain` call), so every step resolution this turn records into the one live context. `flags` is snapshotted from settings at `begin()` and is never `None`.

## Bar

- No routing/flag behaviour change — all recording is pure observation, gated behind the same flag checks; flags-off path byte-identical.
- Existing `llm_core` suites stay green (`split`/`health`/`concurrency`/`fallback`/`llm_core`).
