### PR TITLE
loan: pin bank-name Gujarati transliteration (voice)

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -194,28 +194,57 @@ GU_POLICY_REPLACEMENTS = _build_gu_policy_replacements(GU_TERM_POLICY)
 GU_POST_REPLACEMENTS = GU_POST_REPLACEMENTS_BASE + GU_POLICY_REPLACEMENTS
 
 
-# ── Protected proper nouns: pinned Gujarati rendering (not free-translated) ─────
-# Long named entities (e.g. a full bank name) can't be pinned via the glossary
-# (its selector only builds 1–4 word spans). Instead we substitute the English
-# term with its fixed Gujarati form in the SOURCE before translation: MT models
-# preserve text already in the target language, so the pinned rendering passes
-# through unchanged while the surrounding English is translated normally.
-# No-op for non-gu targets or when the term is absent.
-_PROTECTED_GU_TERMS = {
-    "Kheda District Central Co-Operative Bank Limited - Nadiad":
+# ── Protected proper nouns: pin a fixed Gujarati rendering ──────────────────────
+# A long named entity (e.g. a full bank name) can't be pinned by pre-substitution
+# (the translator RE-TRANSLATES target-language text) nor by a sentinel (dropped in
+# streaming). So we let it translate naturally and REPLACE the model's rendering with
+# the pinned form via a regex covering the model's variants. Applied on the full text
+# (unary) or through a lookback buffer (streaming) so a multi-token name is matched
+# before it is flushed. Gated on the English source containing the term, so ordinary
+# traffic is never buffered or altered.
+_PROTECTED_OUTPUT = [
+    (
+        "Kheda District Central Co-Operative Bank Limited - Nadiad",
+        re.compile(
+            r"ખેડા\s+(?:જિલ્લા|ડિસ્ટ્રિક્ટ)\s+"
+            r"(?:કેન્દ્રીય\s+|મધ્યસ્થ\s+|સેન્ટ્રલ\s+)?"
+            r"(?:સહકારી|કો-?ઓપરેટિવ)\s+બેંક\s+લિમિટેડ\s*-?\s*નડિયાદ"
+        ),
         "ખેડા ડિસ્ટ્રિક્ટ સેન્ટ્રલ કો-ઓપરેટિવ બેંક લિમિટેડ - નડિયાદ",
-}
+    ),
+]
+# Chars to hold back in streaming so a forming match completes before flushing
+# (> the longest model rendering of any protected term).
+_PROTECTED_STREAM_HOLDBACK = 80
 
 
-def _apply_protected_gu_terms(text: str, target_lang: str) -> str:
-    """Swap protected English proper nouns for their pinned Gujarati form before
-    a gu translation, so the model never re-translates or mangles them."""
-    if not text or target_lang.lower() not in ("gujarati", "gu"):
-        return text
-    for en, gu in _PROTECTED_GU_TERMS.items():
-        if en in text:
-            text = text.replace(en, gu)
+def _protected_output_triggers(source_text: str, target_lang: str):
+    """Regex/pinned pairs whose English trigger appears in the source (gu target only)."""
+    if not source_text or target_lang.lower() not in ("gujarati", "gu"):
+        return []
+    return [(rx, pinned) for en, rx, pinned in _PROTECTED_OUTPUT if en in source_text]
+
+
+def _apply_protected_output(text: str, triggers) -> str:
+    for rx, pinned in triggers:
+        text = rx.sub(pinned, text)
     return text
+
+
+async def _buffered_protected_stream(stream, triggers):
+    """Yield chunks while replacing protected renderings across chunk boundaries:
+    hold back a tail long enough to contain a forming match, replace on the buffer,
+    emit the safe prefix, and flush the remainder at the end."""
+    buf = ""
+    async for chunk in stream:
+        buf += chunk
+        buf = _apply_protected_output(buf, triggers)
+        if len(buf) > _PROTECTED_STREAM_HOLDBACK:
+            yield buf[:-_PROTECTED_STREAM_HOLDBACK]
+            buf = buf[-_PROTECTED_STREAM_HOLDBACK:]
+    buf = _apply_protected_output(buf, triggers)
+    if buf:
+        yield buf
 
 # ── Gender-neutral caller-address guard ─────────────────────────────────────
 # Replace gendered address terms directed at the *caller* with neutral forms.
@@ -1067,7 +1096,7 @@ async def translate_text(
         logger.info("Source and target languages are the same, skipping translation")
         return text
 
-    text = _apply_protected_gu_terms(text, target_lang)
+    _prot = _protected_output_triggers(text, target_lang)
 
     instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
     logger.info(f"Translating {source_lang} -> {target_lang} via post-translation chain")
@@ -1083,7 +1112,8 @@ async def translate_text(
             tier.handle, tier.model_name, instruction, source_lang, target_lang, text, temperature, max_tokens
         )
 
-    return await _run_post_translation_chain(chain, _run)
+    result = await _run_post_translation_chain(chain, _run)
+    return _apply_protected_output(result, _prot)
 
 
 def _get_openai_client() -> AsyncOpenAI:
@@ -1570,7 +1600,7 @@ async def translate_text_stream_fast(
         yield text
         return
 
-    text = _apply_protected_gu_terms(text, target_lang)
+    _prot = _protected_output_triggers(text, target_lang)
 
     instruction, tg_prompt = _prepare_translation_inputs(text, source_lang, target_lang)
     logger.info(f"Fast streaming translation {source_lang} -> {target_lang} via post-translation chain")
@@ -1587,9 +1617,11 @@ async def translate_text_stream_fast(
         )
 
     try:
-        async for chunk in _stream_post_translation_chain(
+        base_stream = _stream_post_translation_chain(
             chain, _make_stream, source_lang=source_lang, target_lang=target_lang
-        ):
+        )
+        stream = _buffered_protected_stream(base_stream, _prot) if _prot else base_stream
+        async for chunk in stream:
             yield chunk
     except Exception as e:
         logger.error(f"Translation streaming error: {str(e)}")


### PR DESCRIPTION
Voice companion to amul-oan-api #153: gated output replacement pins the Gujarati transliteration (full-text unary / lookback-buffer streaming). Validated on TranslateGemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)