### PR TITLE
review2 hardening: metrics, engine, health/concurrency, post-translation, ops

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -111,9 +111,13 @@ class Settings(BaseSettings):
     # OSS_LLM_MODEL_NAME) by app/llm_core/legacy_shim.py. The env vars stay; the
     # duplicate settings attributes + the pipeline_router that read them are gone.
 
-    # Standard OSS -> managed fallback (see docs/oss-fallback-design.md).
-    # Kill-switch defaults OFF: when false, pipelines keep today's behaviour.
-    fallback_enabled: bool = os.getenv("FALLBACK_ENABLED", "false").strip().lower() in {
+    # Standard OSS -> managed overflow/fallback (see docs/oss-fallback-design.md).
+    # ARMS the whole overflow system: the OSS->managed attempt chain AND the health
+    # + concurrency guards (which fire ONLY via the fallback walkers) are inert
+    # while this is off. Post-P4 the unified pipeline is the ONLY path (legacy
+    # deleted), so shipping with overflow off makes no sense — DEFAULTS TRUE. Envs
+    # that deliberately want it off can still set FALLBACK_ENABLED=false.
+    fallback_enabled: bool = os.getenv("FALLBACK_ENABLED", "true").strip().lower() in {
         "1", "true", "yes", "on"
     }
     # Per-pipeline OSS time-to-respond budgets before falling back to managed.

--- a/app/llm_core/concurrency.py
+++ b/app/llm_core/concurrency.py
@@ -24,6 +24,31 @@ Two hardening changes vs bh (plan §2):
       a metrics read error was the opposite bias; the plan reverses it so an
       observability blip cannot dump 100% of traffic onto the managed tier.)
 
+Two aggregation/shed improvements over the naive single-scrape bang-bang:
+
+  1. **Fleet-aggregate load via Prometheus (optional).** A single vLLM
+     ``/metrics`` scrape behind an nginx ``least_conn`` LB samples the
+     LEAST-loaded replica, under-reads the true fleet load, and sheds late/never.
+     When ``CONCURRENCY_PROMETHEUS_URL`` is set, the gauge instead comes from the
+     Prometheus HTTP API (``/api/v1/query`` of ``CONCURRENCY_PROMETHEUS_QUERY``,
+     default ``sum(vllm:num_requests_running + vllm:num_requests_waiting)``) — the
+     summed fleet aggregate. The single-endpoint ``/metrics`` scrape remains the
+     fallback when the Prometheus URL is unset. Both paths share the same short
+     Redis cache and the same FAIL-OPEN posture (any read error -> ``None``).
+
+  2. **Smooth probabilistic shed (not bang-bang at the cap).** The old filter
+     flipped 100% of gated traffic the instant the gauge reached
+     ``max_concurrency`` and back the instant it dropped — with a 2s-cached gauge
+     shared across workers, that synchronized flip/flip-back is a herd
+     oscillation. Instead, each call deprioritizes with a PROBABILITY that rises
+     with load: 0 below ``shed_start`` (``CONCURRENCY_SHED_START_FRAC`` * cap,
+     default 0.7*cap), ramping linearly to 1.0 AT the cap (and staying 1.0 above
+     it). So as load approaches the ceiling, only a self-proportioning *fraction*
+     of gated calls shed — "shed SOME gemma" — smoothing the boundary instead of
+     an all-or-nothing cliff, while the configured cap is still a hard 100%-shed
+     ceiling. (Normal Python runtime ``random`` — the "no ``Math.random()``"
+     rule is about deterministic-config contexts, not this load shed.)
+
 Composition (fixed order, plan §2): ``health-prune -> concurrency-reorder ->
 materialize -> classify-walk``. Health prunes known-DOWN tiers FIRST, so a down
 tier is already gone before this reorder runs and can never be reordered back to
@@ -32,15 +57,18 @@ the front — this filter only ever touches saturated-but-UP vLLM tiers.
 Gated by ``CONCURRENCY_GAUGE_ENABLED`` (default off) and only active where a
 ``ConcurrencyGate`` is configured on the step; both off => identity (zero
 behaviour change). Kept import-clean (stdlib + httpx + ``app.config`` + the app
-cache + ``config_model``) so the voice repo can mirror the same public API and the
-eventual repo-merge stays mechanical.
+cache + ``config_model`` + ``app.metrics``) so the voice repo can mirror the same
+public API and the eventual repo-merge stays mechanical.
 """
 
 from __future__ import annotations
 
+import os
+import random
 import re
 from typing import Optional
 
+from app import metrics
 from app.config import settings
 from app.core.cache import cache
 from app.llm_core.config_model import ConcurrencyGate, Provider, Step
@@ -48,9 +76,18 @@ from helpers.utils import get_logger
 
 logger = get_logger(__name__)
 
-# Per-metrics-url cache namespace (bh used a single fixed key; we key by URL so
-# independent boxes cache independently). Short TTL, shared across workers.
+# Per-source cache namespace (bh used a single fixed key; we key by the concrete
+# read source — the single ``/metrics`` URL, or the Prometheus query — so
+# independent boxes / the fleet aggregate cache independently). Short TTL, shared
+# across workers.
 _CACHE_KEY_PREFIX = "llm_core_concurrency:"
+
+# Default Prometheus aggregate query: the summed fleet in-flight request count.
+_DEFAULT_PROM_QUERY = "sum(vllm:num_requests_running + vllm:num_requests_waiting)"
+
+# Fraction of ``max_concurrency`` at which probabilistic shedding STARTS ramping
+# from 0. At/above the cap the shed probability is a hard 1.0. Env-tunable.
+_SHED_START_FRAC = float(os.getenv("CONCURRENCY_SHED_START_FRAC", "0.7"))
 
 # vLLM Prometheus gauges summed into one in-flight number (identical to bh).
 _NUM_RE = re.compile(
@@ -59,8 +96,11 @@ _NUM_RE = re.compile(
 
 
 async def _fetch_concurrency(metrics_url: str) -> Optional[int]:
-    """Sum ``num_requests_running + num_requests_waiting`` from a vLLM ``/metrics``
-    endpoint, or ``None`` on ANY read failure (the fail-open signal)."""
+    """Sum ``num_requests_running + num_requests_waiting`` from a single vLLM
+    ``/metrics`` endpoint, or ``None`` on ANY read failure (the fail-open signal).
+
+    NOTE: behind an nginx ``least_conn`` LB this samples ONE (the least-loaded)
+    replica; prefer the Prometheus aggregate path when a fleet-wide read matters."""
     import httpx  # lazy: keep module import side-effect-free
 
     timeout_s = settings.concurrency_metrics_timeout_ms / 1000.0
@@ -80,34 +120,118 @@ async def _fetch_concurrency(metrics_url: str) -> Optional[int]:
     return total
 
 
+async def _fetch_concurrency_prometheus(prom_url: str, query: str) -> Optional[int]:
+    """Query the Prometheus HTTP API for a scalar/vector aggregate and sum its
+    result values into one in-flight number, or ``None`` on ANY read failure
+    (fail-open). This reads the WHOLE fleet's load (``sum(...)`` across replicas),
+    unlike a single ``/metrics`` scrape that a ``least_conn`` LB biases low."""
+    import httpx  # lazy: keep module import side-effect-free
+
+    timeout_s = settings.concurrency_metrics_timeout_ms / 1000.0
+    url = prom_url.rstrip("/") + "/api/v1/query"
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            resp = await client.get(url, params={"query": query})
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception as e:  # HTTP error / timeout / bad JSON -> fail-open
+        logger.warning("concurrency: prometheus query failed for %s (%s): %s", url, query, e)
+        return None
+
+    if not isinstance(payload, dict) or payload.get("status") != "success":
+        logger.warning("concurrency: prometheus non-success payload for %s: %r", url, payload)
+        return None
+
+    result = (payload.get("data") or {}).get("result") or []
+    total = 0.0
+    saw_value = False
+    for series in result:
+        value = series.get("value") if isinstance(series, dict) else None
+        if value and len(value) >= 2:
+            try:
+                total += float(value[1])
+                saw_value = True
+            except (TypeError, ValueError):
+                continue
+    if not saw_value:
+        # Empty result vector (no series yet / query matched nothing). Treat as a
+        # read miss -> fail-open (None) rather than asserting a real "0 in flight".
+        logger.info("concurrency: prometheus query %s returned no series (fail-open)", query)
+        return None
+    return int(total)
+
+
 async def get_concurrency(metrics_url: str) -> Optional[int]:
-    """Short-TTL Redis-cached read of a vLLM engine's in-flight request count.
+    """Short-TTL Redis-cached read of the vLLM in-flight request count.
+
+    Source selection: if ``CONCURRENCY_PROMETHEUS_URL`` is set, the value is the
+    FLEET AGGREGATE from the Prometheus HTTP API (``CONCURRENCY_PROMETHEUS_QUERY``);
+    otherwise it is the single ``metrics_url`` ``/metrics`` scrape (the fallback).
 
     Cache errors degrade to a direct fetch (a Redis blip must never break the
     request path); a fetch failure returns ``None`` — the fail-open signal the
-    reorder honors (treat as NOT saturated)."""
-    if not metrics_url:
-        return None
-    key = f"{_CACHE_KEY_PREFIX}{metrics_url}"
+    reorder honors (treat as NOT saturated). A successful fresh read publishes
+    ``metrics.set_inflight`` for the read source."""
+    prom_url = os.getenv("CONCURRENCY_PROMETHEUS_URL")
+    prom_url = prom_url.strip() if prom_url else ""
+
+    if prom_url:
+        query = os.getenv("CONCURRENCY_PROMETHEUS_QUERY", _DEFAULT_PROM_QUERY)
+        cache_source = f"prom:{prom_url}:{query}"
+        inflight_label = prom_url
+
+        async def _do_fetch() -> Optional[int]:
+            return await _fetch_concurrency_prometheus(prom_url, query)
+    else:
+        if not metrics_url:
+            return None
+        cache_source = metrics_url
+        inflight_label = metrics_url
+
+        async def _do_fetch() -> Optional[int]:
+            return await _fetch_concurrency(metrics_url)
+
+    key = f"{_CACHE_KEY_PREFIX}{cache_source}"
     try:
         cached = await cache.get(key)
     except Exception as e:  # Redis down -> direct fetch, don't break routing
-        logger.warning("concurrency: cache read failed for %s: %s", metrics_url, e)
+        logger.warning("concurrency: cache read failed for %s: %s", cache_source, e)
         cached = None
     if cached is not None:
         return cached
 
-    value = await _fetch_concurrency(metrics_url)
+    value = await _do_fetch()
     if value is not None:
+        metrics.set_inflight(inflight_label, value)  # no-op if prom lib absent; never raises
         try:
             await cache.set(key, value, ttl=settings.concurrency_metrics_cache_ttl_s)
         except Exception as e:  # persistence best-effort
-            logger.warning("concurrency: cache write failed for %s: %s", metrics_url, e)
+            logger.warning("concurrency: cache write failed for %s: %s", cache_source, e)
     return value
 
 
 def _is_vllm(tier) -> bool:
     return getattr(tier, "provider", None) is Provider.VLLM
+
+
+def _shed_probability(gauge: int, max_concurrency: int) -> float:
+    """Probability that a gated call deprioritizes the vLLM tier at ``gauge``
+    in-flight requests.
+
+    * ``gauge <= shed_start`` (``_SHED_START_FRAC`` * cap): 0.0 — no shed.
+    * ``shed_start < gauge < cap``: linear ramp in (0, 1) — shed a rising,
+      self-proportioning fraction (the smooth band).
+    * ``gauge >= cap``: 1.0 — the configured cap is a hard 100%-shed ceiling.
+
+    A non-positive cap degrades to "any load sheds fully" (defensive)."""
+    if max_concurrency <= 0:
+        return 1.0 if gauge > 0 else 0.0
+    shed_start = _SHED_START_FRAC * max_concurrency
+    if gauge >= max_concurrency:
+        return 1.0
+    if gauge <= shed_start:
+        return 0.0
+    return (gauge - shed_start) / (max_concurrency - shed_start)
 
 
 async def reprioritize_by_load(
@@ -123,14 +247,16 @@ async def reprioritize_by_load(
     * the step has no ``ConcurrencyGate`` configured (``gate is None``) — a step
       without a gate is untouched;
     * the gauge is unreadable (``None``) — **fail-open**: treat as NOT saturated;
-    * the gauge is below ``gate.max_concurrency``.
+    * the probabilistic shed roll declines this call (below the ramp, or a losing
+      draw inside the smooth band).
 
-    Only when the gauge is at/above threshold are the vLLM tiers STABLY moved
-    behind the non-vLLM (managed) tiers, so the managed tier — already the next
-    tier in the chain — is tried first while the box is hot. In the single
-    vLLM-primary + managed-fallback config this is exactly "deprioritize the
-    primary"; "primary" is only index 0, and no primary/secondary inversion
-    exists (see the module docstring).
+    When the shed roll fires, the vLLM tiers are STABLY moved behind the non-vLLM
+    (managed) tiers, so the managed tier — already the next tier in the chain — is
+    tried first while the box is hot. In the single vLLM-primary + managed-fallback
+    config this is exactly "deprioritize the primary"; "primary" is only index 0,
+    and no primary/secondary inversion exists (see the module docstring). Shed
+    probability rises with load (``_shed_probability``): a self-proportioning
+    fraction near the cap, a hard 1.0 at/above it.
 
     Runs on the already-HEALTH-PRUNED inert ``Tier`` list, BEFORE materialize, so
     a tier the health filter already dropped is gone and can never be reordered
@@ -167,9 +293,13 @@ async def reprioritize_by_load(
         )
         _record(False)
         return tiers
-    if gauge < gate.max_concurrency:
+
+    # Probabilistic proportional shed: below the ramp -> never; in the band -> a
+    # rising fraction; at/above the cap -> always. Smooths the 2s-cache herd flip.
+    p = _shed_probability(gauge, gate.max_concurrency)
+    if p <= 0.0 or random.random() >= p:
         _record(False)
-        return tiers            # below threshold -> primary stays primary
+        return tiers            # this call does not shed -> primary stays primary
 
     vllm = [t for t in tiers if _is_vllm(t)]
     others = [t for t in tiers if not _is_vllm(t)]
@@ -180,8 +310,9 @@ async def reprioritize_by_load(
         return tiers
 
     logger.info(
-        "concurrency: step=%s vLLM gauge %d >= %d; deprioritizing %d vLLM tier(s) behind managed",
-        getattr(step, "value", step), gauge, gate.max_concurrency, len(vllm),
+        "concurrency: step=%s vLLM gauge %d vs cap %d (p_shed=%.2f); deprioritizing %d vLLM tier(s) behind managed",
+        getattr(step, "value", step), gauge, gate.max_concurrency, p, len(vllm),
     )
     _record(True)
+    metrics.record_deprioritized(step)  # no-op if prom lib absent; never raises
     return others + vllm

--- a/app/llm_core/config_model.py
+++ b/app/llm_core/config_model.py
@@ -69,6 +69,12 @@ class Tier(BaseModel):
     api_key_env: Optional[str] = None
     api_style: ApiStyle = ApiStyle.CHAT
     timeout_ms: Optional[int] = None
+    # Distinct FIRST-token deadline (ms) — bounds only the wait for the first
+    # streamed token, independent of ``timeout_ms`` (the overall/total per-attempt
+    # cap). Set for the post-translation TranslateGemma tier so a saturated-but-
+    # ALIVE TG overflows in single-digit seconds instead of blocking a voice turn
+    # for the full 60s total. ``None`` -> the consumer falls back to ``timeout_ms``.
+    ttft_ms: Optional[int] = None
     api_version: Optional[str] = None
     max_tokens: Optional[int] = None
     label: Optional[str] = None

--- a/app/llm_core/health.py
+++ b/app/llm_core/health.py
@@ -5,8 +5,19 @@ Two composable pieces feed one per-endpoint breaker, and one filter consumes it:
 * **Passive breaker** (fed by the fallback failure/success path in
   ``app.services.fallback``): a ``FALLBACKABLE`` classified failure on a tier is a
   ``record_failure(endpoint)``; a clean success is a ``record_success(endpoint)``.
-  ``N`` consecutive failures trip the endpoint ``open``; a cooldown lets ONE
-  half-open probe through; a real success resets it ``closed``.
+  The endpoint trips ``open`` on EITHER of two signals:
+    * ``N`` **consecutive** failures (whole-box death — every request errors), OR
+    * a rolling-window **failure RATE** above a threshold (a *brownout* — the box
+      answers 40–60% of requests, so each success resets the consecutive counter
+      and the consecutive trip NEVER fires, yet every failing request still pays
+      the full timeout tax). The rolling window (last ``HEALTH_FAIL_RATE_WINDOW``
+      outcomes) catches exactly that case: once the window is full and the
+      failure share exceeds ``HEALTH_FAIL_RATE_THRESHOLD``, the next failure
+      trips ``open``.
+  A cooldown lets ONE half-open probe through (a single in-flight probe token —
+  the FIRST caller after the cooldown probes; concurrent callers still see the
+  endpoint open and are pruned, so the dead box is not re-flooded during the
+  probe window). A real success resets it ``closed`` immediately.
 * **Active poller** (``app.tasks.health_poller``): periodically GETs the LB
   ``/health`` and reports ``record_healthy_poll`` / ``record_failed_poll``.
   Failback carries **hysteresis** — ``K`` consecutive healthy polls are required
@@ -20,7 +31,8 @@ Two composable pieces feed one per-endpoint breaker, and one filter consumes it:
 
 The breaker is keyed by **endpoint URL**, so the three independent self-hosted
 boxes (agent/OSS, pre-translation, post-translation TranslateGemma) trip and
-recover independently.
+recover independently. Every state transition (closed/half_open/open) is
+published to Prometheus via ``app.metrics.set_breaker_state``.
 
 Gating (the P2 bar — ZERO behaviour change with the flags off):
   * ``record_failure`` / ``record_success``   → no-op unless ``HEALTH_BREAKER_ENABLED``.
@@ -28,17 +40,21 @@ Gating (the P2 bar — ZERO behaviour change with the flags off):
   * ``prune_unhealthy``                        → returns tiers unchanged unless
     ``HEALTH_BREAKER_ENABLED`` **or** ``HEALTH_POLLER_ENABLED``.
 
-Kept import-clean (stdlib + ``app.config`` + ``config_model``) so the voice repo
-can mirror the same public API and the eventual repo-merge stays mechanical.
+Kept import-clean (stdlib + ``app.config`` + ``config_model`` + ``app.metrics``,
+itself dependency-optional/no-op) so the voice repo can mirror the same public API
+and the eventual repo-merge stays mechanical.
 """
 
 from __future__ import annotations
 
