### PR TITLE
Deterministic session routing — refresh % on redeploy (no Redis pin)

### DIFF
--- a/app/llm_core/split.py
+++ b/app/llm_core/split.py
@@ -14,13 +14,12 @@ This is the generalization of two hardwired pieces:
   resolved profile's ``StepConfig.tiers`` materialized through the P0 factory
   (:func:`app.llm_core.factory.materialize`), preserving order (primary first).
 
-Stickiness mirrors voice ``pipeline_router`` **exactly**: deterministic hash
-bucket, Redis-sticky under a new key prefix (``voice_pipeline_profile:``) storing
-the profile NAME, shared across instances, fail-safe to the deterministic bucket
-on any Redis error. TTL comes from ``PipelineConfig.sticky_ttl_s`` (=
-``OSS_VARIANT_TTL`` via the shim). A config *weight* change never re-buckets an
-already-sticky session: the stored name is honored as long as that profile still
-exists.
+Stickiness is the deterministic hash bucket itself — no Redis state. Same
+``session_id`` + same weights -> same profile (stable within a config version);
+a weight change re-maps the bucket so continuing sessions FOLLOW the new % on a
+redeploy / config change rather than freezing on the old model. (voice
+``pipeline_router`` pinned the profile name in Redis, which froze sessions across
+weight changes — deliberately dropped: it defeats the refresh-on-change contract.)
 
 Gated by ``PROFILES_ENABLED`` at the call seam (the fallback walkers via
 ``fallback._resolve_chain``); nothing here reads that flag — it is inert until a
@@ -33,7 +32,6 @@ from __future__ import annotations
 import hashlib
 from typing import Optional
 
-from app.core.cache import cache
 from helpers.utils import get_logger
 from app.llm_core import runtime
 from app.llm_core.config_model import PipelineConfig, Step
@@ -42,10 +40,6 @@ from app.llm_core.resolver import STEP_CLIENT_KIND
 
 logger = get_logger(__name__)
 
-# New sticky namespace (distinct from voice pipeline_router's
-# ``voice_pipeline_variant:`` — mirror of the chat prefix with the voice ``voice_``
-# qualifier the voice pipeline_router uses).
-_PROFILE_KEY_PREFIX = "voice_pipeline_profile:"
 
 
 def profile_for_variant(variant: str) -> str:
@@ -85,43 +79,20 @@ def deterministic_profile(session_id: str, pipeline: PipelineConfig) -> str:
 async def resolve_profile(
     session_id: str, pipeline: Optional[PipelineConfig] = None
 ) -> str:
-    """Sticky weighted-profile assignment for a session (profile NAME).
+    """Deterministic weighted-profile assignment for a session (profile NAME).
 
-    Mirrors ``pipeline_router.resolve_pipeline_variant`` key-for-key:
+    The ``sha256(session_id)`` bucket IS the sticky key: same ``session_id`` +
+    same weights -> same profile, so a session stays on one model within a config
+    version (no mid-session flapping) with zero Redis state. A weight change
+    re-maps the bucket, so continuing sessions FOLLOW the new % on a redeploy /
+    config change instead of freezing on the old model -- e.g. flipping a model
+    0 -> 50% moves ~50% of in-flight sessions, not 0%.
 
