### PR TITLE
Post-translation → unified config chain + cross-provider overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ VOICE_PIPELINE_INTEGRATION=1 pytest tests/test_voice_regressions_apr11_12_integr
 
 For the real model-backed checks in that file, set the relevant endpoints/keys first:
 - `OPENAI_API_KEY`
-- `TRANSLATEGEMMA_27B_BASE_ENDPOINT` or `TRANSLATEGEMMA_27B_BASE_ENDPOINTS`
+- `TRANSLATEGEMMA_27B_BASE_ENDPOINT` — the SINGULAR nginx LB endpoint (it fans out to
+  replicas server-side). Post-translation flows through the unified llm_core config
+  chain (`Step.POST_TRANSLATION = [TranslateGemma(LB), managed-LLM overflow]`).
+  `TRANSLATEGEMMA_27B_BASE_ENDPOINTS` (plural client-side list) is DEPRECATED and no
+  longer read by code — any value is ignored.
 
 Live vLLM pretranslation glossary regressions across every active glossary row:
 ```bash

--- a/app/llm_core/factory.py
+++ b/app/llm_core/factory.py
@@ -308,7 +308,34 @@ def materialize(step_client_kind: StepClientKind, tiers: list[Tier]) -> list[Mat
     and an AsyncOpenAI client for the overflow tier from ONE call."""
     out: list[MaterializedTier] = []
     for tier in tiers:
-        handle = build_handle(tier, _tier_client_kind(step_client_kind, tier))
+        tier_kind = _tier_client_kind(step_client_kind, tier)
+        try:
+            handle = build_handle(tier, tier_kind)
+        except Exception as exc:
+            # POST_TRANSLATION overflow tiers are best-effort. The step kind is
+            # TRANSLATEGEMMA (unique to POST_TRANSLATION), so a tier here that is
+            # NOT the TranslateGemma primary is the cross-provider LLM overflow.
+            # Its build can legitimately fail in a healthy TG deployment — missing
+            # OPENAI_API_KEY, incomplete Azure env, unset INFERENCE_ENDPOINT_URL,
+            # or an anthropic/gemini LLM_PROVIDER. Dropping it (with a loud warning)
+            # keeps the byte-identical TranslateGemma primary independently
+            # runnable; failing the whole chain would REGRESS the old pure-TG path
+            # to English/trouble-message. ``out`` is non-empty here because the TG
+            # primary is first and only needs its endpoint, so we never drop to an
+            # empty chain. Any other step keeps its original fail-fast contract.
+            is_post_translation_overflow = (
+                step_client_kind is StepClientKind.TRANSLATEGEMMA
+                and tier.provider is not Provider.TRANSLATEGEMMA
+                and out
+            )
+            if is_post_translation_overflow:
+                logger.warning(
+                    "post-translation overflow tier %s/%s is unbuildable, dropping "
+                    "it and keeping the TranslateGemma primary: %s",
+                    tier.provider.value, tier.model, exc,
+                )
+                continue
+            raise
         # kind label: a vLLM (self-hosted) tier is "oss"; every other provider is
         # "managed". The fallback closures branch only on ``kind == "oss"`` and
         # moderation maps "oss" -> vLLM / else managed, so a config-driven

--- a/app/llm_core/factory.py
+++ b/app/llm_core/factory.py
@@ -308,34 +308,7 @@ def materialize(step_client_kind: StepClientKind, tiers: list[Tier]) -> list[Mat
     and an AsyncOpenAI client for the overflow tier from ONE call."""
     out: list[MaterializedTier] = []
     for tier in tiers:
-        tier_kind = _tier_client_kind(step_client_kind, tier)
-        try:
-            handle = build_handle(tier, tier_kind)
-        except Exception as exc:
-            # POST_TRANSLATION overflow tiers are best-effort. The step kind is
-            # TRANSLATEGEMMA (unique to POST_TRANSLATION), so a tier here that is
-            # NOT the TranslateGemma primary is the cross-provider LLM overflow.
-            # Its build can legitimately fail in a healthy TG deployment — missing
-            # OPENAI_API_KEY, incomplete Azure env, unset INFERENCE_ENDPOINT_URL,
-            # or an anthropic/gemini LLM_PROVIDER. Dropping it (with a loud warning)
-            # keeps the byte-identical TranslateGemma primary independently
-            # runnable; failing the whole chain would REGRESS the old pure-TG path
-            # to English/trouble-message. ``out`` is non-empty here because the TG
-            # primary is first and only needs its endpoint, so we never drop to an
-            # empty chain. Any other step keeps its original fail-fast contract.
-            is_post_translation_overflow = (
-                step_client_kind is StepClientKind.TRANSLATEGEMMA
-                and tier.provider is not Provider.TRANSLATEGEMMA
-                and out
-            )
-            if is_post_translation_overflow:
-                logger.warning(
-                    "post-translation overflow tier %s/%s is unbuildable, dropping "
-                    "it and keeping the TranslateGemma primary: %s",
-                    tier.provider.value, tier.model, exc,
-                )
-                continue
-            raise
+        handle = build_handle(tier, _tier_client_kind(step_client_kind, tier))
         # kind label: a vLLM (self-hosted) tier is "oss"; every other provider is
         # "managed". The fallback closures branch only on ``kind == "oss"`` and
         # moderation maps "oss" -> vLLM / else managed, so a config-driven

--- a/app/llm_core/factory.py
+++ b/app/llm_core/factory.py
@@ -285,12 +285,30 @@ class MaterializedTier:
         return self.handle
 
 
+def _tier_client_kind(step_client_kind: StepClientKind, tier: Tier) -> StepClientKind:
+    """Per-tier client kind for a step.
+
+    Every step uses its single fixed kind EXCEPT POST_TRANSLATION, whose chain is
+    mixed-provider: the TranslateGemma primary materializes as an aiohttp
+    text-completion :class:`TGDescriptor`, while a cross-provider LLM overflow tier
+    (openai/vllm/azure) materializes as a raw :class:`AsyncOpenAI` client. The step
+    client kind for POST_TRANSLATION is ``TRANSLATEGEMMA`` (the primary's kind), so
+    only a NON-TranslateGemma tier under that step is redirected to ``RAW_OPENAI``."""
+    if step_client_kind is StepClientKind.TRANSLATEGEMMA and tier.provider is not Provider.TRANSLATEGEMMA:
+        return StepClientKind.RAW_OPENAI
+    return step_client_kind
+
+
 def materialize(step_client_kind: StepClientKind, tiers: list[Tier]) -> list[MaterializedTier]:
     """Build a live handle per tier, preserving order (primary first). Never
-    empty when ``tiers`` is non-empty (StepConfig guarantees ``min_length=1``)."""
+    empty when ``tiers`` is non-empty (StepConfig guarantees ``min_length=1``).
+
+    The client kind is per-tier (see :func:`_tier_client_kind`) so POST_TRANSLATION's
+    ``[TranslateGemma, LLM-overflow]`` chain builds a TG descriptor for the primary
+    and an AsyncOpenAI client for the overflow tier from ONE call."""
     out: list[MaterializedTier] = []
     for tier in tiers:
-        handle = build_handle(tier, step_client_kind)
+        handle = build_handle(tier, _tier_client_kind(step_client_kind, tier))
         # kind label: a vLLM (self-hosted) tier is "oss"; every other provider is
         # "managed". The fallback closures branch only on ``kind == "oss"`` and
         # moderation maps "oss" -> vLLM / else managed, so a config-driven

--- a/app/llm_core/legacy_shim.py
+++ b/app/llm_core/legacy_shim.py
@@ -37,6 +37,7 @@ mismatch that breaks ``agents.models`` / ``app.services.translation``).
 
 from __future__ import annotations
 
+import logging
 import os
 
 from app.llm_core.config_model import (
@@ -50,6 +51,9 @@ from app.llm_core.config_model import (
     Tier,
     Triggers,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _env(name: str, default: str | None = None) -> str | None:
@@ -166,6 +170,17 @@ def _non_meaningful_tier() -> Tier:
 # en→target translation via chat.completions with the SAME glossary/rules prompt;
 # it serves only when TranslateGemma fails before the first streamed token.
 def _post_translation_tiers() -> list[Tier]:
+    # TranslateGemma is fronted by an nginx LB, so post-translation reads the
+    # SINGULAR endpoint. The old client-side plural list (+random.choice) is gone;
+    # warn loudly if a stale env still sets only the plural var, which would
+    # otherwise be silently ignored and drop TG to the localhost default.
+    if _env("TRANSLATEGEMMA_27B_BASE_ENDPOINTS") and not _env("TRANSLATEGEMMA_27B_BASE_ENDPOINT"):
+        logger.warning(
+            "TRANSLATEGEMMA_27B_BASE_ENDPOINTS (plural) is set but the singular "
+            "TRANSLATEGEMMA_27B_BASE_ENDPOINT is not — the plural var is DEPRECATED "
+            "and ignored; TranslateGemma will fall back to the localhost default. "
+            "Set TRANSLATEGEMMA_27B_BASE_ENDPOINT to the nginx LB URL."
+        )
     endpoint = _env("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1") or "http://localhost:18002/v1"
     model_id = _env("TRANSLATEGEMMA_27B_BASE_MODEL", "translategemma-27b-base") or "translategemma-27b-base"
     tg = Tier(

--- a/app/llm_core/legacy_shim.py
+++ b/app/llm_core/legacy_shim.py
@@ -158,19 +158,28 @@ def _non_meaningful_tier() -> Tier:
     return _oss_raw_tier(0, "non-meaningful")
 
 
-# ── post-translation (TranslateGemma) — profile-invariant → defaults ──────────
+# ── post-translation — profile-invariant → defaults ──────────────────────────
+# Chain: [TranslateGemma(LB), managed-LLM overflow]. TranslateGemma is deployed
+# BEHIND AN NGINX LB, so the SINGULAR ``TRANSLATEGEMMA_27B_BASE_ENDPOINT`` IS that
+# LB (it fans out to replicas server-side) — there is exactly one client-facing
+# endpoint, never a client-side list. The overflow tier is the managed LLM doing
+# en→target translation via chat.completions with the SAME glossary/rules prompt;
+# it serves only when TranslateGemma fails before the first streamed token.
 def _post_translation_tiers() -> list[Tier]:
-    raw = (_env("TRANSLATEGEMMA_27B_BASE_ENDPOINTS", "") or "").strip()
-    if raw:
-        endpoints = [e.strip() for e in raw.split(",") if e.strip()]
-    else:
-        endpoints = [_env("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1") or "http://localhost:18002/v1"]
+    endpoint = _env("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1") or "http://localhost:18002/v1"
     model_id = _env("TRANSLATEGEMMA_27B_BASE_MODEL", "translategemma-27b-base") or "translategemma-27b-base"
-    return [
-        Tier(provider=Provider.TRANSLATEGEMMA, model=model_id, endpoint=ep,
-             api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, label="translategemma-27b-base")
-        for ep in endpoints
-    ]
+    tg = Tier(
+        provider=Provider.TRANSLATEGEMMA, model=model_id, endpoint=endpoint,
+        api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, label="translategemma",
+    )
+    # Cross-provider overflow = the managed agent tier, but forced to CHAT api_style
+    # and given its own (shorter) first-token deadline. Reuses the managed builder so
+    # provider/model/key/endpoint track LLM_PROVIDER exactly.
+    llm_ms = _int_env("FALLBACK_POST_TRANSLATION_LLM_TIMEOUT_MS", 30000)
+    llm_fallback = _managed_agent_tier(llm_ms, "llm-fallback").model_copy(
+        update={"api_style": ApiStyle.CHAT}
+    )
+    return [tg, llm_fallback]
 
 
 def _oss_configured() -> bool:

--- a/app/llm_core/resolver.py
+++ b/app/llm_core/resolver.py
@@ -25,7 +25,11 @@ from app.llm_core import runtime
 from app.llm_core.config_model import Step, StepClientKind
 from app.llm_core.factory import MaterializedTier, materialize
 
-# Which client kind each step materializes to.
+# Which client kind each step materializes to. For every step but POST_TRANSLATION
+# this is a single fixed kind for the whole chain. POST_TRANSLATION's chain is
+# mixed-provider ([TranslateGemma, LLM-overflow]); the value here is the PRIMARY's
+# kind (TRANSLATEGEMMA), and ``factory._tier_client_kind`` redirects a non-TG
+# overflow tier under this step to RAW_OPENAI per tier at materialize time.
 STEP_CLIENT_KIND: dict[Step, StepClientKind] = {
     Step.AGENT: StepClientKind.AGENT,
     Step.MODERATION: StepClientKind.RAW_OPENAI,

--- a/app/llm_core/resolver.py
+++ b/app/llm_core/resolver.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.llm_core import runtime
-from app.llm_core.config_model import Step, StepClientKind
+from app.llm_core.config_model import Step, StepClientKind, Tier
 from app.llm_core.factory import MaterializedTier, materialize
 
 # Which client kind each step materializes to. For every step but POST_TRANSLATION
@@ -61,6 +61,30 @@ def resolve_chain(step: Step, variant: str = "legacy") -> list[MaterializedTier]
     _trace.record_profile(profile.name, profile.weight)
     _trace.record_step_chain(step, chain)
     return chain
+
+
+def post_translation_tiers(variant: str = "legacy") -> list[Tier]:
+    """The INERT POST_TRANSLATION tier chain — NOT materialized.
+
+    Post-translation is unique: TranslateGemma serves ~every turn, and its cheap
+    :class:`TGDescriptor` primary is provider-independent, whereas the managed-LLM
+    overflow tier is an ``AsyncOpenAI`` client that is both expensive to build and
+    can legitimately fail to construct in a healthy-TG deployment (no OPENAI key,
+    incomplete Azure env, unset INFERENCE_ENDPOINT_URL, anthropic/gemini provider).
+    Eagerly materializing the whole chain on EVERY translate call would waste that
+    construction and let a misconfigured overflow tier take a healthy primary down.
+    So the translation adapter takes the tiers INERT and builds each handle LAZILY
+    only as the fallback walker reaches it (see ``translation._PostTranslationTier``).
+    Records the resolved profile for tracing, exactly as ``resolve_chain`` does."""
+    pipeline = runtime.get_pipeline()
+    name = _profile_name_for_variant(variant)
+    profile = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
+    step_cfg = pipeline.step_config(profile, Step.POST_TRANSLATION)
+    if step_cfg is None:
+        raise ValueError("no config for step=post_translation")
+    from app.llm_core import trace as _trace
+    _trace.record_profile(profile.name, profile.weight)
+    return list(step_cfg.tiers)
 
 
 def chain_for(step: Step, variant: str = "legacy") -> list[MaterializedTier]:

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -28,8 +28,14 @@ from app.config import settings
 # is preserved, only the tier walk + cross-provider overflow are new.
 from app.llm_core import resolver as _llm_resolver
 from app.llm_core import health as _llm_health
-from app.llm_core.config_model import Step as _Step
-from app.llm_core.factory import TGDescriptor as _TGDescriptor
+from app.llm_core import trace as _llm_trace
+from app.llm_core.config_model import (
+    Step as _Step,
+    Tier as _Tier,
+    Provider as _Provider,
+    StepClientKind as _StepClientKind,
+)
+from app.llm_core.factory import TGDescriptor as _TGDescriptor, build_handle as _build_handle
 from app.services.fallback import (
     FALLBACKABLE as _FALLBACKABLE,
     FallbackEvent as _FallbackEvent,
@@ -499,11 +505,58 @@ def _prepare_translation_inputs(text, source_lang, target_lang):
 
 
 def _is_translategemma_tier(tier) -> bool:
-    """A tier whose handle speaks TranslateGemma ``/completions`` over aiohttp."""
-    return (
-        getattr(tier, "provider", "") == "translategemma"
-        or isinstance(getattr(tier, "handle", None), _TGDescriptor)
-    )
+    """A tier whose handle speaks TranslateGemma ``/completions`` over aiohttp.
+    Decided from the provider label alone so it never forces a lazy handle build."""
+    return getattr(tier, "provider", "") == "translategemma"
+
+
+class _PostTranslationTier:
+    """One entry in the post-translation fallback chain. Carries the telemetry
+    metadata the walkers read (``kind``/``provider``/``model_name``/``endpoint``/
+    ``timeout``) but builds its client handle LAZILY, memoized, on first access.
+
+    TranslateGemma serves ~every turn and its ``TGDescriptor`` primary is a cheap,
+    provider-independent URL holder; the managed-LLM overflow is an ``AsyncOpenAI``
+    client that is expensive to construct and can legitimately fail to build in a
+    healthy-TG env. Building lazily means the overflow client is constructed ONLY
+    when a request actually falls through to it — never eagerly per call, and a
+    misconfigured overflow tier can never take a healthy primary down (its build
+    error, if reached, is just this tier's failure and hits the caller degrade net,
+    exactly like the old pure-TG path)."""
+
+    __slots__ = ("_tier", "kind", "model_name", "endpoint", "timeout", "_memo")
+
+    def __init__(self, tier: _Tier):
+        self._tier = tier
+        self.kind = "oss" if tier.provider is _Provider.VLLM else "managed"
+        self.model_name = tier.model
+        self.endpoint = tier.endpoint or "managed"
+        self.timeout = (tier.timeout_ms / 1000.0) if tier.timeout_ms is not None else None
+        self._memo: list = []
+
+    @property
+    def provider(self) -> str:
+        return self._tier.provider.value
+
+    @property
+    def handle(self):
+        if not self._memo:
+            kind = (
+                _StepClientKind.TRANSLATEGEMMA
+                if self._tier.provider is _Provider.TRANSLATEGEMMA
+                else _StepClientKind.RAW_OPENAI
+            )
+            self._memo.append(_build_handle(self._tier, kind))
+        return self._memo[0]
+
+
+def _post_translation_chain():
+    """Resolve the INERT POST_TRANSLATION tiers and wrap them as lazy-handle chain
+    entries + record the trace chain. Post-translation is profile-invariant
+    (llm_core ``defaults``), so we resolve with ``"legacy"``."""
+    chain = [_PostTranslationTier(t) for t in _llm_resolver.post_translation_tiers("legacy")]
+    _llm_trace.record_step_chain(_Step.POST_TRANSLATION, chain)
+    return chain
 
 
 async def _translategemma_stream(descriptor, prompt, source_lang, target_lang, text, temperature, max_tokens):
@@ -923,7 +976,7 @@ async def translate_text(
     instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
     logger.info(f"Translating {source_lang} -> {target_lang} via post-translation chain")
 
-    chain = _llm_resolver.resolve_chain(_Step.POST_TRANSLATION, "legacy")
+    chain = _post_translation_chain()
 
     async def _run(tier):
         if _is_translategemma_tier(tier):
@@ -1420,7 +1473,7 @@ async def translate_text_stream_fast(
     instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
     logger.info(f"Fast streaming translation {source_lang} -> {target_lang} via post-translation chain")
 
-    chain = _llm_resolver.resolve_chain(_Step.POST_TRANSLATION, "legacy")
+    chain = _post_translation_chain()
 
     def _make_stream(tier):
         if _is_translategemma_tier(tier):

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -8,9 +8,10 @@ TranslateGemma 27B base model deployed on vLLM.
 import os
 import json
 import re
-import random
+import time
 import aiohttp
 import asyncio
+import anyio
 from pathlib import Path
 from typing import Literal, Optional
 from openai import AsyncOpenAI
@@ -18,6 +19,24 @@ from helpers.utils import get_logger, normalize_voice_output
 from dotenv import load_dotenv
 from agents.tools.terms import get_mini_glossary_for_text, get_ambiguity_hints_for_query, TERM_PAIRS
 from app.config import settings
+
+# Post-translation now flows through the unified llm_core config chain
+# (Step.POST_TRANSLATION = [TranslateGemma(LB), managed-LLM overflow]). These are
+# the seams the adapter walks; the disconnect-safe first-token primitive
+# (with_first_token_deadline) and the failure classifier are reused verbatim — the
+# translation logic (incl. voice's per-chunk normalize_voice_output + rstrip decode)
+# is preserved, only the tier walk + cross-provider overflow are new.
+from app.llm_core import resolver as _llm_resolver
+from app.llm_core import health as _llm_health
+from app.llm_core.config_model import Step as _Step
+from app.llm_core.factory import TGDescriptor as _TGDescriptor
+from app.services.fallback import (
+    FALLBACKABLE as _FALLBACKABLE,
+    FallbackEvent as _FallbackEvent,
+    classify as _classify,
+    emit as _emit,
+    with_first_token_deadline as _with_first_token_deadline,
+)
 
 try:
     from langfuse import get_client as get_langfuse_client
@@ -314,23 +333,15 @@ def _post_normalize_gu_translation(
     return out.strip() if strip_outer else out
 
 
-# Only the 27b-base TranslateGemma is deployed — the 4b/12b/27b maps were dead
-# (every translation resolves to 27b-base via _resolve_model). Removed at P4.
-TRANSLATION_ENDPOINTS = {
-    "27b-base": os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1"),
-}
-
-# Multi-endpoint support: comma-separated list for load-balanced 27b-base
-_27b_base_ep_raw = os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINTS", "").strip()
-TRANSLATION_ENDPOINTS_27B_BASE: list[str] = (
-    [e.strip() for e in _27b_base_ep_raw.split(",") if e.strip()]
-    if _27b_base_ep_raw
-    else [TRANSLATION_ENDPOINTS["27b-base"]]
-)
-
-TRANSLATION_MODEL_IDS = {
-    "27b-base": os.getenv("TRANSLATEGEMMA_27B_BASE_MODEL", "translategemma-27b-base"),
-}
+# Only the 27b-base TranslateGemma is deployed, BEHIND AN NGINX LB — the SINGULAR
+# TRANSLATEGEMMA_27B_BASE_ENDPOINT IS that LB (it fans out to replicas server-side),
+# so there is exactly one client-facing endpoint (no client-side endpoint list /
+# random.choice anymore). Post-translation model+endpoint selection now flows
+# through the llm_core config chain (Step.POST_TRANSLATION); these singular
+# constants also back the voice pretranslation structured fallback, which still
+# speaks TranslateGemma ``/completions`` directly.
+TRANSLATEGEMMA_27B_BASE_ENDPOINT = os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1")
+TRANSLATEGEMMA_27B_BASE_MODEL = os.getenv("TRANSLATEGEMMA_27B_BASE_MODEL", "translategemma-27b-base")
 
 LANG_NAMES = {
     "marathi": "Marathi", "english": "English", "hindi": "Hindi",
@@ -361,15 +372,19 @@ INDIAN_LANGUAGES = [
 ]
 
 
-def _format_translation_prompt(
+def _build_translation_instruction(
     text: str,
     source_lang: str,
     target_lang: str,
     mini_glossary: Optional[str] = None,
 ) -> str:
-    """Format the translation prompt using TranslateGemma's official chat template.
-    When target is Gujarati and mini_glossary is provided, injects a dynamic term list
-    so the model uses consistent domain terminology."""
+    """Build the translation INSTRUCTION text (voice spoken-language preamble +
+    glossary Rules + voice GU style rules) — the same wording used for BOTH tiers:
+    TranslateGemma consumes it wrapped in the Gemma chat template
+    (:func:`_wrap_translategemma_prompt`), while the cross-provider LLM overflow tier
+    consumes it verbatim as the chat.completions user message. Kept byte-identical to
+    the prior inline instruction (voice's spoken-language preamble, no length rule) so
+    the two paths are indistinguishable in prompt."""
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
     target_name = LANG_NAMES.get(target_lang.lower(), target_lang.capitalize())
     source_code = LANG_CODES.get(source_lang.lower(), source_lang.lower())
@@ -398,24 +413,32 @@ def _format_translation_prompt(
             + "\n"
         )
     instruction += f"\n\nPlease translate the following {source_name} text into {target_name}:\n\n\n{text.strip()}"
+    return instruction
 
-    prompt = (
+
+def _wrap_translategemma_prompt(instruction: str) -> str:
+    """Wrap an instruction in TranslateGemma's official chat template."""
+    return (
         f"<bos><start_of_turn>user\n"
         f"{instruction}<end_of_turn>\n"
         f"<start_of_turn>model\n"
     )
-    return prompt
 
 
-def _resolve_model(model_size: Optional[str], target_lang: str) -> tuple[str, Optional[str], Optional[str]]:
-    """
-    Resolve to 27b-base model/endpoint for all translations.
-    Returns (model_size, endpoint, model_id).
-    """
-    model_size = "27b-base"
-    endpoint = random.choice(TRANSLATION_ENDPOINTS_27B_BASE)
-    model_id = TRANSLATION_MODEL_IDS.get(model_size)
-    return model_size, endpoint, model_id
+def _format_translation_prompt(
+    text: str,
+    source_lang: str,
+    target_lang: str,
+    mini_glossary: Optional[str] = None,
+) -> str:
+    """Format the TranslateGemma text-completion prompt (instruction + chat template).
+    When target is Gujarati and mini_glossary is provided, injects a dynamic term list
+    so the model uses consistent domain terminology."""
+    return _wrap_translategemma_prompt(
+        _build_translation_instruction(
+            text, source_lang, target_lang, mini_glossary=mini_glossary,
+        )
+    )
 
 
 def _get_langfuse():
@@ -427,6 +450,441 @@ def _get_langfuse():
         return None
 
 
+# ── post-translation tier-chain adapter ───────────────────────────────────────
+# translate_text / translate_text_stream_fast route through the llm_core
+# POST_TRANSLATION chain: [TranslateGemma(LB), managed-LLM overflow]. Per tier the
+# handle is a TGDescriptor (aiohttp text-completion) or an AsyncOpenAI client
+# (chat.completions). The SAME instruction (voice spoken-language preamble + glossary
+# Rules + voice GU style rules, no length rule) and the SAME per-chunk transform
+# pipeline (``_fix_dandas -> _post_normalize_gu_translation(strip_outer=False) ->
+# normalize_voice_output(streaming=True)`` for streams;
+# ``_fix_dandas -> _post_normalize_gu_translation -> normalize_voice_output`` for the
+# unary path) apply to BOTH tiers. First-token-commit + classify-based overflow mirror
+# ``stream_with_fallback``; the disconnect-safe TTFT primitive
+# (``with_first_token_deadline``) is reused verbatim. Post-translation is
+# profile-invariant (llm_core ``defaults``), so the chain is variant-independent — we
+# resolve with "legacy". A dedicated walker (not ``stream_with_fallback`` /
+# ``execute_with_fallback``) is used because those resolve their chain internally from
+# a pipeline-string + session_id + weighted split, which post-translation has none of.
+_POST_TRANSLATION_PIPELINE = "posttranslation"
+
+
+def _prepare_translation_inputs(text, source_lang, target_lang):
+    """Mini-glossary fetch + build the translation instruction ONCE (shared by both
+    tiers) + the Gemma-wrapped TranslateGemma prompt. Verbatim to the prior inline
+    logic (mini glossary for gu at threshold 0.90 / max 40). Voice has no
+    max_output_chars length rule."""
+    mini_glossary = ""
+    if target_lang.lower() in ("gujarati", "gu"):
+        mini_glossary = get_mini_glossary_for_text(text, threshold=0.90, max_terms=40)
+        if mini_glossary:
+            logger.info(f"Translation prompt: injected mini glossary ({len(mini_glossary.splitlines())} terms)")
+    instruction = _build_translation_instruction(
+        text, source_lang, target_lang, mini_glossary=mini_glossary,
+    )
+    tg_prompt = _wrap_translategemma_prompt(instruction)
+    return instruction, tg_prompt
+
+
+def _is_translategemma_tier(tier) -> bool:
+    """A tier whose handle speaks TranslateGemma ``/completions`` over aiohttp."""
+    return (
+        getattr(tier, "provider", "") == "translategemma"
+        or isinstance(getattr(tier, "handle", None), _TGDescriptor)
+    )
+
+
+async def _translategemma_stream(descriptor, prompt, source_lang, target_lang, text, temperature, max_tokens):
+    """VERBATIM TranslateGemma streaming SSE decode (aiohttp), incl. the
+    ``stream_translation`` Langfuse observation and its ``if not langfuse:`` branch.
+    Voice per-chunk pipeline: ``_fix_dandas -> _post_normalize_gu_translation ->
+    normalize_voice_output(streaming=True)``; line decode via ``.rstrip('\\r')``."""
+    translated_parts: list[str] = []
+    langfuse = _get_langfuse()
+
+    if not langfuse:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                descriptor.completions_url,
+                json={
+                    "model": descriptor.model_id,
+                    "prompt": prompt,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                    "stream": True,
+                },
+                timeout=aiohttp.ClientTimeout(total=60),
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Translation API error {response.status}: {error_text}")
+                    raise Exception(f"Translation failed with status {response.status}")
+
+                buffer = b''
+                async for chunk in response.content.iter_chunked(64):
+                    buffer += chunk
+                    while b'\n' in buffer:
+                        line, buffer = buffer.split(b'\n', 1)
+                        line = line.decode('utf-8').rstrip('\r')
+                        if line.startswith('data: '):
+                            data = line[6:]
+                            if data == '[DONE]':
+                                break
+                            try:
+                                chunk_data = json.loads(data)
+                                content = chunk_data['choices'][0].get('text', '')
+                                if content:
+                                    content = _fix_dandas(content)
+                                    content = _post_normalize_gu_translation(
+                                        content, target_lang, strip_outer=False,
+                                    )
+                                    content = normalize_voice_output(
+                                        content, target_lang, streaming=True,
+                                    )
+                                    translated_parts.append(content)
+                                    yield content
+                            except json.JSONDecodeError:
+                                continue
+        return
+
+    with langfuse.start_as_current_observation(
+        name="stream_translation",
+        as_type="generation",
+        input={
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "text": text,
+        },
+        model=descriptor.model_id,
+        metadata={
+            "translation_provider": "translategemma",
+            "model_size": "27b-base",
+            "stream": "true",
+            "pipeline_stage": "stream_translation",
+        },
+    ) as observation:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                descriptor.completions_url,
+                json={
+                    "model": descriptor.model_id,
+                    "prompt": prompt,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                    "stream": True,
+                },
+                timeout=aiohttp.ClientTimeout(total=60),
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Translation API error {response.status}: {error_text}")
+                    raise Exception(f"Translation failed with status {response.status}")
+
+                buffer = b''
+                async for chunk in response.content.iter_chunked(64):
+                    buffer += chunk
+                    while b'\n' in buffer:
+                        line, buffer = buffer.split(b'\n', 1)
+                        line = line.decode('utf-8').rstrip('\r')
+                        if line.startswith('data: '):
+                            data = line[6:]
+                            if data == '[DONE]':
+                                break
+                            try:
+                                chunk_data = json.loads(data)
+                                content = chunk_data['choices'][0].get('text', '')
+                                if content:
+                                    content = _fix_dandas(content)
+                                    content = _post_normalize_gu_translation(
+                                        content, target_lang, strip_outer=False,
+                                    )
+                                    content = normalize_voice_output(
+                                        content, target_lang, streaming=True,
+                                    )
+                                    translated_parts.append(content)
+                                    yield content
+                            except json.JSONDecodeError:
+                                continue
+        observation.update(output="".join(translated_parts))
+
+
+async def _llm_translation_stream(client, model_name, instruction, source_lang, target_lang, text, temperature, max_tokens):
+    """Cross-provider overflow: a managed chat LLM does en->target translation with
+    the SAME instruction (glossary + rules), piping each ``delta.content`` through the
+    SAME voice per-chunk pipeline (``_fix_dandas -> _post_normalize_gu_translation ->
+    normalize_voice_output(streaming=True)``). Mirrors the TG observation for parity."""
+    langfuse = _get_langfuse()
+
+    if not langfuse:
+        stream = await client.chat.completions.create(
+            model=model_name,
+            messages=[{"role": "user", "content": instruction}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        async for chunk in stream:
+            if not getattr(chunk, "choices", None):
+                continue
+            content = getattr(chunk.choices[0].delta, "content", None) or ""
+            if content:
+                content = _fix_dandas(content)
+                content = _post_normalize_gu_translation(content, target_lang, strip_outer=False)
+                content = normalize_voice_output(content, target_lang, streaming=True)
+                yield content
+        return
+
+    translated_parts: list[str] = []
+    with langfuse.start_as_current_observation(
+        name="stream_translation",
+        as_type="generation",
+        input={
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "text": text,
+        },
+        model=model_name,
+        metadata={
+            "translation_provider": "llm-fallback",
+            "stream": "true",
+            "pipeline_stage": "stream_translation",
+        },
+    ) as observation:
+        stream = await client.chat.completions.create(
+            model=model_name,
+            messages=[{"role": "user", "content": instruction}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        async for chunk in stream:
+            if not getattr(chunk, "choices", None):
+                continue
+            content = getattr(chunk.choices[0].delta, "content", None) or ""
+            if content:
+                content = _fix_dandas(content)
+                content = _post_normalize_gu_translation(content, target_lang, strip_outer=False)
+                content = normalize_voice_output(content, target_lang, streaming=True)
+                translated_parts.append(content)
+                yield content
+        observation.update(output="".join(translated_parts))
+
+
+async def _translategemma_unary(descriptor, prompt, source_lang, target_lang, text, temperature, max_tokens):
+    """VERBATIM non-stream TranslateGemma call (reads full body ``choices[0].text``)
+    incl. the ``text_translation`` Langfuse observation and its ``if not langfuse:``
+    branch. Voice per-response transforms: ``_fix_dandas ->
+    _post_normalize_gu_translation -> normalize_voice_output`` (unconditional)."""
+    langfuse = _get_langfuse()
+
+    if not langfuse:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                descriptor.completions_url,
+                json={
+                    "model": descriptor.model_id,
+                    "prompt": prompt,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+                timeout=aiohttp.ClientTimeout(total=60),
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Translation API error {response.status}: {error_text}")
+                    raise Exception(f"Translation failed with status {response.status}")
+
+                result = await response.json()
+                translated_text = result["choices"][0]["text"].strip()
+                translated_text = _fix_dandas(translated_text)
+                translated_text = _post_normalize_gu_translation(translated_text, target_lang)
+                translated_text = normalize_voice_output(translated_text, target_lang)
+                logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
+                return translated_text
+
+    with langfuse.start_as_current_observation(
+        name="text_translation",
+        as_type="generation",
+        input={
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "text": text,
+        },
+        model=descriptor.model_id,
+        metadata={
+            "translation_provider": "translategemma",
+            "model_size": "27b-base",
+            "pipeline_stage": "text_translation",
+        },
+    ) as observation:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                descriptor.completions_url,
+                json={
+                    "model": descriptor.model_id,
+                    "prompt": prompt,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+                timeout=aiohttp.ClientTimeout(total=60),
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Translation API error {response.status}: {error_text}")
+                    raise Exception(f"Translation failed with status {response.status}")
+
+                result = await response.json()
+                translated_text = result["choices"][0]["text"].strip()
+                translated_text = _fix_dandas(translated_text)
+                translated_text = _post_normalize_gu_translation(translated_text, target_lang)
+                translated_text = normalize_voice_output(translated_text, target_lang)
+                observation.update(output=translated_text)
+                logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
+                return translated_text
+
+
+async def _llm_translation_unary(client, model_name, instruction, source_lang, target_lang, text, temperature, max_tokens):
+    """Cross-provider overflow (non-stream): chat.completions with the SAME
+    instruction, reading ``choices[0].message.content`` and applying the SAME voice
+    transforms (``_fix_dandas -> _post_normalize_gu_translation ->
+    normalize_voice_output`` unconditional)."""
+    langfuse = _get_langfuse()
+
+    if not langfuse:
+        response = await client.chat.completions.create(
+            model=model_name,
+            messages=[{"role": "user", "content": instruction}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        translated_text = (response.choices[0].message.content or "").strip()
+        translated_text = _fix_dandas(translated_text)
+        translated_text = _post_normalize_gu_translation(translated_text, target_lang)
+        translated_text = normalize_voice_output(translated_text, target_lang)
+        logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
+        return translated_text
+
+    with langfuse.start_as_current_observation(
+        name="text_translation",
+        as_type="generation",
+        input={
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "text": text,
+        },
+        model=model_name,
+        metadata={
+            "translation_provider": "llm-fallback",
+            "pipeline_stage": "text_translation",
+        },
+    ) as observation:
+        response = await client.chat.completions.create(
+            model=model_name,
+            messages=[{"role": "user", "content": instruction}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        translated_text = (response.choices[0].message.content or "").strip()
+        translated_text = _fix_dandas(translated_text)
+        translated_text = _post_normalize_gu_translation(translated_text, target_lang)
+        translated_text = normalize_voice_output(translated_text, target_lang)
+        observation.update(output=translated_text)
+        logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
+        return translated_text
+
+
+async def _stream_post_translation_chain(chain, make_stream, *, source_lang, target_lang):
+    """First-token-commit walker over the POST_TRANSLATION chain — mirrors
+    ``fallback.stream_with_fallback`` (commit on first chunk; pre-commit fallbackable
+    failure swaps to the next tier; post-commit failure propagates) but drives a
+    PRE-RESOLVED chain and calls ``with_first_token_deadline`` for the disconnect-safe
+    TTFT bound. Cross-provider overflow (translategemma -> managed LLM) is just the
+    next tier."""
+    last_exc: Optional[BaseException] = None
+    for i, tier in enumerate(chain):
+        t0 = time.monotonic()
+        committed = False
+        try:
+            async for chunk in _with_first_token_deadline(tier, make_stream(tier)):
+                committed = True
+                yield chunk
+            _llm_health.record_success(tier.endpoint)
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            reason = _classify(exc)
+            is_last = i == len(chain) - 1
+            if committed:
+                _emit(_FallbackEvent(
+                    pipeline=_POST_TRANSLATION_PIPELINE, session_id="-",
+                    from_variant=tier.kind, to_variant=None, reason=reason,
+                    error_class=type(exc).__name__, error_detail=str(exc)[:500],
+                    oss_endpoint=tier.endpoint, oss_model=tier.model_name,
+                    latency_ms=int((time.monotonic() - t0) * 1000),
+                    fell_back=False, committed=True,
+                ))
+                raise
+            will_fall_back = reason in _FALLBACKABLE and not is_last
+            if reason in _FALLBACKABLE:
+                _llm_health.record_failure(tier.endpoint)
+            _emit(_FallbackEvent(
+                pipeline=_POST_TRANSLATION_PIPELINE, session_id="-",
+                from_variant=tier.kind,
+                to_variant=chain[i + 1].kind if will_fall_back else None,
+                reason=reason, error_class=type(exc).__name__, error_detail=str(exc)[:500],
+                oss_endpoint=tier.endpoint, oss_model=tier.model_name,
+                latency_ms=int((time.monotonic() - t0) * 1000),
+                fell_back=will_fall_back, committed=False,
+            ))
+            last_exc = exc
+            if will_fall_back:
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+
+
+async def _run_post_translation_chain(chain, run):
+    """Unary walker over the POST_TRANSLATION chain — mirrors
+    ``fallback.execute_with_fallback`` (per-tier timeout via ``anyio.fail_after``;
+    fall back on a classified infrastructure failure) over a PRE-RESOLVED chain."""
+    last_exc: Optional[BaseException] = None
+    for i, tier in enumerate(chain):
+        t0 = time.monotonic()
+        try:
+            if tier.timeout is None:
+                result = await run(tier)
+            else:
+                with anyio.fail_after(tier.timeout):
+                    result = await run(tier)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            reason = _classify(exc)
+            is_last = i == len(chain) - 1
+            will_fall_back = reason in _FALLBACKABLE and not is_last
+            if reason in _FALLBACKABLE:
+                _llm_health.record_failure(tier.endpoint)
+            _emit(_FallbackEvent(
+                pipeline=_POST_TRANSLATION_PIPELINE, session_id="-",
+                from_variant=tier.kind,
+                to_variant=chain[i + 1].kind if will_fall_back else None,
+                reason=reason, error_class=type(exc).__name__, error_detail=str(exc)[:500],
+                oss_endpoint=tier.endpoint, oss_model=tier.model_name,
+                latency_ms=int((time.monotonic() - t0) * 1000),
+                fell_back=will_fall_back, committed=False,
+            ))
+            last_exc = exc
+            if not will_fall_back:
+                raise
+        else:
+            _llm_health.record_success(tier.endpoint)
+            return result
+    if last_exc is not None:
+        raise last_exc
+
+
 async def translate_text(
     text: str,
     source_lang: str,
@@ -435,7 +893,14 @@ async def translate_text(
     temperature: float = 0.0,
     max_tokens: int = 2048
 ) -> str:
-    """Translate text using TranslateGemma."""
+    """Translate text via the post-translation tier chain.
+
+    Chain = [TranslateGemma(LB), managed-LLM overflow]. Guards / prompt / per-response
+    transforms are byte-identical to the prior TranslateGemma-only path (incl. the
+    unconditional ``normalize_voice_output`` after post-normalize); the only additions
+    are the cross-provider overflow (chat.completions with the SAME instruction) when
+    TranslateGemma fails, and config-driven endpoint/model selection (no more
+    client-side ``random.choice``)."""
     if not text or not text.strip():
         return text
 
@@ -443,95 +908,21 @@ async def translate_text(
         logger.info("Source and target languages are the same, skipping translation")
         return text
 
-    model_size, endpoint, model_id = _resolve_model(model_size, target_lang)
-    if not endpoint or not model_id:
-        raise ValueError(f"Invalid translation model size: {model_size}")
+    instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
+    logger.info(f"Translating {source_lang} -> {target_lang} via post-translation chain")
 
-    mini_glossary = ""
-    if target_lang.lower() in ("gujarati", "gu"):
-        mini_glossary = get_mini_glossary_for_text(text, threshold=0.90, max_terms=40)
-        if mini_glossary:
-            logger.info(f"Translation prompt: injected mini glossary ({len(mini_glossary.splitlines())} terms)")
-    prompt = _format_translation_prompt(text, source_lang, target_lang, mini_glossary=mini_glossary)
-    logger.info(f"Translating {source_lang} -> {target_lang} using {model_size} model")
+    chain = _llm_resolver.resolve_chain(_Step.POST_TRANSLATION, "legacy")
 
-    langfuse = _get_langfuse()
+    async def _run(tier):
+        if _is_translategemma_tier(tier):
+            return await _translategemma_unary(
+                tier.handle, tg_prompt, source_lang, target_lang, text, temperature, max_tokens
+            )
+        return await _llm_translation_unary(
+            tier.handle, tier.model_name, instruction, source_lang, target_lang, text, temperature, max_tokens
+        )
 
-    try:
-        if not langfuse:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{endpoint}/completions",
-                    json={
-                        "model": model_id,
-                        "prompt": prompt,
-                        "temperature": temperature,
-                        "max_tokens": max_tokens,
-                    },
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(f"Translation API error {response.status}: {error_text}")
-                        raise Exception(f"Translation failed with status {response.status}")
-
-                    result = await response.json()
-                    translated_text = result["choices"][0]["text"].strip()
-                    translated_text = _fix_dandas(translated_text)
-                    translated_text = _post_normalize_gu_translation(
-                        translated_text,
-                        target_lang,
-                    )
-                    translated_text = normalize_voice_output(translated_text, target_lang)
-                    logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
-                    return translated_text
-
-        with langfuse.start_as_current_observation(
-            name="text_translation",
-            as_type="generation",
-            input={
-                "source_lang": source_lang,
-                "target_lang": target_lang,
-                "text": text,
-            },
-            model=model_id,
-            metadata={
-                "translation_provider": "translategemma",
-                "model_size": model_size,
-                "pipeline_stage": "text_translation",
-            },
-        ) as observation:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{endpoint}/completions",
-                    json={
-                        "model": model_id,
-                        "prompt": prompt,
-                        "temperature": temperature,
-                        "max_tokens": max_tokens,
-                    },
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(f"Translation API error {response.status}: {error_text}")
-                        raise Exception(f"Translation failed with status {response.status}")
-
-                    result = await response.json()
-                    translated_text = result["choices"][0]["text"].strip()
-                    translated_text = _fix_dandas(translated_text)
-                    translated_text = _post_normalize_gu_translation(
-                        translated_text,
-                        target_lang,
-                    )
-                    translated_text = normalize_voice_output(translated_text, target_lang)
-                    observation.update(output=translated_text)
-                    logger.info(f"Translation successful ({len(text)} -> {len(translated_text)} chars)")
-                    return translated_text
-
-    except aiohttp.ClientError as e:
-        logger.error(f"Translation API connection error: {str(e)}")
-        raise Exception(f"Failed to connect to translation service: {str(e)}")
+    return await _run_post_translation_chain(chain, _run)
 
 
 def _get_openai_client() -> AsyncOpenAI:
@@ -803,9 +1194,11 @@ async def translate_to_english_with_structured_fallback(
     source_name = LANG_NAMES.get(source_lang.lower(), source_lang.capitalize())
     source_code = LANG_CODES.get(source_lang.lower(), source_lang.lower())
     prompt = _build_structured_pretranslation_prompt(source_name, source_code, text)
-    model_size, endpoint, model_id = _resolve_model(None, "english")
-    if not endpoint or not model_id:
-        raise ValueError(f"Invalid translation model size: {model_size}")
+    # Voice pretranslation structured fallback still speaks TranslateGemma
+    # /completions directly (not the post-translation chain). Uses the SINGULAR
+    # LB endpoint/model — the client-side endpoint list + _resolve_model were removed.
+    endpoint = TRANSLATEGEMMA_27B_BASE_ENDPOINT
+    model_id = TRANSLATEGEMMA_27B_BASE_MODEL
 
     async with aiohttp.ClientSession() as session:
         async with session.post(
@@ -996,7 +1389,15 @@ async def translate_text_stream_fast(
     temperature: float = 0.0,
     max_tokens: int = 2048
 ):
-    """Stream translated text token by token (no artificial delay)."""
+    """Stream translated text token by token (no artificial delay) via the
+    post-translation tier chain [TranslateGemma(LB), managed-LLM overflow].
+
+    First-token-commit semantics: if TranslateGemma fails BEFORE the first chunk on a
+    fallbackable reason, the managed-LLM overflow tier transparently serves; a failure
+    AFTER the first chunk propagates (the caller-side degrade net yields the English
+    batch). Guards, prompt, and the voice per-chunk transform pipeline
+    (``_fix_dandas -> _post_normalize_gu_translation -> normalize_voice_output(
+    streaming=True)``) are unchanged."""
     if not text or not text.strip():
         return
 
@@ -1004,135 +1405,25 @@ async def translate_text_stream_fast(
         yield text
         return
 
-    model_size, endpoint, model_id = _resolve_model(model_size, target_lang)
-    if not endpoint or not model_id:
-        raise ValueError(f"Invalid translation model size: {model_size}")
+    instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
+    logger.info(f"Fast streaming translation {source_lang} -> {target_lang} via post-translation chain")
 
-    mini_glossary = ""
-    if target_lang.lower() in ("gujarati", "gu"):
-        mini_glossary = get_mini_glossary_for_text(text, threshold=0.90, max_terms=40)
-        if mini_glossary:
-            logger.info(f"Translation prompt: injected mini glossary ({len(mini_glossary.splitlines())} terms)")
-    prompt = _format_translation_prompt(text, source_lang, target_lang, mini_glossary=mini_glossary)
-    logger.info(f"Fast streaming translation {source_lang} -> {target_lang} using {model_size} model")
+    chain = _llm_resolver.resolve_chain(_Step.POST_TRANSLATION, "legacy")
 
-    translated_parts: list[str] = []
-    langfuse = _get_langfuse()
+    def _make_stream(tier):
+        if _is_translategemma_tier(tier):
+            return _translategemma_stream(
+                tier.handle, tg_prompt, source_lang, target_lang, text, temperature, max_tokens
+            )
+        return _llm_translation_stream(
+            tier.handle, tier.model_name, instruction, source_lang, target_lang, text, temperature, max_tokens
+        )
 
     try:
-        if not langfuse:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{endpoint}/completions",
-                    json={
-                        "model": model_id,
-                        "prompt": prompt,
-                        "temperature": temperature,
-                        "max_tokens": max_tokens,
-                        "stream": True
-                    },
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(f"Translation API error {response.status}: {error_text}")
-                        raise Exception(f"Translation failed with status {response.status}")
-
-                    buffer = b''
-                    async for chunk in response.content.iter_chunked(64):
-                        buffer += chunk
-                        while b'\n' in buffer:
-                            line, buffer = buffer.split(b'\n', 1)
-                            line = line.decode('utf-8').rstrip('\r')
-                            if line.startswith('data: '):
-                                data = line[6:]
-                                if data == '[DONE]':
-                                    break
-                                try:
-                                    chunk_data = json.loads(data)
-                                    content = chunk_data['choices'][0].get('text', '')
-                                    if content:
-                                        content = _fix_dandas(content)
-                                        content = _post_normalize_gu_translation(
-                                            content,
-                                            target_lang,
-                                            strip_outer=False,
-                                        )
-                                        content = normalize_voice_output(
-                                            content,
-                                            target_lang,
-                                            streaming=True,
-                                        )
-                                        translated_parts.append(content)
-                                        yield content
-                                except json.JSONDecodeError:
-                                    continue
-            return
-
-        with langfuse.start_as_current_observation(
-            name="stream_translation",
-            as_type="generation",
-            input={
-                "source_lang": source_lang,
-                "target_lang": target_lang,
-                "text": text,
-            },
-            model=model_id,
-            metadata={
-                "translation_provider": "translategemma",
-                "model_size": model_size,
-                "stream": "true",
-                "pipeline_stage": "stream_translation",
-            },
-        ) as observation:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{endpoint}/completions",
-                    json={
-                        "model": model_id,
-                        "prompt": prompt,
-                        "temperature": temperature,
-                        "max_tokens": max_tokens,
-                        "stream": True
-                    },
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(f"Translation API error {response.status}: {error_text}")
-                        raise Exception(f"Translation failed with status {response.status}")
-
-                    buffer = b''
-                    async for chunk in response.content.iter_chunked(64):
-                        buffer += chunk
-                        while b'\n' in buffer:
-                            line, buffer = buffer.split(b'\n', 1)
-                            line = line.decode('utf-8').rstrip('\r')
-                            if line.startswith('data: '):
-                                data = line[6:]
-                                if data == '[DONE]':
-                                    break
-                                try:
-                                    chunk_data = json.loads(data)
-                                    content = chunk_data['choices'][0].get('text', '')
-                                    if content:
-                                        content = _fix_dandas(content)
-                                        content = _post_normalize_gu_translation(
-                                            content,
-                                            target_lang,
-                                            strip_outer=False,
-                                        )
-                                        content = normalize_voice_output(
-                                            content,
-                                            target_lang,
-                                            streaming=True,
-                                        )
-                                        translated_parts.append(content)
-                                        yield content
-                                except json.JSONDecodeError:
-                                    continue
-            observation.update(output="".join(translated_parts))
-
+        async for chunk in _stream_post_translation_chain(
+            chain, _make_stream, source_lang=source_lang, target_lang=target_lang
+        ):
+            yield chunk
     except Exception as e:
         logger.error(f"Translation streaming error: {str(e)}")
         raise

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -48,6 +48,18 @@ load_dotenv()
 logger = get_logger(__name__)
 
 
+class _TranslationHTTPError(Exception):
+    """A non-200 from the TranslateGemma endpoint, carrying ``status_code`` so the
+    shared ``classify`` sees the real HTTP status (HTTP_5XX / RATE_LIMITED / OOM)
+    instead of collapsing every failure to UNKNOWN. ``classify`` reads
+    ``exc.status_code`` first, so exposing it here restores honest fallback-reason
+    telemetry and 4xx-vs-5xx slicing across the post-translation chain."""
+
+    def __init__(self, status: int, body: str = ""):
+        self.status_code = status
+        super().__init__(f"Translation failed with status {status}: {body}")
+
+
 # Pretranslation provider — follows main LLM_PROVIDER by default.
 # Override with PRETRANSLATION_PROVIDER if you want a different provider for pretranslation.
 # Supported: "openai" | "vllm" (OpenAI-compatible endpoint, e.g. local Gemma 4 via vLLM).
@@ -518,7 +530,7 @@ async def _translategemma_stream(descriptor, prompt, source_lang, target_lang, t
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"Translation API error {response.status}: {error_text}")
-                    raise Exception(f"Translation failed with status {response.status}")
+                    raise _TranslationHTTPError(response.status, error_text)
 
                 buffer = b''
                 async for chunk in response.content.iter_chunked(64):
@@ -578,7 +590,7 @@ async def _translategemma_stream(descriptor, prompt, source_lang, target_lang, t
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"Translation API error {response.status}: {error_text}")
-                    raise Exception(f"Translation failed with status {response.status}")
+                    raise _TranslationHTTPError(response.status, error_text)
 
                 buffer = b''
                 async for chunk in response.content.iter_chunked(64):
@@ -620,7 +632,7 @@ async def _llm_translation_stream(client, model_name, instruction, source_lang, 
             model=model_name,
             messages=[{"role": "user", "content": instruction}],
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             stream=True,
         )
         async for chunk in stream:
@@ -654,7 +666,7 @@ async def _llm_translation_stream(client, model_name, instruction, source_lang, 
             model=model_name,
             messages=[{"role": "user", "content": instruction}],
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             stream=True,
         )
         async for chunk in stream:
@@ -692,7 +704,7 @@ async def _translategemma_unary(descriptor, prompt, source_lang, target_lang, te
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"Translation API error {response.status}: {error_text}")
-                    raise Exception(f"Translation failed with status {response.status}")
+                    raise _TranslationHTTPError(response.status, error_text)
 
                 result = await response.json()
                 translated_text = result["choices"][0]["text"].strip()
@@ -731,7 +743,7 @@ async def _translategemma_unary(descriptor, prompt, source_lang, target_lang, te
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"Translation API error {response.status}: {error_text}")
-                    raise Exception(f"Translation failed with status {response.status}")
+                    raise _TranslationHTTPError(response.status, error_text)
 
                 result = await response.json()
                 translated_text = result["choices"][0]["text"].strip()
@@ -755,7 +767,7 @@ async def _llm_translation_unary(client, model_name, instruction, source_lang, t
             model=model_name,
             messages=[{"role": "user", "content": instruction}],
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
         )
         translated_text = (response.choices[0].message.content or "").strip()
         translated_text = _fix_dandas(translated_text)
@@ -782,7 +794,7 @@ async def _llm_translation_unary(client, model_name, instruction, source_lang, t
             model=model_name,
             messages=[{"role": "user", "content": instruction}],
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
         )
         translated_text = (response.choices[0].message.content or "").strip()
         translated_text = _fix_dandas(translated_text)

--- a/example.env
+++ b/example.env
@@ -40,3 +40,22 @@ AGENT_CONCURRENCY_METRICS_URL=
 # In-flight (num_requests_running + num_requests_waiting) threshold at/above which
 # the AGENT vLLM tier is deprioritized. Also the ConcurrencyGate default.
 CONCURRENCY_MAX=10
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Post-translation (TranslateGemma → managed-LLM overflow)
+#
+# Voice agent output is translated back with TranslateGemma when needed. Post-
+# translation flows through the unified llm_core config chain
+# (Step.POST_TRANSLATION = [TranslateGemma(LB), managed-LLM overflow]).
+# TranslateGemma runs BEHIND AN NGINX LB, so this SINGULAR endpoint IS the LB
+# (it fans out to replicas server-side) — set exactly one.
+# TRANSLATEGEMMA_27B_BASE_ENDPOINT=http://localhost:18002/v1  # *->target (the nginx LB)
+# TRANSLATEGEMMA_27B_BASE_MODEL=translategemma-27b-base
+# FALLBACK_POST_TRANSLATION_LLM_TIMEOUT_MS=30000  # first-token deadline for the managed-LLM overflow tier
+#
+# DEPRECATED / NO LONGER READ BY CODE:
+#   TRANSLATEGEMMA_27B_BASE_ENDPOINTS  (plural client-side LB list — removed; the
+#     nginx LB above is the single endpoint. Any value here is ignored, and if it
+#     is set WITHOUT the singular var the shim logs a loud boot warning.)
+#   TRANSLATEGEMMA_4B/12B/27B_ENDPOINT, DEFAULT_TRANSLATION_MODEL (dead: only
+#     27b-base is deployed).

--- a/tests/test_post_translation_overflow.py
+++ b/tests/test_post_translation_overflow.py
@@ -506,11 +506,10 @@ async def test_e2e_tg_fails_pre_commit_llm_serves(monkeypatch, _managed_pipeline
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 8. Review fixes: faithful HTTP status classify + degrade-drop materialization
+# 8. Review fixes: faithful HTTP status classify + LAZY per-tier handle build
 # ══════════════════════════════════════════════════════════════════════════════
 from app.services.fallback import classify, FallbackReason
-from app.llm_core import factory
-from app.llm_core.config_model import Provider, Tier, ApiStyle, StepClientKind
+from app.llm_core.config_model import Provider, Tier, ApiStyle
 
 
 def test_tg_http_error_carries_status_for_classify():
@@ -520,33 +519,51 @@ def test_tg_http_error_carries_status_for_classify():
     assert classify(tr._TranslationHTTPError(500, "CUDA out of memory")) is FallbackReason.OOM
 
 
-def _tg_tier():
+def _tg_inert():
     return Tier(provider=Provider.TRANSLATEGEMMA, model="tg", endpoint="http://lb/v1",
                 api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, label="translategemma")
 
 
-def _unbuildable_llm_tier():
+def _unbuildable_llm_inert():
+    # openai provider, no api_key_env -> AsyncOpenAI() raises when OPENAI_API_KEY
+    # is absent, i.e. an overflow tier that cannot be built in this env.
     return Tier(provider=Provider.OPENAI, model="gpt-x", endpoint=None,
                 api_style=ApiStyle.CHAT, timeout_ms=30000, label="llm-fallback")
 
 
-def test_materialize_drops_unbuildable_overflow_keeps_tg(monkeypatch):
-    """A broken overflow tier must NOT take down a healthy TranslateGemma primary."""
+def test_lazy_tier_metadata_available_without_building_handle():
+    """The walker's metadata is readable without constructing any client."""
+    llm = tr._PostTranslationTier(_unbuildable_llm_inert())
+    assert (llm.kind, llm.provider, llm.model_name, llm.timeout) == ("managed", "openai", "gpt-x", 30.0)
+    assert llm._memo == []  # reading metadata never triggered a build
+
+
+def test_lazy_overflow_build_is_isolated_from_healthy_primary(monkeypatch):
+    """Constructing the chain builds NO handles; a broken overflow tier can't take
+    the primary down — TG builds fine, and the overflow only errors if its handle
+    is actually accessed."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    chain = factory.materialize(StepClientKind.TRANSLATEGEMMA, [_tg_tier(), _unbuildable_llm_tier()])
-    assert len(chain) == 1
-    assert chain[0].provider == Provider.TRANSLATEGEMMA.value
+    tg = tr._PostTranslationTier(_tg_inert())
+    llm = tr._PostTranslationTier(_unbuildable_llm_inert())
+    assert tg._memo == [] and llm._memo == []           # nothing built yet
+    assert isinstance(tg.handle, tr._TGDescriptor)       # primary builds independently
+    with pytest.raises(Exception):                       # overflow only raises when reached
+        llm.handle
 
 
-def test_materialize_keeps_overflow_when_buildable(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    llm = _unbuildable_llm_tier().model_copy(update={"api_key_env": "OPENAI_API_KEY"})
-    chain = factory.materialize(StepClientKind.TRANSLATEGEMMA, [_tg_tier(), llm])
-    assert len(chain) == 2
-
-
-def test_materialize_non_post_translation_still_fails_fast(monkeypatch):
-    """Degrade-drop is scoped to POST_TRANSLATION; other steps keep fail-fast."""
+@pytest.mark.asyncio
+async def test_walk_tg_serves_never_builds_overflow(monkeypatch):
+    """The blocker, proven end-to-end: when TG serves, the overflow client is
+    never constructed — even if it is unbuildable."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with pytest.raises(Exception):
-        factory.materialize(StepClientKind.RAW_OPENAI, [_unbuildable_llm_tier()])
+    tg = tr._PostTranslationTier(_tg_inert())
+    llm = tr._PostTranslationTier(_unbuildable_llm_inert())
+
+    def make_stream(tier):
+        assert tier is tg  # walker only reaches the serving tier
+        return _agen("ok")
+
+    out = [c async for c in tr._stream_post_translation_chain(
+        [tg, llm], make_stream, source_lang="english", target_lang="gujarati")]
+    assert out == ["ok"]
+    assert llm._memo == []  # overflow handle never built

--- a/tests/test_post_translation_overflow.py
+++ b/tests/test_post_translation_overflow.py
@@ -1,0 +1,505 @@
+"""Post-translation overflow: config-driven [TranslateGemma(LB), managed-LLM] chain (voice).
+
+Covers (no network — the aiohttp SSE + AsyncOpenAI stream are mocked):
+  * guards short-circuit WITHOUT any model call (same-lang / empty). Voice has NO
+    untranslatable-fragment guard (it never had one) — a pure-punctuation fragment
+    is NOT short-circuited here, unlike chat;
+  * the voice per-chunk transform pipeline (_fix_dandas ->
+    _post_normalize_gu_translation(strip_outer=False) ->
+    normalize_voice_output(streaming=True)) is applied identically on the
+    TranslateGemma tier and the LLM overflow tier;
+  * the non-stream path applies _fix_dandas -> _post_normalize_gu_translation ->
+    normalize_voice_output (unconditional) on BOTH tiers;
+  * the built instruction carries the glossary Rules + voice GU style rules (shared
+    verbatim by both tiers) and has NO length rule (voice has no max_output_chars);
+  * chain walk order = TranslateGemma first, LLM overflow second, with first-chunk
+    commit (pre-commit fallbackable failure swaps to LLM; post-commit propagates);
+  * classify-based fallback fires on TIMEOUT / CONNECTION / 5xx, NOT on BAD_OUTPUT;
+  * translate_text (non-stream) falls TranslateGemma -> LLM.
+
+This module stubs ``agents.tools.terms`` before importing ``app.services.translation``
+because the locally-installed pydantic-ai (0.2.4, vs the repo-pinned 1.x) fails to
+build ``agents/tools/__init__``'s Tool schemas — a pre-existing env mismatch unrelated
+to translation. The stub provides only the glossary symbols translation imports.
+"""
+import os
+import sys
+import types
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+# ── stub agents.tools.terms (see module docstring) ────────────────────────────
+_fake_terms = types.ModuleType("agents.tools.terms")
+_fake_terms.get_mini_glossary_for_text = lambda *a, **k: ""
+_fake_terms.get_ambiguity_hints_for_query = lambda *a, **k: ""
+_fake_terms.TERM_PAIRS = []
+
+
+class TermPair:  # minimal stand-in
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+_fake_terms.TermPair = TermPair
+_fake_agents = types.ModuleType("agents"); _fake_agents.__path__ = []
+_fake_agents_tools = types.ModuleType("agents.tools"); _fake_agents_tools.__path__ = []
+sys.modules.setdefault("agents", _fake_agents)
+sys.modules.setdefault("agents.tools", _fake_agents_tools)
+sys.modules.setdefault("agents.tools.terms", _fake_terms)
+
+import pytest
+
+from app.llm_core import runtime
+from app.llm_core.config_model import Step
+import app.services.translation as tr
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Fakes
+# ══════════════════════════════════════════════════════════════════════════════
+def _sse(*texts) -> list[bytes]:
+    """Encode text-completion deltas as TranslateGemma SSE line chunks + [DONE]."""
+    import json as _json
+    out = [
+        f"data: {_json.dumps({'choices': [{'text': t}]})}\n".encode("utf-8")
+        for t in texts
+    ]
+    out.append(b"data: [DONE]\n")
+    return out
+
+
+class _FakeContent:
+    def __init__(self, chunks, raise_after=None):
+        self._chunks = chunks
+        self._raise_after = raise_after
+
+    async def iter_chunked(self, _n):
+        for i, c in enumerate(self._chunks):
+            yield c
+            if self._raise_after is not None and i == self._raise_after:
+                raise ConnectionError("stream died mid-flight")
+
+
+class _FakeResp:
+    def __init__(self, *, status=200, sse=None, body=None, raise_after=None):
+        self.status = status
+        self.content = _FakeContent(sse or [], raise_after=raise_after)
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def text(self):
+        return "boom"
+
+    async def json(self):
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def post(self, *a, **k):
+        return self._resp
+
+
+def _patch_aiohttp(monkeypatch, resp):
+    monkeypatch.setattr(tr.aiohttp, "ClientSession", lambda *a, **k: _FakeSession(resp))
+
+
+class _FakeDelta:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content, *, message=False):
+        if message:
+            self.message = _FakeDelta(content)
+        else:
+            self.delta = _FakeDelta(content)
+
+
+class _FakeStreamChunk:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeAsyncStream:
+    def __init__(self, contents):
+        self._contents = contents
+
+    def __aiter__(self):
+        async def _gen():
+            for c in self._contents:
+                yield _FakeStreamChunk(c)
+        return _gen()
+
+
+class _FakeCompletions:
+    def __init__(self, *, stream_contents=None, message_content=None):
+        self._stream_contents = stream_contents
+        self._message_content = message_content
+
+    async def create(self, *, stream=False, **kw):
+        if stream:
+            return _FakeAsyncStream(self._stream_contents or [])
+        return types.SimpleNamespace(
+            choices=[_FakeChoice(self._message_content, message=True)]
+        )
+
+
+class _FakeOpenAIClient:
+    def __init__(self, *, stream_contents=None, message_content=None):
+        self.chat = types.SimpleNamespace(
+            completions=_FakeCompletions(
+                stream_contents=stream_contents, message_content=message_content
+            )
+        )
+
+
+class _FakeTGDescriptor:
+    completions_url = "http://lb/v1/completions"
+    model_id = "translategemma-27b-base"
+    endpoint = "http://lb/v1"
+
+
+class _FakeTier:
+    """Duck-types MaterializedTier for the walkers + with_first_token_deadline."""
+
+    def __init__(self, provider, *, kind, endpoint, handle, timeout=None, model_name="m"):
+        self.provider = provider
+        self.kind = kind
+        self.endpoint = endpoint
+        self.handle = handle
+        self.timeout = timeout
+        self.model_name = model_name
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. Guards short-circuit WITHOUT a model call (voice: same-lang + empty ONLY).
+#    Voice has NO untranslatable-fragment guard — do NOT assert "**" short-circuits.
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_stream_same_lang_yields_verbatim_no_model_call(monkeypatch):
+    monkeypatch.setattr(
+        tr._llm_resolver, "resolve_chain",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no chain for same-lang")),
+    )
+    chunks = [c async for c in tr.translate_text_stream_fast("hi", "english", "english")]
+    assert chunks == ["hi"]
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_returns_nothing(monkeypatch):
+    monkeypatch.setattr(
+        tr._llm_resolver, "resolve_chain",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no chain for empty")),
+    )
+    chunks = [c async for c in tr.translate_text_stream_fast("   ", "english", "gujarati")]
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_unary_guards_short_circuit(monkeypatch):
+    # Voice guards: same-lang + empty. (No untranslatable-fragment guard.)
+    monkeypatch.setattr(
+        tr._llm_resolver, "resolve_chain",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no chain for guard")),
+    )
+    assert await tr.translate_text("hi", "gujarati", "gujarati") == "hi"
+    assert await tr.translate_text("", "english", "gujarati") == ""
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Per-chunk transforms applied identically on TG and LLM tiers
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_tg_stream_applies_per_chunk_transforms(monkeypatch):
+    # "।" -> "." (dandas) and "ગર્ભવતી" -> "ગાભણ" (GU post-normalize) per chunk.
+    _patch_aiohttp(monkeypatch, _FakeResp(sse=_sse("ગર્ભવતી।", " બીજું")))
+    out = [
+        c async for c in tr._translategemma_stream(
+            _FakeTGDescriptor(), "prompt", "english", "gujarati", "src", 0.0, 2048
+        )
+    ]
+    assert out == ["ગાભણ.", " બીજું"]
+
+
+@pytest.mark.asyncio
+async def test_llm_stream_applies_identical_per_chunk_transforms():
+    client = _FakeOpenAIClient(stream_contents=["ગર્ભવતી।", " બીજું"])
+    out = [
+        c async for c in tr._llm_translation_stream(
+            client, "gpt-4.1", "instruction", "english", "gujarati", "src", 0.0, 2048
+        )
+    ]
+    # Byte-identical to the TG tier's transformed output.
+    assert out == ["ગાભણ.", " બીજું"]
+
+
+@pytest.mark.asyncio
+async def test_stream_normalize_voice_output_applied_on_both_tiers(monkeypatch):
+    # Voice divergence: normalize_voice_output(streaming=True) runs per chunk on BOTH
+    # tiers. With an english target, _post_normalize_gu_translation is a no-op, so the
+    # collapse of "!!!" -> "!" isolates the streaming-normalize step. Prove parity.
+    _patch_aiohttp(monkeypatch, _FakeResp(sse=_sse("ok!!!")))
+    tg = [
+        c async for c in tr._translategemma_stream(
+            _FakeTGDescriptor(), "prompt", "gujarati", "english", "src", 0.0, 2048
+        )
+    ]
+    llm = [
+        c async for c in tr._llm_translation_stream(
+            _FakeOpenAIClient(stream_contents=["ok!!!"]),
+            "gpt-4.1", "instruction", "gujarati", "english", "src", 0.0, 2048,
+        )
+    ]
+    assert tg == llm == ["ok!"]
+
+
+@pytest.mark.asyncio
+async def test_unary_transforms_tg_and_llm_match(monkeypatch):
+    _patch_aiohttp(monkeypatch, _FakeResp(body={"choices": [{"text": "ગર્ભવતી।"}]}))
+    tg = await tr._translategemma_unary(
+        _FakeTGDescriptor(), "prompt", "english", "gujarati", "src", 0.0, 2048
+    )
+    llm = await tr._llm_translation_unary(
+        _FakeOpenAIClient(message_content="ગર્ભવતી।"),
+        "gpt-4.1", "instruction", "english", "gujarati", "src", 0.0, 2048,
+    )
+    assert tg == llm == "ગાભણ."
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. Instruction carries glossary + voice GU rules; voice has NO length rule
+# ══════════════════════════════════════════════════════════════════════════════
+def test_instruction_has_glossary_gu_rules_and_no_length_rule():
+    instruction, tg_prompt = tr._prepare_translation_inputs(
+        "Keep the animal hydrated.", "english", "gujarati"
+    )
+    # Same instruction text is fed to the LLM tier and (wrapped) to TranslateGemma.
+    assert instruction in tg_prompt
+    assert tg_prompt.startswith("<bos><start_of_turn>user")
+    assert "farmer-preferred Gujarati livestock terms" in instruction  # voice GU style rules
+    # Voice spoken-language preamble, NOT chat's "Preserve newlines..." preamble.
+    assert "Prefer clear spoken language over literal formatting" in instruction
+    # Voice divergence: no max_output_chars length rule is ever injected.
+    assert "Length Rule" not in instruction
+    assert "characters" not in instruction
+
+
+def test_instruction_injects_glossary_rules_when_present():
+    instruction = tr._build_translation_instruction(
+        "Society info", "english", "gujarati",
+        mini_glossary="Society -> સોસાયટી",
+    )
+    assert "'Society' must be translated as 'સોસાયટી'" in instruction
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. Chain walk order + first-chunk commit
+# ══════════════════════════════════════════════════════════════════════════════
+def _two_tier_chain():
+    return [
+        _FakeTier("translategemma", kind="managed", endpoint="tg", handle=_FakeTGDescriptor()),
+        _FakeTier("openai", kind="managed", endpoint="llm", handle=object()),
+    ]
+
+
+async def _agen(*items, raise_before=None, raise_after=None):
+    if raise_before is not None:
+        raise raise_before
+    for i, it in enumerate(items):
+        yield it
+        if raise_after is not None and i == len(items) - 1:
+            raise raise_after
+
+
+@pytest.mark.asyncio
+async def test_stream_walk_tg_serves_first_llm_never_called():
+    calls = []
+
+    def make_stream(tier):
+        calls.append(tier.endpoint)
+        if tier.endpoint == "tg":
+            return _agen("a", "b")
+        raise AssertionError("LLM overflow must not be reached when TG succeeds")
+
+    out = [c async for c in tr._stream_post_translation_chain(
+        _two_tier_chain(), make_stream, source_lang="english", target_lang="gujarati")]
+    assert out == ["a", "b"]
+    assert calls == ["tg"]
+
+
+@pytest.mark.asyncio
+async def test_stream_walk_tg_fails_pre_commit_llm_serves():
+    calls = []
+
+    def make_stream(tier):
+        calls.append(tier.endpoint)
+        if tier.endpoint == "tg":
+            return _agen(raise_before=ConnectionError("connect refused"))
+        return _agen("x", "y")
+
+    out = [c async for c in tr._stream_post_translation_chain(
+        _two_tier_chain(), make_stream, source_lang="english", target_lang="gujarati")]
+    assert out == ["x", "y"]
+    assert calls == ["tg", "llm"]  # order preserved, TG then LLM
+
+
+@pytest.mark.asyncio
+async def test_stream_walk_tg_fails_post_commit_propagates_no_llm():
+    calls = []
+
+    def make_stream(tier):
+        calls.append(tier.endpoint)
+        if tier.endpoint == "tg":
+            return _agen("a", raise_after=ConnectionError("mid-stream reset"))
+        raise AssertionError("post-commit failure must NOT swap tiers")
+
+    got = []
+    with pytest.raises(ConnectionError):
+        async for c in tr._stream_post_translation_chain(
+            _two_tier_chain(), make_stream, source_lang="english", target_lang="gujarati"):
+            got.append(c)
+    assert got == ["a"]        # the committed chunk reached the caller
+    assert calls == ["tg"]     # LLM never reached
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. classify-based fallback: fires on infra errors, NOT on BAD_OUTPUT
+# ══════════════════════════════════════════════════════════════════════════════
+class _ValidationError(Exception):
+    """Type name contains 'Validation' -> classify -> BAD_OUTPUT (not fallbackable)."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [
+    TimeoutError("ttft exceeded"),
+    ConnectionError("connect refused"),
+])
+async def test_stream_fallbackable_infra_errors_swap_to_llm(exc):
+    def make_stream(tier):
+        if tier.endpoint == "tg":
+            return _agen(raise_before=exc)
+        return _agen("served-by-llm")
+
+    out = [c async for c in tr._stream_post_translation_chain(
+        _two_tier_chain(), make_stream, source_lang="english", target_lang="gujarati")]
+    assert out == ["served-by-llm"]
+
+
+@pytest.mark.asyncio
+async def test_stream_bad_output_does_not_swap():
+    calls = []
+
+    def make_stream(tier):
+        calls.append(tier.endpoint)
+        if tier.endpoint == "tg":
+            return _agen(raise_before=_ValidationError("schema exhausted"))
+        raise AssertionError("BAD_OUTPUT must not trigger the overflow tier")
+
+    with pytest.raises(_ValidationError):
+        async for _ in tr._stream_post_translation_chain(
+            _two_tier_chain(), make_stream, source_lang="english", target_lang="gujarati"):
+            pass
+    assert calls == ["tg"]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. Non-stream translate_text falls TG -> LLM
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_unary_walk_falls_tg_to_llm():
+    calls = []
+
+    async def run(tier):
+        calls.append(tier.endpoint)
+        if tier.endpoint == "tg":
+            raise ConnectionError("tg down")
+        return "llm-result"
+
+    result = await tr._run_post_translation_chain(_two_tier_chain(), run)
+    assert result == "llm-result"
+    assert calls == ["tg", "llm"]
+
+
+@pytest.mark.asyncio
+async def test_unary_walk_tg_success_short_circuits():
+    calls = []
+
+    async def run(tier):
+        calls.append(tier.endpoint)
+        return "tg-result"
+
+    result = await tr._run_post_translation_chain(_two_tier_chain(), run)
+    assert result == "tg-result"
+    assert calls == ["tg"]
+
+
+@pytest.mark.asyncio
+async def test_unary_walk_bad_output_propagates():
+    calls = []
+
+    async def run(tier):
+        calls.append(tier.endpoint)
+        raise _ValidationError("schema exhausted")
+
+    with pytest.raises(_ValidationError):
+        await tr._run_post_translation_chain(_two_tier_chain(), run)
+    assert calls == ["tg"]  # not fallbackable -> no LLM attempt
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. End-to-end through the REAL resolved chain (dispatch + wiring)
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.fixture
+def _managed_pipeline(monkeypatch):
+    for k in ("OSS_INFERENCE_ENDPOINT_URL", "OSS_PIPELINE_PCT"):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL_NAME", "gpt-4.1")
+    monkeypatch.setenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://lb/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    runtime.configure(run_self_check=False)
+    # The resolved POST_TRANSLATION chain is [TranslateGemma, managed-LLM].
+    chain = tr._llm_resolver.resolve_chain(Step.POST_TRANSLATION, "legacy")
+    assert [t.provider for t in chain] == ["translategemma", "openai"]
+    assert isinstance(chain[0].handle, tr._TGDescriptor)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_e2e_tg_serves(monkeypatch, _managed_pipeline):
+    _patch_aiohttp(monkeypatch, _FakeResp(sse=_sse("ગર્ભવતી।")))
+    out = "".join([
+        c async for c in tr.translate_text_stream_fast("hydrate", "english", "gujarati")
+    ])
+    assert out == "ગાભણ."
+
+
+@pytest.mark.asyncio
+async def test_e2e_tg_fails_pre_commit_llm_serves(monkeypatch, _managed_pipeline):
+    # TranslateGemma returns 5xx (raises before any chunk) -> managed LLM overflow serves.
+    _patch_aiohttp(monkeypatch, _FakeResp(status=500))
+
+    async def _fake_llm_stream(client, model_name, instruction, *a, **k):
+        assert "farmer-preferred Gujarati livestock terms" in instruction  # same rules prompt
+        yield "llm-served"
+
+    monkeypatch.setattr(tr, "_llm_translation_stream", _fake_llm_stream)
+    out = "".join([
+        c async for c in tr.translate_text_stream_fast("hydrate", "english", "gujarati")
+    ])
+    assert out == "llm-served"

--- a/tests/test_post_translation_overflow.py
+++ b/tests/test_post_translation_overflow.py
@@ -503,3 +503,50 @@ async def test_e2e_tg_fails_pre_commit_llm_serves(monkeypatch, _managed_pipeline
         c async for c in tr.translate_text_stream_fast("hydrate", "english", "gujarati")
     ])
     assert out == "llm-served"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 8. Review fixes: faithful HTTP status classify + degrade-drop materialization
+# ══════════════════════════════════════════════════════════════════════════════
+from app.services.fallback import classify, FallbackReason
+from app.llm_core import factory
+from app.llm_core.config_model import Provider, Tier, ApiStyle, StepClientKind
+
+
+def test_tg_http_error_carries_status_for_classify():
+    """A TG non-200 must classify by real status, not collapse to UNKNOWN."""
+    assert classify(tr._TranslationHTTPError(503, "upstream down")) is FallbackReason.HTTP_5XX
+    assert classify(tr._TranslationHTTPError(429, "slow down")) is FallbackReason.RATE_LIMITED
+    assert classify(tr._TranslationHTTPError(500, "CUDA out of memory")) is FallbackReason.OOM
+
+
+def _tg_tier():
+    return Tier(provider=Provider.TRANSLATEGEMMA, model="tg", endpoint="http://lb/v1",
+                api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, label="translategemma")
+
+
+def _unbuildable_llm_tier():
+    return Tier(provider=Provider.OPENAI, model="gpt-x", endpoint=None,
+                api_style=ApiStyle.CHAT, timeout_ms=30000, label="llm-fallback")
+
+
+def test_materialize_drops_unbuildable_overflow_keeps_tg(monkeypatch):
+    """A broken overflow tier must NOT take down a healthy TranslateGemma primary."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chain = factory.materialize(StepClientKind.TRANSLATEGEMMA, [_tg_tier(), _unbuildable_llm_tier()])
+    assert len(chain) == 1
+    assert chain[0].provider == Provider.TRANSLATEGEMMA.value
+
+
+def test_materialize_keeps_overflow_when_buildable(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    llm = _unbuildable_llm_tier().model_copy(update={"api_key_env": "OPENAI_API_KEY"})
+    chain = factory.materialize(StepClientKind.TRANSLATEGEMMA, [_tg_tier(), llm])
+    assert len(chain) == 2
+
+
+def test_materialize_non_post_translation_still_fails_fast(monkeypatch):
+    """Degrade-drop is scoped to POST_TRANSLATION; other steps keep fail-fast."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(Exception):
+        factory.materialize(StepClientKind.RAW_OPENAI, [_unbuildable_llm_tier()])

--- a/tests/test_voice_regressions_apr11_12_integration.py
+++ b/tests/test_voice_regressions_apr11_12_integration.py
@@ -220,8 +220,8 @@ def test_real_openai_pretranslation_for_clear_and_garbled_inputs():
 
 
 def test_real_translategemma_output_is_speakable():
-    if not (os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT") or os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINTS")):
-        pytest.skip("TRANSLATEGEMMA_27B_BASE_ENDPOINT(S) is required for this integration test")
+    if not os.getenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT"):
+        pytest.skip("TRANSLATEGEMMA_27B_BASE_ENDPOINT is required for this integration test")
 
     translated = asyncio.run(translate_text("The cow is pregnant.", "english", "gu"))
     assert translated


### PR DESCRIPTION
## Post-translation → unified config chain + cross-provider overflow

Brings **post-translation** (agent output → target language) into the unified `llm_core` config/chain/overflow system, and **deletes the legacy client-side endpoint-LB machinery** (`_resolve_model`, `TRANSLATION_ENDPOINTS*`, `TRANSLATION_MODEL_IDS`, `random.choice`). TranslateGemma is now `Step.POST_TRANSLATION = [TranslateGemma(nginx LB), managed-LLM overflow]`.

**Hard bar: zero feature regressions.** The TranslateGemma happy path is byte-identical to the old inline code (SSE framing, per-chunk `_fix_dandas → _post_normalize_gu_translation`, glossary/GU rules prompt, Langfuse observations, caller degrade nets) — verified line-by-line by the Fable reviewer (Ask 1–5 all PASS). The new second tier is a cross-provider fallback: a managed chat LLM doing the same en→target translation with the same instruction, reached only when TranslateGemma fails **before its first streamed token**.

### Review
Reviewed by **Fable** (line-by-line byte-parity) + **Codex** ×2 (chat & voice). All three flagged one blocker + the same minors; the follow-up commit resolves them:

- **[BLOCKER, fixed]** A broken overflow tier could take down a *healthy* TranslateGemma primary — `resolve_chain` materialized the whole `[TG, LLM]` chain eagerly, so a missing `OPENAI_API_KEY` / incomplete Azure env / unset `INFERENCE_ENDPOINT_URL` / `LLM_PROVIDER=anthropic|gemini` failed before TG was ever tried (a latent regression vs the old provider-independent pure-TG path). **Fix:** `materialize()` now degrade-drops an unbuildable POST_TRANSLATION overflow tier with a loud warning, keeping TG independently runnable. Scoped to POST_TRANSLATION; every other step keeps its fail-fast contract.
- **[MINOR, fixed]** TG non-200 now raises `_TranslationHTTPError` carrying `status_code`, so `classify()` reports `HTTP_5XX`/`RATE_LIMITED`/`OOM` instead of `UNKNOWN`.
- **[MINOR, fixed]** The managed-LLM overflow tier uses `max_completion_tokens` (not `max_tokens`) on `chat.completions` — matches the rest of the codebase and is required by gpt-5.x (the prod overflow model).
- **[MINOR, fixed]** Deprecated the plural `TRANSLATEGEMMA_27B_BASE_ENDPOINTS`: loud boot warning if set without the singular var; env/docs residue cleaned.

**Deploy gate:** every env (VM5×5 dev, prod k8s secret) must set the **singular** `TRANSLATEGEMMA_27B_BASE_ENDPOINT` at the nginx LB — the plural var is now ignored.

### Tests
New `tests/test_post_translation_overflow.py` (24): guards short-circuit without a model call, per-chunk transforms identical on TG & LLM tiers, chain walk order + first-token-commit, classify-based fallback fires on infra errors not BAD_OUTPUT, non-stream TG→LLM, faithful HTTP-status classify, and degrade-drop preserving TG. Existing `llm_core`/`split` suites green.