+import os
 import time
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
 
+from app import metrics
 from app.config import settings
 from app.llm_core.config_model import Step
 from helpers.utils import get_logger
@@ -59,6 +75,13 @@ class BreakerConfig:
     fail_threshold: int = 5          # N consecutive failures -> open
     cooldown_s: float = 30.0         # open -> half_open after this idle window
     healthy_polls_required: int = 3  # K consecutive healthy polls -> closed (hysteresis)
+    # Rolling-window failure-RATE trip (brownout coverage). The breaker also trips
+    # when, over the last ``fail_rate_window`` outcomes, the failure share exceeds
+    # ``fail_rate_threshold``. The window must be FULL before the rate can trip, so
+    # a short burst never fires it (that is the consecutive-failure trip's job) —
+    # this is purely the "40–60% flaky box that never trips consecutively" case.
+    fail_rate_window: int = 20       # rolling outcome window size (0 disables the rate trip)
+    fail_rate_threshold: float = 0.5  # failure share (>, strict) over a FULL window -> open
 
 
 @dataclass
@@ -67,6 +90,13 @@ class _EndpointState:
     consecutive_failures: int = 0
     consecutive_healthy_polls: int = 0
     opened_at: Optional[float] = None  # monotonic timestamp of the last trip
+    # Rolling window of recent outcomes (True=success, False=failure) for the
+    # failure-RATE trip; bounded to the configured window in ``_push_outcome``.
+    outcomes: deque = field(default_factory=deque)
+    # Single half-open probe token: True while ONE caller holds the in-flight
+    # probe after the cooldown elapsed. Concurrent callers see the endpoint as
+    # still open (pruned) until the probe resolves (success->closed / failure->open).
+    probe_in_flight: bool = False
 
 
 class HealthRegistry:
@@ -93,45 +123,105 @@ class HealthRegistry:
             self._by_endpoint[endpoint] = st
         return st
 
+    def _push_outcome(self, st: _EndpointState, ok: bool) -> None:
+        """Append an outcome to the rolling window and trim to the configured
+        size. Fed by BOTH failures and live successes so the failure-RATE reflects
+        a realistic brownout mix (each success does NOT clear the window — clearing
+        it on every success is exactly what let the brownout hide from the old
+        consecutive-only trip)."""
+        st.outcomes.append(ok)
+        window = self._config.fail_rate_window
+        while len(st.outcomes) > window:
+            st.outcomes.popleft()
+
+    def _rate_tripped(self, st: _EndpointState) -> bool:
+        """True when the rolling window is FULL and its failure share strictly
+        exceeds the threshold. Requires a full window so a short failure burst
+        (already covered by the consecutive trip) never fires this."""
+        window = self._config.fail_rate_window
+        if window <= 0 or len(st.outcomes) < window:
+            return False
+        fails = sum(1 for ok in st.outcomes if not ok)
+        return (fails / len(st.outcomes)) > self._config.fail_rate_threshold
+
+    def _emit(self, endpoint: str, state: BreakerState) -> None:
+        """Publish a breaker transition to Prometheus (no-op if the lib is absent;
+        never raises)."""
+        try:
+            metrics.set_breaker_state(endpoint, state.value)
+        except Exception:  # pragma: no cover - telemetry must never break routing
+            pass
+
     # ── passive breaker feed ─────────────────────────────────────────────────
     def record_failure(self, endpoint: str, *, now: Optional[float] = None) -> None:
         """A classified infrastructure failure on ``endpoint``.
 
         Fed by real request failures (fallback) AND failed polls. Any failure
         resets the healthy-poll hysteresis progress. A failure in ``half_open``
-        (the probe failed) immediately re-opens the endpoint."""
+        (the probe failed) immediately re-opens the endpoint. A failure while
+        already ``open`` REFRESHES the cooldown (continuous failures extend the
+        open window instead of letting the cooldown lapse). While ``closed`` the
+        endpoint trips on EITHER N consecutive failures OR a full-window failure
+        rate above threshold (brownout)."""
         if not endpoint:
             return
         now = time.monotonic() if now is None else now
         st = self._get(endpoint)
         st.consecutive_healthy_polls = 0
         st.consecutive_failures += 1
+        self._push_outcome(st, ok=False)
+
         if st.state is BreakerState.HALF_OPEN:
             st.state = BreakerState.OPEN
             st.opened_at = now
+            st.probe_in_flight = False
+            self._emit(endpoint, BreakerState.OPEN)
             logger.warning("health: endpoint %s re-opened (half-open probe failed)", endpoint)
             return
-        if st.state is BreakerState.CLOSED and st.consecutive_failures >= self._config.fail_threshold:
+        if st.state is BreakerState.OPEN:
+            # Already tripped: refresh the cooldown so a steady failure stream keeps
+            # the endpoint open rather than half-opening mid-outage.
+            st.opened_at = now
+            self._emit(endpoint, BreakerState.OPEN)
+            return
+        # CLOSED: trip on consecutive-failure OR rolling failure-rate (brownout).
+        if st.consecutive_failures >= self._config.fail_threshold:
             st.state = BreakerState.OPEN
             st.opened_at = now
+            self._emit(endpoint, BreakerState.OPEN)
             logger.warning(
                 "health: endpoint %s OPEN after %d consecutive failures",
                 endpoint, st.consecutive_failures,
+            )
+        elif self._rate_tripped(st):
+            fails = sum(1 for ok in st.outcomes if not ok)
+            st.state = BreakerState.OPEN
+            st.opened_at = now
+            self._emit(endpoint, BreakerState.OPEN)
+            logger.warning(
+                "health: endpoint %s OPEN on brownout (%d/%d failures in window > %.0f%%)",
+                endpoint, fails, len(st.outcomes), self._config.fail_rate_threshold * 100,
             )
 
     def record_success(self, endpoint: str) -> None:
         """A clean end-to-end request success — the strongest healthy signal, so
         it resets the endpoint ``closed`` immediately (no hysteresis: unlike a
-        lightweight ``/health`` poll, a real success proves the whole path)."""
+        lightweight ``/health`` poll, a real success proves the whole path). The
+        outcome is still appended to the rolling window (WITHOUT clearing it) so a
+        brownout box's failure-rate keeps accumulating across its intermittent
+        successes."""
         if not endpoint:
             return
         st = self._get(endpoint)
         was_open = st.state is not BreakerState.CLOSED
         st.consecutive_failures = 0
         st.consecutive_healthy_polls = 0
+        st.probe_in_flight = False
         st.state = BreakerState.CLOSED
         st.opened_at = None
+        self._push_outcome(st, ok=True)
         if was_open:
+            self._emit(endpoint, BreakerState.CLOSED)
             logger.info("health: endpoint %s reset CLOSED on live success", endpoint)
 
     # ── active poller feed ───────────────────────────────────────────────────
@@ -156,19 +246,26 @@ class HealthRegistry:
             st.consecutive_failures = 0
             st.consecutive_healthy_polls = 0
             st.opened_at = None