-    * no session id      -> deterministic bucket (no Redis);
-    * Redis hit (valid)  -> the stored profile name (sticky; a later weight change
-                            does not move the session);
-    * Redis miss         -> deterministic bucket, persisted best-effort;
-    * any Redis error    -> deterministic bucket, never raised into the caller.
-
-    A stored name that is no longer a configured profile is ignored (re-bucketed),
-    guarding against a profile being renamed/removed out from under a sticky key.
+    Deliberately no Redis profile-name pin (``pipeline_router`` had one; it froze
+    sessions across weight changes, defeating the refresh-on-change contract).
+    Kept ``async`` so the call seams are unchanged.
     """
-    pipeline = pipeline or runtime.get_pipeline()
-
-    if not session_id:
-        return deterministic_profile(session_id, pipeline)
-
-    key = f"{_PROFILE_KEY_PREFIX}{session_id}"
-    valid = {p.name for p in pipeline.profiles}
-
-    try:
-        stored = await cache.get(key)
-        if stored in valid:
-            return stored
-    except Exception as e:  # Redis down / timeout -> deterministic fallback
-        logger.warning("llm_core.split: cache read failed for %s: %s", session_id, e)
-        return deterministic_profile(session_id, pipeline)
-
-    name = deterministic_profile(session_id, pipeline)
-
-    try:
-        await cache.set(key, name, ttl=pipeline.sticky_ttl_s)
-    except Exception as e:  # persistence is best-effort; assignment still stable
-        logger.warning("llm_core.split: cache write failed for %s: %s", session_id, e)
-
-    return name
+    return deterministic_profile(session_id, pipeline or runtime.get_pipeline())
 
 
 def _profile_for(pipeline: PipelineConfig, name: str):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -246,72 +246,40 @@ def _sid_with_bucket_between(lo, hi):
         i += 1
 
 
-def test_sticky_profile_persists_across_weight_change(monkeypatch):
+def test_resolve_profile_is_pure_deterministic():
+    """resolve_profile == deterministic bucket over the CURRENT weights; no Redis
+    state, so nothing pins a session across weight changes."""
     import asyncio
 
-    fake = _FakeCache()
-    monkeypatch.setattr(split, "cache", fake)
+    cfg = two_profile_config(70)
+    for sid in ("a", "b", "sess-xyz", ""):
+        assert asyncio.run(split.resolve_profile(sid, cfg)) == split.deterministic_profile(sid, cfg)
+
+
+def test_weight_change_rebuckets_continuing_session():
+    """The refresh-on-change contract: a session assigned to one model at a given
+    weight MOVES to the other model when the weight changes — it is not frozen."""
+    import asyncio
 
     sid, bucket = _sid_with_bucket_between(30, 60)
-    cfg_a = two_profile_config(bucket + 5)   # bucket < pct -> 'oss'
-    cfg_b = two_profile_config(bucket - 5)   # bucket >= pct -> deterministic 'managed'
-
-    first = asyncio.run(split.resolve_profile(sid, cfg_a))
-    assert first == "oss"
-    assert fake.store[f"voice_pipeline_profile:{sid}"] == "oss"   # stored under the voice P1 key
-
-    assert split.deterministic_profile(sid, cfg_b) == "managed"
-    assert asyncio.run(split.resolve_profile(sid, cfg_b)) == "oss"
+    cfg_hi = two_profile_config(bucket + 5)   # bucket < pct -> 'oss'
+    cfg_lo = two_profile_config(bucket - 5)   # bucket >= pct -> 'managed'
+    assert asyncio.run(split.resolve_profile(sid, cfg_hi)) == "oss"
+    # SAME session id, weight changed -> re-buckets to the new model (does NOT stick).
+    assert asyncio.run(split.resolve_profile(sid, cfg_lo)) == "managed"
 
 
-def test_sticky_hit_short_circuits_bucketing(monkeypatch):
+def test_zero_to_fifty_moves_about_half_of_continuing_sessions():
+    """0 -> 50% for the oss model moves ~half of continuing (same-id) sessions onto
+    it — exactly the redeploy scenario, not 0%."""
     import asyncio
 
-    fake = _FakeCache()
-    fake.store["voice_pipeline_profile:preset"] = "managed"
-    monkeypatch.setattr(split, "cache", fake)
-    cfg = two_profile_config(100)
-    assert asyncio.run(split.resolve_profile("preset", cfg)) == "managed"
-    assert fake.sets == []   # a hit must not re-write
-
-
-def test_sticky_ttl_comes_from_config(monkeypatch):
-    import asyncio
-
-    fake = _FakeCache()
-    monkeypatch.setattr(split, "cache", fake)
-    cfg = two_profile_config(50, ttl=12345)
-    asyncio.run(split.resolve_profile("ttl-sess", cfg))
-    assert fake.sets and fake.sets[0][2] == 12345
-
-
-def test_stale_stored_name_is_rebucketed(monkeypatch):
-    import asyncio
-
-    fake = _FakeCache()
-    fake.store["voice_pipeline_profile:x"] = "no-such-profile"
-    monkeypatch.setattr(split, "cache", fake)
-    cfg = two_profile_config(100)
-    assert asyncio.run(split.resolve_profile("x", cfg)) == "oss"
-
-
-def test_resolve_profile_fail_safe_on_cache_error(monkeypatch):
-    import asyncio
-
-    monkeypatch.setattr(split, "cache", _BrokenCache())
-    cfg = two_profile_config(70)
-    got = asyncio.run(split.resolve_profile("err-sess", cfg))
-    assert got == split.deterministic_profile("err-sess", cfg)
-
-
-def test_empty_session_id_skips_cache(monkeypatch):
-    import asyncio
-
-    fake = _FakeCache()
-    monkeypatch.setattr(split, "cache", fake)
-    cfg = two_profile_config(50)
-    asyncio.run(split.resolve_profile("", cfg))
-    assert fake.sets == [] and fake.store == {}   # no id -> no Redis touch
+    ids = [f"s{i}" for i in range(400)]
+    at_zero = [asyncio.run(split.resolve_profile(s, two_profile_config(0))) for s in ids]
+    at_fifty = [asyncio.run(split.resolve_profile(s, two_profile_config(50))) for s in ids]
+    assert all(p == "managed" for p in at_zero)          # 0% oss -> everyone on managed
+    moved = sum(1 for a, b in zip(at_zero, at_fifty) if a != b and b == "oss")
+    assert 150 <= moved <= 250                            # ~50% of continuing sessions moved
 
 
 # ── (B) voice router gates the variant resolver on PROFILES_ENABLED ───────────

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -9,12 +9,12 @@ The bar these pin:
   (b) ``resolve_chain`` returns a non-empty materialized chain matching the
       resolved profile's tiers (order + models + kind labels), incl. the voice
       RAW_OPENAI moderation step.
-  (c) a config (weight) change does not re-bucket an already-sticky session.
+  (c) a config (weight) change RE-BUCKETS a continuing session — the sha256
+      bucket over the CURRENT weights is the sticky key; no Redis pin freezes it.
   (d) the flags-OFF path is byte-untouched: PROFILES_ENABLED defaults off and the
       fallback chain acquisition degrades to the legacy ``attempt_chain``.
 
-Zero network: session_id="" avoids Redis entirely (deterministic path); the
-sticky/fail-safe tests inject an in-memory fake cache. Building a factory handle
+Zero network: routing is pure deterministic (no Redis). Building a factory handle
 is lazy (no model call is ever made). Dummy OPENAI/OSS keys set before import.
 
 NOTE (env): the bit-compatibility PROOF is recomputed independently (no import of
@@ -76,29 +76,6 @@ def two_profile_config(pct: int, ttl: int = 604800) -> PipelineConfig:
         ],
         sticky_ttl_s=ttl,
     )
-
-
-class _FakeCache:
-    """In-memory async cache mirroring the aiocache surface split uses."""
-
-    def __init__(self):
-        self.store = {}
-        self.sets = []
-
-    async def get(self, key):
-        return self.store.get(key)
-
-    async def set(self, key, value, ttl=None):
-        self.store[key] = value
-        self.sets.append((key, value, ttl))
-
-
-class _BrokenCache:
-    async def get(self, key):
-        raise RuntimeError("redis down")
-
-    async def set(self, key, value, ttl=None):
-        raise RuntimeError("redis down")
 
 
 def _ref_bucket(session_id: str) -> int:


### PR DESCRIPTION
## Deterministic session routing — refresh on weight change

Makes the session-level % split honor **refresh-on-redeploy**: continuing sessions re-bucket to the new % instead of freezing on the old model.

**Change:** `resolve_profile` drops the Redis profile-name pin — the `sha256(session_id)` bucket *is* the sticky key.
- Same `session_id` + same weights → same profile (stable within a config version, no mid-session flapping, **zero Redis state**).
- A weight change re-maps the bucket → a session assigned to model A at weight X moves to model B when the weight changes. Flipping a model **0→50% moves ~50%** of in-flight sessions, not 0%.

**Why:** the previous Redis name-pin (inherited from `pipeline_router`) kept a session on its assigned profile for 7 days across redeploys/weight changes — which defeated the refresh-on-change requirement. Removed.

**Unchanged:** fallbacks are orthogonal and request-level (health-prune / concurrency-reorder / failure-classify operate on the resolved chain per request, driven by live signals) — they don't depend on this. `resolve_chain(variant=...)` still threads the router-resolved variant so the fallback chain can't diverge from the primary path.

Tests: flipped the "persists across weight change" test to **re-buckets**; added the explicit 0→50% ~half-move scenario; removed the Redis-cache stubs (no cache in `resolve_profile` anymore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
