### PR TITLE
fix(loan): bound loan DB connection path (voice)

### DIFF
--- a/app/core/loan_db.py
+++ b/app/core/loan_db.py
@@ -42,6 +42,16 @@ def _get_sessionmaker() -> async_sessionmaker:
         settings.loan_db_url,
         pool_size=settings.loan_db_pool_size,
         pool_pre_ping=True,
+        # Bound every part of the connection path so a stale pooled connection
+        # (TCP flow silently dropped by NAT after hours idle) can never hang the
+        # request until nginx's 60s proxy-read-timeout kills the voice call:
+        #  - pool_recycle: drop+rebuild connections older than 5 min (< NAT idle window)
+        #  - pool_timeout: cap the wait for a free pooled slot
+        #  - connect_args (asyncpg): cap connect AND every statement (incl. the
+        #    pre_ping SELECT 1) so a dead socket errors fast and pre_ping reconnects.
+        pool_recycle=300,
+        pool_timeout=10,
+        connect_args={"timeout": 10, "command_timeout": 10},
         future=True,
     )
     _sessionmaker = async_sessionmaker(_engine, expire_on_commit=False, class_=AsyncSession)


### PR DESCRIPTION
Voice companion to amul-oan-api #155: adds pool_recycle/pool_timeout/asyncpg command_timeout to the loan engine so a stale connection can't hang the voice call until nginx's 60s cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)