+            st.probe_in_flight = False
+            self._emit(endpoint, BreakerState.CLOSED)
 
     def record_failed_poll(self, endpoint: str, *, now: Optional[float] = None) -> None:
         """A non-200 / unreachable ``/health`` — same evidence as a request
-        failure, so it feeds the same trip counter (whole-box death trips it)."""
+        failure, so it feeds the same trip counter (whole-box death trips it) and
+        the same cooldown refresh when already open."""
         self.record_failure(endpoint, now=now)
 
     # ── read side (the filter consumes this) ─────────────────────────────────
     def is_open(self, endpoint: str, *, now: Optional[float] = None) -> bool:
         """Should ``endpoint`` be pruned right now?
 
-        ``open`` past its cooldown lazily transitions to ``half_open`` and is
-        NOT pruned (so a single probe request can re-validate it). ``closed`` and
-        ``half_open`` are never pruned; only a still-cooling ``open`` is."""
+        ``open`` past its cooldown lazily transitions to ``half_open`` and grants
+        the SINGLE probe token to THIS caller (returns False → not pruned) so one
+        request can re-validate the box. While ``half_open`` with the probe token
+        already held by another caller, this returns True (pruned) — so the dead
+        box is probed by exactly one request, not re-flooded. ``closed`` is never
+        pruned; a still-cooling ``open`` (or a half-open whose probe is in flight
+        elsewhere) is."""
         if not endpoint:
             return False
         st = self._by_endpoint.get(endpoint)
@@ -178,9 +275,18 @@ class HealthRegistry:
             now = time.monotonic() if now is None else now
             if st.opened_at is not None and (now - st.opened_at) >= self._config.cooldown_s:
                 st.state = BreakerState.HALF_OPEN
-                logger.info("health: endpoint %s HALF_OPEN (cooldown elapsed, probe allowed)", endpoint)
+                st.probe_in_flight = True          # grant the single probe to THIS caller
+                self._emit(endpoint, BreakerState.HALF_OPEN)
+                logger.info("health: endpoint %s HALF_OPEN (cooldown elapsed, single probe allowed)", endpoint)
                 return False
             return True
+        if st.state is BreakerState.HALF_OPEN:
+            if st.probe_in_flight:
+                return True                        # another caller holds the probe -> prune
+            # Probe token free (e.g. a prior probe resolved without a definitive
+            # success/failure) -> grant it to THIS caller.
+            st.probe_in_flight = True
+            return False
         return False
 
     def state_of(self, endpoint: str) -> BreakerState:
@@ -188,14 +294,20 @@ class HealthRegistry:
         return st.state if st is not None else BreakerState.CLOSED
 
     def snapshot(self) -> dict[str, dict]:
-        return {
-            ep: {
+        out: dict[str, dict] = {}
+        for ep, st in self._by_endpoint.items():
+            n = len(st.outcomes)
+            fails = sum(1 for ok in st.outcomes if not ok)
+            out[ep] = {
                 "state": st.state.value,
                 "consecutive_failures": st.consecutive_failures,
                 "consecutive_healthy_polls": st.consecutive_healthy_polls,
+                "window_size": n,
+                "window_failures": fails,
+                "failure_rate": (fails / n) if n else 0.0,
+                "probe_in_flight": st.probe_in_flight,
             }
-            for ep, st in self._by_endpoint.items()
-        }
+        return out
 
 
 def _default_config() -> BreakerConfig:
@@ -203,6 +315,8 @@ def _default_config() -> BreakerConfig:
         fail_threshold=settings.health_breaker_fail_threshold,
         cooldown_s=settings.health_breaker_cooldown_ms / 1000.0,
         healthy_polls_required=settings.health_poller_healthy_polls,
+        fail_rate_window=int(os.getenv("HEALTH_FAIL_RATE_WINDOW", "20")),
+        fail_rate_threshold=float(os.getenv("HEALTH_FAIL_RATE_THRESHOLD", "0.5")),
     )
 
 

--- a/app/llm_core/legacy_shim.py
+++ b/app/llm_core/legacy_shim.py
@@ -183,9 +183,14 @@ def _post_translation_tiers() -> list[Tier]:
         )
     endpoint = _env("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1") or "http://localhost:18002/v1"
     model_id = _env("TRANSLATEGEMMA_27B_BASE_MODEL", "translategemma-27b-base") or "translategemma-27b-base"
+    # ``timeout_ms`` is the 60s overall/total per-attempt cap; ``ttft_ms`` is the
+    # distinct, SHORT first-token deadline (single-digit seconds) so a saturated-
+    # but-alive TG overflows fast instead of blocking a voice turn for the full 60s.
     tg = Tier(
         provider=Provider.TRANSLATEGEMMA, model=model_id, endpoint=endpoint,
-        api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, label="translategemma",
+        api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000,
+        ttft_ms=_int_env("FALLBACK_POST_TRANSLATION_TG_TTFT_MS", 5000),
+        label="translategemma",
     )
     # Cross-provider overflow = the managed agent tier, but forced to CHAT api_style
     # and given its own (shorter) first-token deadline. Reuses the managed builder so

--- a/app/llm_core/resolver.py
+++ b/app/llm_core/resolver.py
@@ -75,15 +75,18 @@ def post_translation_tiers(variant: str = "legacy") -> list[Tier]:
     construction and let a misconfigured overflow tier take a healthy primary down.
     So the translation adapter takes the tiers INERT and builds each handle LAZILY
     only as the fallback walker reaches it (see ``translation._PostTranslationTier``).
-    Records the resolved profile for tracing, exactly as ``resolve_chain`` does."""
+
+    Deliberately does NOT ``record_profile``: post-translation runs AFTER the agent
+    step and is profile-INVARIANT (it lives in ``defaults``), so recording a profile
+    here would last-write-wins CLOBBER the turn's real ``pipeline_profile`` (set by
+    the agent-step ``resolve_chain``) to "managed". The step chain is still recorded
+    by the translation adapter's ``_post_translation_chain`` via ``record_step_chain``."""
     pipeline = runtime.get_pipeline()
     name = _profile_name_for_variant(variant)
     profile = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
     step_cfg = pipeline.step_config(profile, Step.POST_TRANSLATION)
     if step_cfg is None:
         raise ValueError("no config for step=post_translation")
-    from app.llm_core import trace as _trace
-    _trace.record_profile(profile.name, profile.weight)
     return list(step_cfg.tiers)
 
 

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -87,6 +87,53 @@ def _load_from_yaml(path: str) -> PipelineConfig:
     return PipelineConfig(**data)
 
 
+def _truthy_env(name: str) -> bool:
+    v = os.getenv(name)
+    return v is not None and v.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _assert_boot_posture() -> None:
+    """Emit a LOUD one-line 'overflow ARMED / DISARMED' posture summary at boot.
+
+    The whole overflow system — the OSS->managed attempt chain AND the health +
+    concurrency guards, which fire ONLY via the fallback walkers — is inert unless
+    ``FALLBACK_ENABLED`` is on. A deploy from defaults could therefore ship dark
+    with nothing in the logs saying so. This line makes the armament state greppable
+    at startup (``grep 'llm_core posture'``): INFO when armed, WARNING when disarmed.
+
+    Honors the opt-in ``REQUIRE_OVERFLOW_ARMED``: when truthy, a DISARMED boot is a
+    hard error (raises) so prod can gate on it and never ship overflow-off."""
+    from app.config import settings
+
+    def _onoff(b: bool) -> str:
+        return "on" if b else "off"
+
+    fallback_on = bool(settings.fallback_enabled)
+    if settings.concurrency_gauge_enabled:
+        conc = "on(metrics_url set)" if settings.agent_concurrency_metrics_url else "on(metrics_url unset — no-op)"
+    else:
+        conc = "off"
+    guards = (
+        f"health_breaker={_onoff(settings.health_breaker_enabled)} "
+        f"health_poller={_onoff(settings.health_poller_enabled)} "
+        f"concurrency={conc}"
+    )
+    if fallback_on:
+        logger.info("llm_core posture: overflow=ARMED fallback=on %s", guards)
+    else:
+        logger.warning(
+            "llm_core posture: overflow=DISARMED (FALLBACK_ENABLED=false) — "
+            "health/concurrency guards inert (they fire only via the fallback "
+            "walkers); %s", guards,
+        )
+        if _truthy_env("REQUIRE_OVERFLOW_ARMED"):
+            raise RuntimeError(
+                "llm_core boot refused: REQUIRE_OVERFLOW_ARMED=true but overflow is "
+                "DISARMED (FALLBACK_ENABLED=false). Set FALLBACK_ENABLED=true to arm "
+                "the unified overflow/fallback path, or unset REQUIRE_OVERFLOW_ARMED."
+            )
+
+
 def configure(*, run_self_check: bool = True) -> PipelineConfig:
     """Load / synthesize the pipeline config, validate, store, self-check."""
     global PIPELINE
@@ -109,6 +156,10 @@ def configure(*, run_self_check: bool = True) -> PipelineConfig:
     # in logs even before any turn arrives (`grep llm_core.full_config`).
     from app.llm_core import trace as _trace
     _trace.log_full_config(PIPELINE)
+    # Boot posture assertion: LOUD ARMED/DISARMED overflow summary (+ hard-gate via
+    # REQUIRE_OVERFLOW_ARMED). Placed after config load so a hard-gate raise fires
+    # before the (non-fatal) self-check.
+    _assert_boot_posture()
     if run_self_check:
         try:
             self_check()

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -92,6 +92,13 @@ def _truthy_env(name: str) -> bool:
     return v is not None and v.strip().lower() in {"1", "true", "yes", "on"}
 
 
+class BootRefused(RuntimeError):
+    """Intentional hard-gate boot failure (e.g. REQUIRE_OVERFLOW_ARMED with overflow
+    DISARMED). Distinct type so the best-effort ``configure()`` call site in main.py
+    can re-raise it (a deliberate refusal to boot) while still swallowing genuine
+    non-fatal configure/self-check edge cases."""
+
+
 def _assert_boot_posture() -> None:
     """Emit a LOUD one-line 'overflow ARMED / DISARMED' posture summary at boot.
 
@@ -127,7 +134,7 @@ def _assert_boot_posture() -> None:
             "walkers); %s", guards,
         )
         if _truthy_env("REQUIRE_OVERFLOW_ARMED"):
-            raise RuntimeError(
+            raise BootRefused(
                 "llm_core boot refused: REQUIRE_OVERFLOW_ARMED=true but overflow is "
                 "DISARMED (FALLBACK_ENABLED=false). Set FALLBACK_ENABLED=true to arm "
                 "the unified overflow/fallback path, or unset REQUIRE_OVERFLOW_ARMED."

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -20,7 +20,16 @@ Design constraints:
 
 from __future__ import annotations
 
+import os
 from typing import Optional
+
+# Multi-worker aggregation: uvicorn/gunicorn with >1 worker gives each process its
+# OWN in-process registry, so a /metrics scrape hits only one worker and undercounts.
+# When PROMETHEUS_MULTIPROC_DIR is set, prometheus_client writes metrics to that
+# shared dir and render() aggregates across all workers via a MultiProcessCollector.
+# Leave it UNSET for single-worker deployments (simple in-process registry). Set it
+# (e.g. /tmp/prom_multiproc, a fresh dir per container) whenever workers > 1.
+_MULTIPROC_DIR = os.environ.get("PROMETHEUS_MULTIPROC_DIR") or None
 
 try:  # optional dependency — the pipeline runs fine without it (no-op mode)
     from prometheus_client import (
@@ -32,8 +41,18 @@ try:  # optional dependency — the pipeline runs fine without it (no-op mode)
     )
 
     _ENABLED = True
+    if _MULTIPROC_DIR:
+        from prometheus_client import multiprocess as _multiprocess
+
+        # Best-effort: ensure the shared dir exists (fresh per container, so no stale
+        # cross-restart files). Never fatal — fall back to in-process on any error.
+        try:
+            os.makedirs(_MULTIPROC_DIR, exist_ok=True)
+        except Exception:
+            _MULTIPROC_DIR = None
 except Exception:  # pragma: no cover - exercised only where the lib is absent
     _ENABLED = False
+    _MULTIPROC_DIR = None
     CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
 
 
@@ -45,7 +64,15 @@ def _s(v: object) -> str:
 
 
 if _ENABLED:
-    REGISTRY = CollectorRegistry()
+    # In multiproc mode, metrics MUST NOT bind a custom registry — the library
+    # collects them from PROMETHEUS_MULTIPROC_DIR and render() aggregates. In
+    # single-process mode they live on our own dedicated registry.
+    if _MULTIPROC_DIR:
+        REGISTRY = None
+        _reg_kw: dict = {}
+    else:
+        REGISTRY = CollectorRegistry()
+        _reg_kw = {"registry": REGISTRY}
 
     # Which tier actually served a step (incremented where fallback commits/returns).
     # kind = "oss" | "managed"; provider/model identify the concrete tier.
@@ -53,35 +80,38 @@ if _ENABLED:
         "llm_served_total",
         "Turns served, by step and the tier that actually served them.",
         ["step", "kind", "provider", "model"],
-        registry=REGISTRY,
+        **_reg_kw,
     )
     # Every classified failure the fallback engine emits (fallbacks AND terminals).
     _fallback_total = Counter(
         "llm_fallback_total",
         "Classified overflow/fallback events by step, reason and outcome.",
         ["step", "reason", "fell_back", "committed"],
-        registry=REGISTRY,
+        **_reg_kw,
     )
     # Per-endpoint circuit-breaker state: 0 closed, 1 half-open, 2 open.
+    # ``multiprocess_mode="max"`` so a scrape reflects the worst (most-open) worker.
     _breaker_state = Gauge(
         "llm_health_breaker_state",
         "Per-endpoint health breaker state (0=closed, 1=half_open, 2=open).",
         ["endpoint"],
-        registry=REGISTRY,
+        multiprocess_mode="max",
+        **_reg_kw,
     )
     # Concurrency-gauge deprioritizations (a saturated vLLM tier pushed back).
     _deprioritized_total = Counter(
         "llm_concurrency_deprioritized_total",
         "Times a saturated vLLM tier was deprioritized by the concurrency gauge.",
         ["step"],
-        registry=REGISTRY,
+        **_reg_kw,
     )
     # Last-scraped in-flight (running+waiting) request count per vLLM endpoint.
     _inflight = Gauge(
         "llm_concurrency_inflight",
         "Last-scraped in-flight (running+waiting) requests per vLLM endpoint.",
         ["endpoint"],
-        registry=REGISTRY,
+        multiprocess_mode="max",
+        **_reg_kw,
     )
 
 _BREAKER_STATE_CODES = {"closed": 0, "half_open": 1, "half-open": 1, "open": 2}
@@ -152,6 +182,12 @@ def render() -> tuple[bytes, str]:
             CONTENT_TYPE_LATEST,
         )
     try:
+        if _MULTIPROC_DIR:
+            # Aggregate every worker's metrics from the shared dir into a fresh
+            # registry (the documented multiprocess exposition pattern).
+            reg = CollectorRegistry()
+            _multiprocess.MultiProcessCollector(reg)
+            return generate_latest(reg), CONTENT_TYPE_LATEST
         return generate_latest(REGISTRY), CONTENT_TYPE_LATEST
     except Exception:
         return b"# metrics render error\n", CONTENT_TYPE_LATEST

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,161 @@
+"""Prometheus metrics for the unified LLM pipeline (routing / overflow / health).
+
+Answers the operational question the compact Langfuse trace cannot: *"what share
+of traffic is being served by the managed (gpt-5.1) tier right now?"* — the exact
+number needed in week 1 and during a GPU-outage failover. Every hook site
+(``fallback.emit``/``_record_served``, ``health`` breaker transitions,
+``concurrency`` reorders) already fires at the right moment; this module is the
+sink they were missing.
+
+Design constraints:
+- **Never break boot or a request.** ``prometheus_client`` is an OPTIONAL import;
+  when it is absent every ``record_*`` / ``set_*`` call is a silent no-op and
+  ``render()`` returns an explanatory comment. This keeps the module safe to ship
+  before the dependency lands in every environment.
+- **Never raise from a telemetry call.** Each recorder swallows its own errors —
+  a metrics bug must never take down a farmer's turn.
+- Its own ``CollectorRegistry`` (not the global default) so the ``/metrics``
+  endpoint exposes exactly these series and nothing the process imports elsewhere.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # optional dependency — the pipeline runs fine without it (no-op mode)
+    from prometheus_client import (
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        generate_latest,
+        CONTENT_TYPE_LATEST,
+    )
+
+    _ENABLED = True
+except Exception:  # pragma: no cover - exercised only where the lib is absent
+    _ENABLED = False
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+
+def _s(v: object) -> str:
+    """Coerce a label value to a bounded string (None -> "none")."""
+    if v is None:
+        return "none"
+    return str(v)
+
+
+if _ENABLED:
+    REGISTRY = CollectorRegistry()
+
+    # Which tier actually served a step (incremented where fallback commits/returns).
+    # kind = "oss" | "managed"; provider/model identify the concrete tier.
+    _served_total = Counter(
+        "llm_served_total",
+        "Turns served, by step and the tier that actually served them.",
+        ["step", "kind", "provider", "model"],
+        registry=REGISTRY,
+    )
+    # Every classified failure the fallback engine emits (fallbacks AND terminals).
+    _fallback_total = Counter(
+        "llm_fallback_total",
+        "Classified overflow/fallback events by step, reason and outcome.",
+        ["step", "reason", "fell_back", "committed"],
+        registry=REGISTRY,
+    )
+    # Per-endpoint circuit-breaker state: 0 closed, 1 half-open, 2 open.
+    _breaker_state = Gauge(
+        "llm_health_breaker_state",
+        "Per-endpoint health breaker state (0=closed, 1=half_open, 2=open).",
+        ["endpoint"],
+        registry=REGISTRY,
+    )
+    # Concurrency-gauge deprioritizations (a saturated vLLM tier pushed back).
+    _deprioritized_total = Counter(
+        "llm_concurrency_deprioritized_total",
+        "Times a saturated vLLM tier was deprioritized by the concurrency gauge.",
+        ["step"],
+        registry=REGISTRY,
+    )
+    # Last-scraped in-flight (running+waiting) request count per vLLM endpoint.
+    _inflight = Gauge(
+        "llm_concurrency_inflight",
+        "Last-scraped in-flight (running+waiting) requests per vLLM endpoint.",
+        ["endpoint"],
+        registry=REGISTRY,
+    )
+
+_BREAKER_STATE_CODES = {"closed": 0, "half_open": 1, "half-open": 1, "open": 2}
+
+
+def record_served(step: object, kind: object, provider: object, model: object) -> None:
+    """A step was served by ``kind`` (oss/managed) tier ``provider``/``model``.
+
+    Call at the point the walker commits/returns a result (``_record_served`` sites).
+    The aggregate ``managed``-share over this counter is the system's core KPI."""
+    if not _ENABLED:
+        return
+    try:
+        _served_total.labels(_s(step), _s(kind), _s(provider), _s(model)).inc()
+    except Exception:
+        pass
+
+
+def record_fallback(step: object, reason: object, fell_back: object, committed: object) -> None:
+    """A classified failure was emitted (mirror of ``fallback.emit``).
+
+    ``fell_back`` True = moved to the next tier; ``committed`` True = failure after
+    the stream had already yielded (post-commit, not fallbackable)."""
+    if not _ENABLED:
+        return
+    try:
+        _fallback_total.labels(_s(step), _s(reason), _s(bool(fell_back)).lower(), _s(bool(committed)).lower()).inc()
+    except Exception:
+        pass
+
+
+def set_breaker_state(endpoint: object, state: object) -> None:
+    """Publish a per-endpoint breaker transition (closed/half_open/open)."""
+    if not _ENABLED:
+        return
+    try:
+        code = _BREAKER_STATE_CODES.get(_s(state).lower().replace(" ", "_"), 0)
+        _breaker_state.labels(_s(endpoint)).set(code)
+    except Exception:
+        pass
+
+
+def record_deprioritized(step: object) -> None:
+    """A vLLM tier was deprioritized by the concurrency gauge for ``step``."""
+    if not _ENABLED:
+        return
+    try:
+        _deprioritized_total.labels(_s(step)).inc()
+    except Exception:
+        pass
+
+
+def set_inflight(endpoint: object, value: object) -> None:
+    """Publish the last-scraped in-flight request count for a vLLM endpoint."""
+    if not _ENABLED:
+        return
+    try:
+        _inflight.labels(_s(endpoint)).set(float(value))
+    except Exception:
+        pass
+
+
+def render() -> tuple[bytes, str]:
+    """(_body_, _content_type_) for the ``GET /metrics`` endpoint."""
+    if not _ENABLED:
+        return (
+            b"# prometheus_client not installed; llm_core metrics disabled.\n",
+            CONTENT_TYPE_LATEST,
+        )
+    try:
+        return generate_latest(REGISTRY), CONTENT_TYPE_LATEST
+    except Exception:
+        return b"# metrics render error\n", CONTENT_TYPE_LATEST
+
+
+def enabled() -> bool:
+    return _ENABLED

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -21,6 +21,8 @@ own task + queue, so it stays disconnect-safe (see its docstring).
 from __future__ import annotations
 
 import asyncio
+import os
+import random
 import time
 
 import anyio
@@ -73,6 +75,21 @@ FALLBACKABLE = {
     FallbackReason.RATE_LIMITED,
     FallbackReason.OOM,
     FallbackReason.UNKNOWN,
+}
+
+# (G) Breaker evidence — the subset of FALLBACKABLE that genuinely indicts the
+# ENDPOINT (the box is down / erroring / overloaded), as distinct from a
+# caller-side or context problem. We still fall to the next tier on ANY
+# FALLBACKABLE reason, but only feed the health breaker on BREAKER_EVIDENCE — so a
+# caller ``TypeError`` (-> UNKNOWN) or a 4xx context-overflow (-> UNKNOWN) can no
+# longer trip the OSS breaker and shift everyone to the managed tier. UNKNOWN is
+# deliberately excluded; it is fallbackable but is NOT endpoint evidence.
+BREAKER_EVIDENCE = {
+    FallbackReason.CONNECTION,
+    FallbackReason.HTTP_5XX,
+    FallbackReason.OOM,
+    FallbackReason.RATE_LIMITED,
+    FallbackReason.TIMEOUT,
 }
 
 _OOM_MARKERS = ("out of memory", "cuda", "oom", "kv cache", "no available memory")
@@ -204,6 +221,10 @@ def emit(event: FallbackEvent) -> None:
     Sentry breadcrumb are added best-effort. NOTE: this intentionally does not use
     the canonical telemetry queue — that pipeline is for farmer Q&A analytics, not
     ops metrics; revisit if a fallback event type is added there."""
+    reason_value = event.reason.value
+    from app import metrics
+    metrics.record_fallback(event.pipeline, reason_value, event.fell_back, event.committed)
+
     logger.warning(
         "oss_fallback pipeline=%s reason=%s fell_back=%s from=%s to=%s "
         "endpoint=%s model=%s latency_ms=%s error_class=%s committed=%s session=%s detail=%s",
@@ -256,6 +277,95 @@ def _record_served(pipeline: str, kind: str, index: int) -> None:
         pass
 
 
+# (D) Internal commit sentinel. Agent producers yield this the instant the agent
+# does ANY work — the FIRST pydantic-ai model event, which is a tool-call part that
+# pydantic-ai emits BEFORE it runs the tools and long before the first TEXT delta.
+# ``with_first_token_deadline`` treats the sentinel as the first-token commit, so a
+# turn that has begun executing tools can never trip the TTFT deadline and force a
+# cross-tier re-run of side-effecting tools (duplicate bookings / SMS) or poison the
+# OSS breaker. The sentinel is consumed by the deadline wrapper and is NEVER
+# forwarded to the caller. (Liveness is preserved: a truly hung endpoint emits no
+# event, so no sentinel arrives and the deadline still fires -> swap.)
+class _AgentActivity:
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "<AGENT_ACTIVITY>"
+
+
+AGENT_ACTIVITY = _AgentActivity()
+
+
+# (F) Bound concurrent MANAGED-tier admission + honor 429 on the last tier.
+# During a full GPU outage ~100% of turns overflow to the managed tier; with no cap
+# we drive it into its own 429 with nothing behind it. A per-process semaphore caps
+# concurrent managed calls (size from ``MANAGED_MAX_CONCURRENCY``); OSS tiers are
+# uncapped. Acquisition is FAIL-OPEN — if a slot can't be had within a short
+# timeout we proceed anyway rather than deadlock a farmer's turn.
+def _managed_max_concurrency() -> int:
+    try:
+        return max(1, int(os.getenv("MANAGED_MAX_CONCURRENCY", "64")))
+    except Exception:
+        return 64
+
+
+_MANAGED_ACQUIRE_TIMEOUT = 5.0   # fail-open cap on waiting for a managed slot (s)
+_RATE_LIMIT_MAX_WAIT = 5.0       # cap on honoring a last-tier 429 Retry-After (s)
+
+# The semaphore is (re)bound to the RUNNING loop lazily: a module-level Semaphore
+# binds to whatever loop imported this module and then explodes when awaited from a
+# different loop (per-test ``asyncio.run`` loops, a reloaded app loop). Keyed on the
+# identity of the running loop, so production creates it exactly once and tests get
+# a fresh one per loop.
+_managed_sem_state: dict = {"loop": None, "sem": None}
+
+
+def _get_managed_sem() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    if _managed_sem_state["sem"] is None or _managed_sem_state["loop"] is not loop:
+        _managed_sem_state["loop"] = loop
+        _managed_sem_state["sem"] = asyncio.Semaphore(_managed_max_concurrency())
+    return _managed_sem_state["sem"]
+
+
+async def _acquire_managed_slot(sem: asyncio.Semaphore) -> bool:
+    """Acquire a managed-tier slot; FAIL-OPEN on timeout so a turn never deadlocks.
+
+    Returns True if the slot was acquired (caller must ``release``), False if it
+    proceeded uncapped after the acquire timed out."""
+    try:
+        await asyncio.wait_for(sem.acquire(), _MANAGED_ACQUIRE_TIMEOUT)
+        return True
+    except asyncio.TimeoutError:
+        logger.warning(
+            "fallback: managed-tier slot acquire timed out (%.1fs); proceeding uncapped",
+            _MANAGED_ACQUIRE_TIMEOUT,
+        )
+        return False
+
+
+def _retry_after_seconds(exc: BaseException) -> float:
+    """Best-effort ``Retry-After`` (seconds) from a 429, capped + jittered.
+
+    Reads a numeric ``Retry-After`` header off the exception's response when
+    present; otherwise a small default backoff. Always bounded by
+    ``_RATE_LIMIT_MAX_WAIT`` so a hostile/huge value can't stall the turn."""
+    delay: Optional[float] = None
+    resp = getattr(exc, "response", None)
+    headers = getattr(resp, "headers", None) or getattr(exc, "headers", None)
+    if headers is not None:
+        try:
+            getter = getattr(headers, "get", None)
+            raw = (getter("retry-after") or getter("Retry-After")) if getter else None
+            if raw is not None:
+                delay = float(str(raw).strip())
+        except Exception:
+            delay = None
+    if delay is None or delay < 0:
+        delay = 0.5
+    return min(delay, _RATE_LIMIT_MAX_WAIT) + random.uniform(0.0, 0.25)
+
+
 async def execute_with_fallback(
     *,
     pipeline: str,
@@ -274,47 +384,67 @@ async def execute_with_fallback(
     """
     chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, variant=variant)
     for i, attempt in enumerate(chain):
-        t0 = time.monotonic()
-        try:
-            if attempt.timeout is None:
-                result = await run(attempt)
-            else:
-                with anyio.fail_after(attempt.timeout):
+        is_last = i == len(chain) - 1
+        # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped.
+        sem = _get_managed_sem() if attempt.kind == "managed" else None
+        retried_rate_limit = False
+        while True:
+            t0 = time.monotonic()
+            acquired = False
+            try:
+                if sem is not None:
+                    acquired = await _acquire_managed_slot(sem)
+                if attempt.timeout is None:
                     result = await run(attempt)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            reason = classify(exc)
-            is_last = i == len(chain) - 1
-            will_fall_back = reason in FALLBACKABLE and not is_last
-            # P2 passive breaker feed: an infrastructure (FALLBACKABLE) failure is
-            # evidence this endpoint is down — count it toward the trip. Self-gated:
-            # a no-op unless HEALTH_BREAKER_ENABLED, so flag-off behaviour is identical.
-            if reason in FALLBACKABLE:
-                health.record_failure(attempt.endpoint)
-            emit(
-                FallbackEvent(
-                    pipeline=pipeline,
-                    session_id=session_id,
-                    from_variant=attempt.kind,
-                    to_variant=chain[i + 1].kind if will_fall_back else None,
-                    reason=reason,
-                    error_class=type(exc).__name__,
-                    error_detail=str(exc)[:500],
-                    oss_endpoint=attempt.endpoint,
-                    oss_model=attempt.model_name,
-                    latency_ms=int((time.monotonic() - t0) * 1000),
-                    fell_back=will_fall_back,
-                )
-            )
-            if not will_fall_back:
+                else:
+                    with anyio.fail_after(attempt.timeout):
+                        result = await run(attempt)
+            except asyncio.CancelledError:
                 raise
-        else:
-            # Clean success resets the breaker for this endpoint (P2). No-op unless
-            # HEALTH_BREAKER_ENABLED.
-            health.record_success(attempt.endpoint)
-            _record_served(pipeline, attempt.kind, i)
-            return result
+            except Exception as exc:
+                reason = classify(exc)
+                will_fall_back = reason in FALLBACKABLE and not is_last
+                # (G) FALLBACKABLE decides fall-to-next-tier; only BREAKER_EVIDENCE
+                # (never UNKNOWN) feeds the health breaker, so a caller error / 4xx
+                # overflow can't trip the OSS breaker. Self-gated: a no-op unless
+                # HEALTH_BREAKER_ENABLED, so flag-off behaviour is identical.
+                if reason in BREAKER_EVIDENCE:
+                    health.record_failure(attempt.endpoint)
+                emit(
+                    FallbackEvent(
+                        pipeline=pipeline,
+                        session_id=session_id,
+                        from_variant=attempt.kind,
+                        to_variant=chain[i + 1].kind if will_fall_back else None,
+                        reason=reason,
+                        error_class=type(exc).__name__,
+                        error_detail=str(exc)[:500],
+                        oss_endpoint=attempt.endpoint,
+                        oss_model=attempt.model_name,
+                        latency_ms=int((time.monotonic() - t0) * 1000),
+                        fell_back=will_fall_back,
+                    )
+                )
+                # (F) Last tier hit 429 with nothing behind it: ONE bounded retry
+                # honoring Retry-After (capped + jittered) before giving up.
+                if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
+                    retried_rate_limit = True
+                    await asyncio.sleep(_retry_after_seconds(exc))
+                    continue
+                if not will_fall_back:
+                    raise
+                break  # fall to the next tier
+            else:
+                # Clean success resets the breaker for this endpoint (P2). No-op unless
+                # HEALTH_BREAKER_ENABLED.
+                health.record_success(attempt.endpoint)
+                _record_served(pipeline, attempt.kind, i)
+                from app import metrics
+                metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
+                return result
+            finally:
+                if acquired:
+                    sem.release()
 
 
 async def with_first_token_deadline(attempt: MaterializedTier, agen: AsyncIterator[Any]) -> AsyncIterator[Any]:
@@ -373,7 +503,11 @@ async def with_first_token_deadline(attempt: MaterializedTier, agen: AsyncIterat
                 return
             if kind == _ERR:
                 raise val
-            yield val
+            # (D) The AGENT_ACTIVITY sentinel satisfies the first-token deadline (the
+            # endpoint is alive and working — a tool-call event precedes any text) but
+            # is INTERNAL: it commits the turn without being forwarded to the caller.
+            if val is not AGENT_ACTIVITY:
+                yield val
             kind, val = await queue.get()
     finally:
         # Single-task teardown: cancelling _drain unwinds run_stream's scope in its
@@ -423,76 +557,98 @@ async def stream_with_fallback(
     chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, variant=variant)
     last_exc: Optional[BaseException] = None
     for i, attempt in enumerate(chain):
-        t0 = time.monotonic()
-        committed = False
+        is_last = i == len(chain) - 1
+        # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped. The slot
+        # is held for the whole managed stream and released in `finally` — including on
+        # a client disconnect / aclose, which unwinds through this frame's finally.
+        sem = _get_managed_sem() if attempt.kind == "managed" else None
+        retried_rate_limit = False
+        while True:
+            t0 = time.monotonic()
+            committed = False
+            acquired = False
 
-        # IMPORTANT: consume make_stream here with a plain `async for` and never
-        # wrap THIS loop in an external timeout/cancel scope — pydantic-ai's
-        # run_stream opens an anyio cancel scope inside make_stream that stays open
-        # across the `yield`, so any scope spanning these yields unwinds out of order
-        # on aclose/disconnect ("cancel scope in a different task"). The
-        # time-to-first-token deadline is applied by callers wrapping make_stream in
-        # `with_first_token_deadline`, which isolates run_stream in its own task +
-        # queue precisely so no anyio scope is ever open at a `yield` (disconnect-safe).
-        try:
-            async for chunk in make_stream(attempt):
-                committed = True
-                yield chunk
-            # Clean stream finish resets the breaker for this endpoint (P2).
-            health.record_success(attempt.endpoint)
-            _record_served(pipeline, attempt.kind, i)
-            return  # stream finished cleanly
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            reason = classify(exc)
-            is_last = i == len(chain) - 1
-            if committed:
-                # Client already received output — a transparent swap is impossible.
+            # IMPORTANT: consume make_stream here with a plain `async for` and never
+            # wrap THIS loop in an external timeout/cancel scope — pydantic-ai's
+            # run_stream opens an anyio cancel scope inside make_stream that stays open
+            # across the `yield`, so any scope spanning these yields unwinds out of order
+            # on aclose/disconnect ("cancel scope in a different task"). The plain
+            # semaphore `finally` below is NOT a cancel scope, so it is disconnect-safe.
+            # The time-to-first-token deadline is applied by callers wrapping make_stream
+            # in `with_first_token_deadline`, which isolates run_stream in its own task +
+            # queue precisely so no anyio scope is ever open at a `yield`.
+            try:
+                if sem is not None:
+                    acquired = await _acquire_managed_slot(sem)
+                async for chunk in make_stream(attempt):
+                    committed = True
+                    yield chunk
+                # Clean stream finish resets the breaker for this endpoint (P2).
+                health.record_success(attempt.endpoint)
+                _record_served(pipeline, attempt.kind, i)
+                from app import metrics
+                metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
+                return  # stream finished cleanly
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                reason = classify(exc)
+                if committed:
+                    # Client already received output — a transparent swap is impossible.
+                    emit(
+                        FallbackEvent(
+                            pipeline=pipeline,
+                            session_id=session_id,
+                            from_variant=attempt.kind,
+                            to_variant=None,
+                            reason=reason,
+                            error_class=type(exc).__name__,
+                            error_detail=str(exc)[:500],
+                            oss_endpoint=attempt.endpoint,
+                            oss_model=attempt.model_name,
+                            latency_ms=int((time.monotonic() - t0) * 1000),
+                            fell_back=False,
+                            committed=True,
+                        )
+                    )
+                    raise
+                will_fall_back = reason in FALLBACKABLE and not is_last
+                # (G) Only PRE-commit BREAKER_EVIDENCE feeds the breaker: a post-commit
+                # failure (handled above) is NOT evidence — the box answered and
+                # streamed tokens — and neither is UNKNOWN (a caller/context problem).
+                # Self-gated (no-op unless HEALTH_BREAKER_ENABLED).
+                if reason in BREAKER_EVIDENCE:
+                    health.record_failure(attempt.endpoint)
                 emit(
                     FallbackEvent(
                         pipeline=pipeline,
                         session_id=session_id,
                         from_variant=attempt.kind,
-                        to_variant=None,
+                        to_variant=chain[i + 1].kind if will_fall_back else None,
                         reason=reason,
                         error_class=type(exc).__name__,
                         error_detail=str(exc)[:500],
                         oss_endpoint=attempt.endpoint,
                         oss_model=attempt.model_name,
                         latency_ms=int((time.monotonic() - t0) * 1000),
-                        fell_back=False,
-                        committed=True,
+                        fell_back=will_fall_back,
+                        committed=False,
                     )
                 )
+                last_exc = exc
+                # (F) Last tier hit 429 pre-commit with nothing behind it: ONE bounded
+                # retry honoring Retry-After. Safe because committed is False (no output
+                # reached the caller), so the retried stream can't duplicate anything.
+                if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
+                    retried_rate_limit = True
+                    await asyncio.sleep(_retry_after_seconds(exc))
+                    continue
+                if will_fall_back:
+                    break  # fall to the next tier
                 raise
-            will_fall_back = reason in FALLBACKABLE and not is_last
-            # P2 passive breaker feed: only PRE-commit infrastructure failures are
-            # evidence the endpoint is down. A post-commit failure (handled above)
-            # is NOT — the box answered and streamed tokens — so it must not trip
-            # the breaker. Self-gated (no-op unless HEALTH_BREAKER_ENABLED).
-            if reason in FALLBACKABLE:
-                health.record_failure(attempt.endpoint)
-            emit(
-                FallbackEvent(
-                    pipeline=pipeline,
-                    session_id=session_id,
-                    from_variant=attempt.kind,
-                    to_variant=chain[i + 1].kind if will_fall_back else None,
-                    reason=reason,
-                    error_class=type(exc).__name__,
-                    error_detail=str(exc)[:500],
-                    oss_endpoint=attempt.endpoint,
-                    oss_model=attempt.model_name,
-                    latency_ms=int((time.monotonic() - t0) * 1000),
-                    fell_back=will_fall_back,
-                    committed=False,
-                )
-            )
-            last_exc = exc
-            if will_fall_back:
-                continue
-            raise
+            finally:
+                if acquired:
+                    sem.release()
 
     # All tiers failed before commit (every fallbackable tier swapped, last raised).
     if last_exc is not None:

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -29,6 +29,7 @@ from app.config import settings
 from app.llm_core import resolver as _llm_resolver
 from app.llm_core import health as _llm_health
 from app.llm_core import trace as _llm_trace
+from app import metrics as _metrics
 from app.llm_core.config_model import (
     Step as _Step,
     Tier as _Tier,
@@ -468,6 +469,20 @@ def _get_langfuse():
         return None
 
 
+def _is_untranslatable_fragment(text: str) -> bool:
+    """True when there is nothing to translate — the fragment has no letters or
+    digits in any script (pure punctuation / markdown / symbols, e.g. ``**``).
+
+    TranslateGemma free-generates an unrelated canned paragraph when handed such a
+    degenerate fragment (a streaming chunk boundary can isolate ``**`` on its own),
+    so we must short-circuit and return it verbatim instead of calling the model.
+    This matters MORE for voice than chat: voice drives ``translate_text_stream_fast``
+    per streaming chunk, so a lone ``**`` chunk is exactly the degenerate-chunk case
+    behind the TG "appended-garbage" hallucination whose prescribed fix is this
+    pre-model chunk guard (ported verbatim from chat)."""
+    return not re.search(r"[^\W_]", text, flags=re.UNICODE)
+
+
 # ── post-translation tier-chain adapter ───────────────────────────────────────
 # translate_text / translate_text_stream_fast route through the llm_core
 # POST_TRANSLATION chain: [TranslateGemma(LB), managed-LLM overflow]. Per tier the
@@ -524,7 +539,7 @@ class _PostTranslationTier:
     error, if reached, is just this tier's failure and hits the caller degrade net,
     exactly like the old pure-TG path)."""
 
-    __slots__ = ("_tier", "kind", "model_name", "endpoint", "timeout", "_memo")
+    __slots__ = ("_tier", "kind", "model_name", "endpoint", "timeout", "ttft", "_memo")
 
     def __init__(self, tier: _Tier):
         self._tier = tier
@@ -532,6 +547,10 @@ class _PostTranslationTier:
         self.model_name = tier.model
         self.endpoint = tier.endpoint or "managed"
         self.timeout = (tier.timeout_ms / 1000.0) if tier.timeout_ms is not None else None
+        # Distinct SHORT first-token deadline (seconds) — the stream walker bounds
+        # time-to-first-token by this, keeping ``timeout`` as the overall/total cap.
+        # ``None`` (e.g. the managed overflow tier) -> walker falls back to ``timeout``.
+        self.ttft = (tier.ttft_ms / 1000.0) if tier.ttft_ms is not None else None
         self._memo: list = []
 
     @property
@@ -550,11 +569,49 @@ class _PostTranslationTier:
         return self._memo[0]
 
 
+class _TtftDeadlineView:
+    """Minimal view exposing ONLY the attributes ``with_first_token_deadline`` reads
+    (``timeout``/``kind``/``endpoint``), so a post-translation tier can present a
+    SHORT first-token bound (its ``ttft``) to that primitive while its real
+    ``timeout`` stays the 60s overall/total cap the unary walker + aiohttp honor.
+    A saturated-but-ALIVE TranslateGemma thus overflows in single-digit seconds
+    instead of blocking a voice turn for up to the full 60s."""
+
+    __slots__ = ("timeout", "kind", "endpoint")
+
+    def __init__(self, tier, ttft):
+        self.timeout = ttft
+        self.kind = tier.kind
+        self.endpoint = tier.endpoint
+
+
+def _record_served_tier(tier, index: int) -> None:
+    """Record the tier that actually served this post-translation turn: onto the
+    per-turn Langfuse pipeline trace (served kind + 0-based chain index) and the
+    Prometheus served counter (the managed-share KPI). Both hooks are best-effort
+    no-ops off-path (no active trace context / prometheus_client absent)."""
+    _llm_trace.record_served(_Step.POST_TRANSLATION, tier.kind, index)
+    _metrics.record_served(
+        _Step.POST_TRANSLATION.value, tier.kind, tier.provider, tier.model_name
+    )
+
+
 def _post_translation_chain():
-    """Resolve the INERT POST_TRANSLATION tiers and wrap them as lazy-handle chain
-    entries + record the trace chain. Post-translation is profile-invariant
-    (llm_core ``defaults``), so we resolve with ``"legacy"``."""
-    chain = [_PostTranslationTier(t) for t in _llm_resolver.post_translation_tiers("legacy")]
+    """Resolve the INERT POST_TRANSLATION tiers, HEALTH-PRUNE known-down endpoints,
+    wrap the survivors as lazy-handle chain entries + record the trace chain.
+    Post-translation is profile-invariant (llm_core ``defaults``), so we resolve
+    with ``"legacy"``.
+
+    The prune is why this exists: the post-translation walkers DO feed the breaker
+    (``record_failure``/``record_success``) and the poller polls the TG ``/health``,
+    but without pruning here a down TG is re-attempted (and re-timed-out) EVERY turn
+    on the most-traveled path. ``prune_unhealthy`` drops tiers whose endpoint breaker
+    is ``open`` and is contractually never-empty (all-open -> chain returned
+    unchanged), and it is a settings-gated identity no-op when the health flags are
+    off, so the flags-off path is byte-identical."""
+    tiers = _llm_resolver.post_translation_tiers("legacy")
+    tiers = _llm_health.prune_unhealthy(_Step.POST_TRANSLATION, tiers)
+    chain = [_PostTranslationTier(t) for t in tiers]
     _llm_trace.record_step_chain(_Step.POST_TRANSLATION, chain)
     return chain
 
@@ -870,10 +927,19 @@ async def _stream_post_translation_chain(chain, make_stream, *, source_lang, tar
         t0 = time.monotonic()
         committed = False
         try:
-            async for chunk in _with_first_token_deadline(tier, make_stream(tier)):
+            # Bound the FIRST-token wait by the tier's short ``ttft`` (falling back to
+            # its ``timeout`` when unset); the 60s ``timeout`` remains the overall/total
+            # cap (aiohttp total + unary walker), so a saturated-but-alive TG overflows
+            # fast instead of holding a voice turn for the whole 60s.
+            _ttft = getattr(tier, "ttft", None)
+            _deadline_view = _TtftDeadlineView(
+                tier, _ttft if _ttft is not None else tier.timeout
+            )
+            async for chunk in _with_first_token_deadline(_deadline_view, make_stream(tier)):
                 committed = True
                 yield chunk
             _llm_health.record_success(tier.endpoint)
+            _record_served_tier(tier, i)
             return
         except asyncio.CancelledError:
             raise
@@ -945,6 +1011,7 @@ async def _run_post_translation_chain(chain, run):
                 raise
         else:
             _llm_health.record_success(tier.endpoint)
+            _record_served_tier(tier, i)
             return result
     if last_exc is not None:
         raise last_exc
@@ -967,6 +1034,9 @@ async def translate_text(
     TranslateGemma fails, and config-driven endpoint/model selection (no more
     client-side ``random.choice``)."""
     if not text or not text.strip():
+        return text
+
+    if _is_untranslatable_fragment(text):
         return text
 
     if source_lang.lower() == target_lang.lower():
@@ -1464,6 +1534,10 @@ async def translate_text_stream_fast(
     (``_fix_dandas -> _post_normalize_gu_translation -> normalize_voice_output(
     streaming=True)``) are unchanged."""
     if not text or not text.strip():
+        return
+
+    if _is_untranslatable_fragment(text):
+        yield text
         return
 
     if source_lang.lower() == target_lang.lower():

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -56,7 +56,7 @@ from app.services.stt_signals import (
     count_consecutive_stt_signals,
 )
 from app.services.moderation import ModerationVerdict, check_moderation
-from app.services.fallback import classify, execute_with_fallback, stream_with_fallback, with_first_token_deadline
+from app.services.fallback import AGENT_ACTIVITY, classify, execute_with_fallback, stream_with_fallback, with_first_token_deadline
 from app.services.non_meaningful import NonMeaningfulVerdict, check_non_meaningful_streak
 from app.services.translation import (
     INDIAN_LANGUAGES,
@@ -2386,25 +2386,53 @@ async def stream_voice_message(
                     _fb_holder: dict = {}
 
                     async def _raw_stream(attempt, _attempt_info):
-                        async with active_agent.run_stream(
+                        # (D) COMMIT-ON-FIRST-ACTIVITY. Iterate via agent.iter()+node.stream()
+                        # so the FIRST pydantic-ai model event (a tool-call part, emitted
+                        # BEFORE the tools run and long before the first TEXT delta) is
+                        # surfaced once as the AGENT_ACTIVITY sentinel.
+                        # with_first_token_deadline treats that as the first-token commit,
+                        # so the slow 20s milk-collection tool can no longer trip the TTFT
+                        # deadline and force a cross-tier re-run of side-effecting tools
+                        # (CreateAICall booking / SMS -> duplicate bookings). The sentinel
+                        # is swallowed by the deadline wrapper and never heard by the
+                        # caller. Liveness is preserved: a hung endpoint emits no event, so
+                        # the deadline still fires -> swap. _attempt_had_chunk / committed
+                        # stay tied to real TEXT (unchanged caller-visible commit).
+                        _activity_signaled = False
+                        async with active_agent.iter(
                             user_prompt=user_message,
                             message_history=model_input_history,
                             deps=deps,
                             usage_limits=usage_limits,
                             model=attempt.model,
-                        ) as rs:
+                        ) as agent_run:
                             _attempt_had_chunk = False
-                            async for _c in rs.stream_text(delta=True, debounce_by=0):
-                                if not _attempt_had_chunk:
-                                    _attempt_had_chunk = True
-                                    _attempt_info["committed"] = True
-                                    _attempt_info["status"] = "committed"
-                                yield _c
+                            async for node in agent_run:
+                                if type(node).__name__ == 'ModelRequestNode':
+                                    async with node.stream(agent_run.ctx) as request_stream:
+                                        async for event in request_stream:
+                                            if not _activity_signaled:
+                                                _activity_signaled = True
+                                                yield AGENT_ACTIVITY
+                                            event_type = type(event).__name__
+                                            _c = None
+                                            if event_type == 'PartStartEvent' and hasattr(event, 'part'):
+                                                if type(event.part).__name__ == 'TextPart' and hasattr(event.part, 'content'):
+                                                    _c = event.part.content
+                                            elif event_type == 'PartDeltaEvent' and hasattr(event, 'delta'):
+                                                if type(event.delta).__name__ == 'TextPartDelta':
+                                                    _c = event.delta.content_delta
+                                            if _c:
+                                                if not _attempt_had_chunk:
+                                                    _attempt_had_chunk = True
+                                                    _attempt_info["committed"] = True
+                                                    _attempt_info["status"] = "committed"
+                                                yield _c
                             if _attempt_had_chunk and _attempt_info.get("status") != "error":
                                 _attempt_info["status"] = "ok"
                             elif _attempt_info.get("status") != "error":
                                 _attempt_info["status"] = "ok_no_output"
-                            _fb_holder["new_messages"] = rs.new_messages()
+                            _fb_holder["new_messages"] = agent_run.result.new_messages()
 
                     async def _make_stream(attempt):
                         nonlocal _agent_actual_tier, _agent_actual_provider, _agent_actual_model

--- a/example.env
+++ b/example.env
@@ -1,24 +1,30 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Unified LLM pipeline (app/llm_core) — voice-oan-api
 #
-# The five guards below are now ENABLED BY DEFAULT. Every one is still fully
-# env-overridable: set it to "false" to revert that piece to the legacy path.
-# Setting ALL of them false reproduces the pre-llm_core behavior byte-for-byte.
+# The unified config-driven pipeline is ALWAYS ON — it is the ONLY model-selection
+# path. The old P0/P1 kill-switches LLM_CORE_ENABLED / PROFILES_ENABLED were
+# DELETED at P4; no code reads them anymore, so setting them does NOTHING (do not
+# rely on them mid-incident). The weighted OSS/managed split and the config-driven
+# attempt chain are always live.
+#
+# ARM THE OVERFLOW PATH — FALLBACK_ENABLED arms the OSS->managed overflow chain AND
+# the health + concurrency guards below (those guards fire ONLY via the fallback
+# walkers, so they are inert while overflow is disarmed). It now DEFAULTS TRUE; set
+# it false only to deliberately ship with overflow off.
+# FALLBACK_ENABLED=true
+#
+# The real operational levers (all default ON; env always overrides the code default):
+#   OSS_PIPELINE_PCT            — % of sessions on the OSS profile (the weighted split)
+#   HEALTH_BREAKER_ENABLED      — passive per-endpoint circuit breaker
+#   HEALTH_POLLER_ENABLED       — active LB /health poller (lifespan task)
+#   CONCURRENCY_GAUGE_ENABLED   — deprioritize a saturated-but-up vLLM tier
+#
+# HARD-GATE A PROD BOOT — set REQUIRE_OVERFLOW_ARMED=true and the app REFUSES to
+# start whenever overflow is disarmed (FALLBACK_ENABLED=false), so a default-off
+# deploy can never ship dark. The boot always logs a loud one-line posture summary:
+#   llm_core posture: overflow=ARMED fallback=on health_breaker=on health_poller=on concurrency=...
+# REQUIRE_OVERFLOW_ARMED=true
 # ─────────────────────────────────────────────────────────────────────────────
-
-# Route the voice agent / moderation / non_meaningful / pretranslation call sites
-# through the llm_core resolver (identity with the legacy singletons for the
-# current env, verified at startup by app.llm_core.runtime.self_check). When on,
-# the config is also validated at boot (RAW_OPENAI steps — pre_translation /
-# moderation / non_meaningful — accept only vllm/openai/azure-openai providers).
-LLM_CORE_ENABLED=true
-
-# Weighted named-profile split + config-driven attempt chain. When on, the voice
-# router resolves the session's sticky profile via the llm_core split (honoring a
-# pre-existing voice_pipeline_variant: sticky key so nothing re-buckets), and the
-# fallback walkers materialize the resolved profile's tiers. Composes with
-# LLM_CORE_ENABLED (both required for the config-driven factory chain).
-PROFILES_ENABLED=true
 
 # Pre-flight health FILTER (per-endpoint circuit breaker). Two independent
 # switches; the prune is active when EITHER is on. It only DROPS tiers whose

--- a/example.env
+++ b/example.env
@@ -65,3 +65,9 @@ CONCURRENCY_MAX=10
 #     is set WITHOUT the singular var the shim logs a loud boot warning.)
 #   TRANSLATEGEMMA_4B/12B/27B_ENDPOINT, DEFAULT_TRANSLATION_MODEL (dead: only
 #     27b-base is deployed).
+
+# Prometheus metrics aggregation across workers. When the app runs with >1 uvicorn
+# worker, set this to a writable, per-container-fresh dir so /metrics aggregates all
+# workers (else a scrape sees only one worker and undercounts). Leave UNSET for a
+# single worker. Example:
+# PROMETHEUS_MULTIPROC_DIR=/tmp/prom_multiproc

--- a/main.py
+++ b/main.py
@@ -35,9 +35,10 @@ async def lifespan(app: FastAPI):
     from app.llm_core import runtime as _llm_runtime
     try:
         _llm_runtime.configure()
-    except _llm_runtime.PipelineConfigError:
+    except (_llm_runtime.PipelineConfigError, _llm_runtime.BootRefused):
         # Fail-fast at boot: an unbuildable pipeline config (E, e.g. an anthropic
-        # tier on a RAW_OPENAI step) must stop startup, not crash per-request.
+        # tier on a RAW_OPENAI step) OR an intentional REQUIRE_OVERFLOW_ARMED
+        # hard-gate must stop startup, not crash per-request / ship dark.
         raise
     except Exception as _llm_exc:  # pragma: no cover - defensive
         print(f"⚠️  llm_core configure skipped: {_llm_exc}")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from contextlib import asynccontextmanager
@@ -78,6 +78,15 @@ async def root():
         "debug": settings.debug,
         "api_prefix": settings.api_prefix
     }
+
+@app.get("/metrics")
+async def metrics():
+    """Prometheus exposition for the unified LLM pipeline (plain text, no auth,
+    scraped internally). render() is a no-op safe stub when prometheus_client is
+    absent, so this route works whether or not the dependency is installed."""
+    from app import metrics as _metrics
+    body, content_type = _metrics.render()
+    return Response(content=body, media_type=content_type)
 
 # Include all routers with API prefix from settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,9 @@ tenacity
 langfuse
 gevent>=22.10.0
 
+# Prometheus metrics (optional at runtime; app/metrics.py degrades to a no-op when absent)
+prometheus-client==0.21.1
+
 # Redis for caching and stuff
 redis
 apscheduler==3.10.4

--- a/scripts/check_pipeline_parity.py
+++ b/scripts/check_pipeline_parity.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Cross-repo parity guard for the unified LLM pipeline core (``app/llm_core``).
+
+WHAT THIS GUARDS
+================
+The chat repo (``amul-oan-api``) and the voice repo (``voice-oan-api``) each carry
+their own copy of the unified LLM pipeline core under ``app/llm_core/`` (plus the
+shared fallback walker at ``app/services/fallback.py``). The north-star is a single
+merged repo; until then the two copies are kept in lockstep BY DISCIPLINE ALONE —
+there is no build-time link, so an edit landed in one repo and forgotten in the
+other drifts silently and is only discovered when the two behave differently in
+prod. This script turns that discipline into a CI check.
+
+It splits the pipeline files into two sets:
+
+  * MUST-MATCH — infrastructure that has NO legitimate reason to differ between the
+    repos. These are byte-compared; ANY difference fails CI (exit 1) and prints a
+    unified diff. Keeping them identical is the whole point of the guard.
+
+  * TOLERATED — files that legitimately differ because chat and voice genuinely
+    have different pipeline shapes (e.g. chat has a ``suggestions`` step; voice has
+    a ``non_meaningful`` step and RAW_OPENAI moderation). For these we still want
+    to catch *unexpected* drift, so each file declares a WHITELIST of the regions
+    that are ALLOWED to differ:
+      - "region-whitelisted" files (``config_model.py``, ``resolver.py``): only the
+        named regions (the ``Step`` enum / ``StepClientKind`` block; the
+        ``STEP_CLIENT_KIND`` map) may differ. Each whitelisted region is collapsed
+        to a single sentinel line in BOTH files and the REMAINDER is compared; a
+        difference outside every whitelisted region is un-whitelisted drift and
+        fails CI. If a whitelist anchor no longer matches (file restructured) the
+        script says so loudly so the whitelist gets updated.
+      - "whole-file" files (``legacy_shim.py``, ``split.py``, ``runtime.py``): these
+        are pervasively repo-specific (per-repo env wiring, docstrings, boot glue).
+        The whole file is whitelisted-as-divergent: the script prints an
+        informational diff summary for human review but never fails on them.
+
+WHY THE SPLIT IS SAFE
+=====================
+The MUST-MATCH set is chosen so that a divergence there is always a bug: the
+circuit breaker (``health.py``), the concurrency gauge (``concurrency.py``), the
+boot-config tracer (``trace.py``) and the fallback walker (``fallback.py``) encode
+shared cross-cutting behavior. The TOLERATED set is exactly the files whose
+per-repo divergence is a deliberate, documented product difference — and even those
+are pinned down to the specific regions allowed to move.
+
+USAGE
+=====
+    python scripts/check_pipeline_parity.py <chat_root> <voice_root>
+
+Roots may also come from ``PARITY_CHAT_ROOT`` / ``PARITY_VOICE_ROOT``; if neither
+args nor env are given, the two repos are assumed to sit side by side as
+``../amul-oan-api`` and ``../voice-oan-api`` relative to this repo.
+
+Exit code: 0 = in parity (only whitelisted regions differ); 1 = un-whitelisted
+divergence in a MUST-MATCH or region-whitelisted file (CI failure); 2 = usage /
+missing-file error. This file is intended to be IDENTICAL in both repos.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import sys
+from dataclasses import dataclass
+
+# ── files that MUST stay byte-identical across the two repos ──────────────────
+MUST_MATCH: list[str] = [
+    "app/llm_core/health.py",       # P2 passive circuit breaker
+    "app/llm_core/concurrency.py",  # P3 concurrency gauge / reorder
+    "app/llm_core/trace.py",        # boot full-config tracer
+    "app/services/fallback.py",     # OSS->managed fallback walker
+]
+
+
+@dataclass(frozen=True)
+class Region:
+    """A contiguous span that is ALLOWED to differ between the repos.
+
+    Bounded by substring anchors: the region starts at the first line containing
+    ``start`` and ends at the next line containing ``end``. ``include_end`` decides
+    whether that end-anchor line is part of the region (True) or is shared code that
+    must still be compared (False). The whole span is collapsed to one sentinel line
+    so a region of unequal length on each side still compares equal.
+    """
+
+    name: str
+    start: str
+    end: str
+    include_end: bool = False
+
+
+# ── files that legitimately differ, pinned to whitelisted regions ─────────────
+# Only these named regions may differ; the rest of the file must still match.
+REGION_TOLERATED: dict[str, list[Region]] = {
+    "app/llm_core/config_model.py": [
+        # Per-repo prose only.
+        Region("module docstring", '"""Config data model', "from __future__ import"),
+        # THE deliberate difference: chat has SUGGESTIONS, voice has NON_MEANINGFUL.
+        Region("Step enum", "class Step(str, Enum)", "class StepClientKind"),
+        # Same members, per-repo inline comments (which steps map to which kind).
+        Region("StepClientKind enum", "class StepClientKind", "class Tier"),
+    ],
+    "app/llm_core/resolver.py": [
+        Region("module docstring", '"""Resolver', "from __future__ import"),
+        # chat: MODERATION/SUGGESTIONS are AGENT-kind; voice: MODERATION/
+        # NON_MEANINGFUL are RAW_OPENAI-kind. This map is the single seam that
+        # encodes that product difference.
+        Region("STEP_CLIENT_KIND map", "STEP_CLIENT_KIND: dict", "}", include_end=True),
+    ],
+}
+
+# ── files that are pervasively repo-specific: informational diff only ─────────
+WHOLE_FILE_TOLERATED: dict[str, str] = {
+    "app/llm_core/legacy_shim.py": (
+        "per-repo env->config synthesis (chat: suggestions tiers; voice: shared "
+        "RAW_OPENAI moderation/non_meaningful clients) — pervasively different"
+    ),
+    "app/llm_core/split.py": (
+        "per-repo variant<->profile helpers and router-seam wiring — pervasively "
+        "different"
+    ),
+    "app/llm_core/runtime.py": (
+        "per-repo boot glue: docstrings, validate_config shape, Provider import — "
+        "the shared boot-posture assertion is kept in sync by hand"
+    ),
+}
+
+
+def _read(path: str) -> list[str] | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.readlines()
+    except FileNotFoundError:
+        return None
+
+
+def _mask(lines: list[str], regions: list[Region]) -> tuple[list[str], list[str]]:
+    """Collapse each whitelisted region to a single sentinel line.
+
+    Returns ``(masked_lines, stale_region_names)`` — a region whose anchors don't
+    match (start present but end never found) is left unmasked and reported stale.
+    """
+    out: list[str] = []
+    stale: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        hit: Region | None = None
+        for reg in regions:
+            if reg.start in lines[i]:
+                hit = reg
+                break
+        if hit is None:
+            out.append(lines[i])
+            i += 1
+            continue
+        end_idx: int | None = None
+        for k in range(i + 1, n):
+            if hit.end in lines[k]:
+                end_idx = k
+                break
+        if end_idx is None:
+            stale.append(hit.name)
+            out.append(lines[i])
+            i += 1
+            continue
+        last = end_idx if hit.include_end else end_idx - 1
+        out.append(f"<<<WHITELISTED REGION: {hit.name}>>>\n")
+        i = last + 1
+    return out, stale
+
+
+def _diff(a: list[str], b: list[str], rel: str) -> str:
+    return "".join(
+        difflib.unified_diff(a, b, fromfile=f"chat/{rel}", tofile=f"voice/{rel}")
+    )
+
+
+def _resolve_roots(argv: list[str]) -> tuple[str, str]:
+    if len(argv) >= 2:
+        return os.path.abspath(argv[0]), os.path.abspath(argv[1])
+    env_chat = os.getenv("PARITY_CHAT_ROOT")
+    env_voice = os.getenv("PARITY_VOICE_ROOT")
+    if env_chat and env_voice:
+        return os.path.abspath(env_chat), os.path.abspath(env_voice)
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    parent = os.path.dirname(repo)
+    return os.path.join(parent, "amul-oan-api"), os.path.join(parent, "voice-oan-api")
+
+
+def main(argv: list[str]) -> int:
+    chat_root, voice_root = _resolve_roots(argv)
+    print(f"chat_root  = {chat_root}")
+    print(f"voice_root = {voice_root}")
+    for root in (chat_root, voice_root):
+        if not os.path.isdir(root):
+            print(f"ERROR: not a directory: {root}", file=sys.stderr)
+            return 2
+
+    failures = 0
+
+    print("\n== MUST-MATCH (byte-identical required) ==")
+    for rel in MUST_MATCH:
+        a = _read(os.path.join(chat_root, rel))
+        b = _read(os.path.join(voice_root, rel))
+        if a is None or b is None:
+            print(f"  FAIL  {rel}: missing (chat={a is not None}, voice={b is not None})")
+            failures += 1
+            continue
+        if a == b:
+            print(f"  OK    {rel}")
+        else:
+            print(f"  FAIL  {rel}: DIVERGED")
+            print(_diff(a, b, rel))
+            failures += 1
+
+    print("\n== TOLERATED: region-whitelisted (only named regions may differ) ==")
+    for rel, regions in REGION_TOLERATED.items():
+        a = _read(os.path.join(chat_root, rel))
+        b = _read(os.path.join(voice_root, rel))
+        if a is None or b is None:
+            print(f"  FAIL  {rel}: missing (chat={a is not None}, voice={b is not None})")
+            failures += 1
+            continue
+        ma, stale_a = _mask(a, regions)
+        mb, stale_b = _mask(b, regions)
+        stale = sorted(set(stale_a) | set(stale_b))
+        if stale:
+            print(f"  WARN  {rel}: whitelist anchors stale (region(s) not located): {stale}")
+        if ma == mb:
+            print(f"  OK    {rel}: differs ONLY inside whitelisted regions "
+                  f"({', '.join(r.name for r in regions)})")
+        else:
+            print(f"  FAIL  {rel}: UN-WHITELISTED divergence (outside {', '.join(r.name for r in regions)})")
+            print(_diff(ma, mb, rel + " [whitelisted regions masked]"))
+            failures += 1
+
+    print("\n== TOLERATED: whole-file divergence expected (informational only) ==")
+    for rel, reason in WHOLE_FILE_TOLERATED.items():
+        a = _read(os.path.join(chat_root, rel))
+        b = _read(os.path.join(voice_root, rel))
+        if a is None or b is None:
+            print(f"  WARN  {rel}: missing (chat={a is not None}, voice={b is not None})")
+            continue
+        if a == b:
+            print(f"  SAME  {rel}: identical (reason for tolerance: {reason})")
+        else:
+            n = len(list(difflib.unified_diff(a, b)))
+            print(f"  DIFF  {rel}: ~{n} diff lines — expected ({reason})")
+
+    print()
+    if failures:
+        print(f"PARITY CHECK FAILED: {failures} un-whitelisted divergence(s).")
+        return 1
+    print("PARITY CHECK PASSED: MUST-MATCH identical; tolerated files differ only where whitelisted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_llm_core.py
+++ b/tests/test_llm_core.py
@@ -249,6 +249,26 @@ def test_shim_pretranslation_and_post_translation(monkeypatch):
     assert post.model == "translategemma-27b-base"
 
 
+def test_shim_post_translation_tg_ttft_deadline(monkeypatch):
+    """TG carries a distinct SHORT first-token deadline (ttft_ms) separate from its
+    60s overall/total cap (timeout_ms); default 5000ms, overridable via env. The
+    managed overflow tier has none (it keeps only its own timeout)."""
+    monkeypatch.delenv("OSS_INFERENCE_ENDPOINT_URL", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("TRANSLATEGEMMA_27B_BASE_ENDPOINT", "http://localhost:18002/v1")
+
+    monkeypatch.delenv("FALLBACK_POST_TRANSLATION_TG_TTFT_MS", raising=False)
+    tiers = synthesize_from_env().defaults[Step.POST_TRANSLATION].tiers
+    tg, overflow = tiers[0], tiers[1]
+    assert tg.timeout_ms == 60000       # overall/total cap unchanged
+    assert tg.ttft_ms == 5000           # distinct short first-token deadline (default)
+    assert overflow.ttft_ms is None     # overflow keeps only its own timeout
+
+    monkeypatch.setenv("FALLBACK_POST_TRANSLATION_TG_TTFT_MS", "3500")
+    tg2 = synthesize_from_env().defaults[Step.POST_TRANSLATION].tiers[0]
+    assert tg2.ttft_ms == 3500 and tg2.timeout_ms == 60000
+
+
 def test_shim_agent_resolves_to_env_managed_tier(monkeypatch):
     """Resolver's AGENT primary reflects the env-synthesized managed tier
     (provider + model come from LLM_PROVIDER / LLM_MODEL_NAME)."""

--- a/tests/test_post_translation_overflow.py
+++ b/tests/test_post_translation_overflow.py
@@ -1,9 +1,10 @@
 """Post-translation overflow: config-driven [TranslateGemma(LB), managed-LLM] chain (voice).
 
 Covers (no network — the aiohttp SSE + AsyncOpenAI stream are mocked):
-  * guards short-circuit WITHOUT any model call (same-lang / empty). Voice has NO
-    untranslatable-fragment guard (it never had one) — a pure-punctuation fragment
-    is NOT short-circuited here, unlike chat;
+  * guards short-circuit WITHOUT any model call (untranslatable / same-lang / empty);
+    voice now ports chat's degenerate-fragment guard — a pure-punctuation chunk like
+    "**" is returned verbatim with NO model call (the prescribed fix for the TG
+    appended-garbage chunk hallucination, since voice translates per streaming chunk);
   * the voice per-chunk transform pipeline (_fix_dandas ->
     _post_normalize_gu_translation(strip_outer=False) ->
     normalize_voice_output(streaming=True)) is applied identically on the
@@ -187,9 +188,23 @@ class _FakeTier:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 1. Guards short-circuit WITHOUT a model call (voice: same-lang + empty ONLY).
-#    Voice has NO untranslatable-fragment guard — do NOT assert "**" short-circuits.
+# 1. Guards short-circuit WITHOUT a model call (untranslatable / same-lang / empty).
+#    Voice now ports chat's degenerate-fragment guard ("**" -> verbatim, no model).
 # ══════════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_stream_untranslatable_yields_verbatim_no_model_call(monkeypatch):
+    """Ported guard: a pure-punctuation fragment ("**") short-circuits verbatim in
+    BOTH the streaming and unary paths, WITHOUT resolving or calling any model — the
+    prescribed fix for the TG appended-garbage chunk hallucination in voice."""
+    monkeypatch.setattr(
+        tr._llm_resolver, "resolve_chain",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no chain for untranslatable")),
+    )
+    chunks = [c async for c in tr.translate_text_stream_fast("**", "english", "gujarati")]
+    assert chunks == ["**"]
+    assert await tr.translate_text("**", "english", "gujarati") == "**"
+
+
 @pytest.mark.asyncio
 async def test_stream_same_lang_yields_verbatim_no_model_call(monkeypatch):
     monkeypatch.setattr(
@@ -212,7 +227,7 @@ async def test_stream_empty_returns_nothing(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_unary_guards_short_circuit(monkeypatch):
-    # Voice guards: same-lang + empty. (No untranslatable-fragment guard.)
+    # Voice guards: same-lang + empty (untranslatable "**" covered separately above).
     monkeypatch.setattr(
         tr._llm_resolver, "resolve_chain",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("no chain for guard")),
@@ -567,3 +582,85 @@ async def test_walk_tg_serves_never_builds_overflow(monkeypatch):
         [tg, llm], make_stream, source_lang="english", target_lang="gujarati")]
     assert out == ["ok"]
     assert llm._memo == []  # overflow handle never built
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 9. Review fixes: distinct TG first-token deadline (ttft) + health-prune wiring
+# ══════════════════════════════════════════════════════════════════════════════
+def _tg_inert_ttft():
+    return Tier(provider=Provider.TRANSLATEGEMMA, model="tg", endpoint="http://lb/v1",
+                api_style=ApiStyle.TEXT_COMPLETION, timeout_ms=60000, ttft_ms=5000,
+                label="translategemma")
+
+
+def test_post_translation_tier_carries_distinct_ttft():
+    """_PostTranslationTier exposes ttft (the SHORT first-token bound) alongside the
+    unchanged timeout (the overall/total cap). The overflow tier (no ttft_ms) -> None."""
+    pt = tr._PostTranslationTier(_tg_inert_ttft())
+    assert pt.timeout == 60.0     # overall/total cap unchanged
+    assert pt.ttft == 5.0         # distinct short first-token deadline
+    assert tr._PostTranslationTier(_unbuildable_llm_inert()).ttft is None
+
+
+@pytest.mark.asyncio
+async def test_stream_walker_bounds_first_token_by_ttft_not_total(monkeypatch):
+    """The stream walker hands with_first_token_deadline the tier's SHORT ttft as the
+    bound (NOT the 60s total), while preserving kind/endpoint for its telemetry."""
+    captured = {}
+
+    def fake_deadline(attempt, agen):
+        captured["timeout"] = attempt.timeout
+        captured["endpoint"] = attempt.endpoint
+        captured["kind"] = attempt.kind
+        return agen
+
+    monkeypatch.setattr(tr, "_with_first_token_deadline", fake_deadline)
+    tg = tr._PostTranslationTier(_tg_inert_ttft())
+    out = [c async for c in tr._stream_post_translation_chain(
+        [tg], lambda tier: _agen("ok"), source_lang="english", target_lang="gujarati")]
+    assert out == ["ok"]
+    assert captured["timeout"] == 5.0              # ttft, NOT the 60s total cap
+    assert captured["endpoint"] == "http://lb/v1"  # tier identity preserved for errors
+    assert captured["kind"] == "managed"
+
+
+@pytest.mark.asyncio
+async def test_stream_walker_ttft_falls_back_to_timeout_when_unset(monkeypatch):
+    """A tier without ttft (the managed overflow) bounds first-token by its own timeout."""
+    captured = {}
+
+    def fake_deadline(attempt, agen):
+        captured["timeout"] = attempt.timeout
+        return agen
+
+    monkeypatch.setattr(tr, "_with_first_token_deadline", fake_deadline)
+    llm = tr._PostTranslationTier(_unbuildable_llm_inert())  # timeout_ms=30000, no ttft
+    out = [c async for c in tr._stream_post_translation_chain(
+        [llm], lambda tier: _agen("ok"), source_lang="english", target_lang="gujarati")]
+    assert out == ["ok"]
+    assert captured["timeout"] == 30.0
+
+
+def test_post_translation_chain_invokes_health_prune(monkeypatch, _managed_pipeline):
+    """_post_translation_chain routes the INERT tiers through health.prune_unhealthy
+    BEFORE wrapping them — so a down TG is pruned at resolve time, not re-discovered
+    (and re-timed-out) every turn. Proven by a prune that drops the TG tier."""
+    seen = {}
+
+    def fake_prune(step, tiers):
+        seen["step"] = step
+        seen["endpoints"] = [t.endpoint for t in tiers]  # inert Tiers, pre-wrap
+        return [t for t in tiers if t.provider is not Provider.TRANSLATEGEMMA]
+
+    monkeypatch.setattr(tr._llm_health, "prune_unhealthy", fake_prune)
+    chain = tr._post_translation_chain()
+    assert seen["step"] is Step.POST_TRANSLATION
+    assert "http://lb/v1" in seen["endpoints"]
+    assert [t.provider for t in chain] == ["openai"]  # TG pruned, overflow kept
+
+
+def test_post_translation_chain_prune_noop_when_flags_off(_managed_pipeline):
+    """Flags-off path is byte-identical: the real prune is a settings-gated identity,
+    so the full [TG, overflow] chain survives unchanged."""
+    chain = tr._post_translation_chain()
+    assert [t.provider for t in chain] == ["translategemma", "openai"]


### PR DESCRIPTION
## review2 hardening — birds-eye review fixes + chaos-validated on dev

Implements the fixes from the second birds-eye review (7 fable + 2 codex agents), built by 5 parallel file-disjoint agents and kept identical across both repos. **Deployed to dev and chaos-tested** (agent failover, TG fast-overflow, concurrency shed, session-% split, posture hard-gate, `/metrics`).

### Observability (B)
New `app/metrics.py` (graceful — no-op without `prometheus_client`) + `GET /metrics`: `llm_served_total` (the "% served by managed" KPI), `llm_fallback_total`, `llm_health_breaker_state`, `llm_concurrency_deprioritized_total`, `llm_concurrency_inflight`. **Multiprocess mode** (`PROMETHEUS_MULTIPROC_DIR`) so multi-worker uvicorn aggregates correctly.

### Fallback engine (G/F/D)
- **G:** `BREAKER_EVIDENCE` decoupled from `FALLBACKABLE` — a caller `TypeError` or 4xx context-overflow (→UNKNOWN) no longer poisons the OSS breaker.
- **F:** managed-tier admission semaphore (`MANAGED_MAX_CONCURRENCY`, fail-open) + one bounded `Retry-After`-honoring retry on a last-tier 429.
- **D:** commit-on-first-AGENT-ACTIVITY (`AGENT_ACTIVITY` sentinel via `agent.iter()`) so a slow tool can't spuriously fall back and **re-run side-effecting tools (duplicate bookings)** or poison the breaker.

### Health / concurrency
Rolling-window failure-rate (brownout) breaker; single half-open probe + cooldown refresh; Prometheus fleet-aggregate gauge (`CONCURRENCY_PROMETHEUS_URL`) fixing the least_conn single-replica bias; probabilistic proportional shed.

### Post-translation (C/H)
Health-prune the post-translation chain; distinct short TG first-token deadline (`FALLBACK_POST_TRANSLATION_TG_TTFT_MS`, 5s) vs the 60s total so a saturated TG overflows fast; `record_served` + dropped the profile clobber; ported `_is_untranslatable_fragment` guard to voice.

### Ops (E/H)
ARMED/DISARMED boot posture + `REQUIRE_OVERFLOW_ARMED` hard-gate; flipped `FALLBACK_ENABLED` default → true (pipeline is the only path post-P4); deleted placebo kill-switch docs; `scripts/check_pipeline_parity.py` cross-repo drift guard.

### Chaos-found + fixed
1. **Posture hard-gate was swallowed** by main.py's best-effort `configure()` try/except → `runtime.BootRefused` re-raised at the call site (now `Application startup failed. Exiting.`).
2. **`/metrics` under-counted** across uvicorn's 2 workers → prometheus multiprocess mode; validated all series aggregate.

### Validation
Tests: chat 146 / voice 150 green (+ 4 pre-existing `agents.suggestions` combined-run import failures, also on base). Live dev: staged deploy, D agent-streaming validated on pydantic-ai 1.x, full chaos battery passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)