### PR TITLE
fix(search): bound Marqo calls so a stalled TCP flow can't drop voice calls

### DIFF
--- a/agents/tools/search.py
+++ b/agents/tools/search.py
@@ -18,6 +18,19 @@ from app.observability import start_observation
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
+
+# Marqo's sync client has no client-side timeout; a stalled keep-alive TCP flow
+# (server healthy, but a pooled connection silently NAT-dropped) makes the blocking
+# call hang until nginx's 60s proxy-read-timeout drops the voice call. Bound every
+# Marqo call so it fails fast and the existing handlers degrade instead.
+_MARQO_TIMEOUT_S = float(os.getenv("MARQO_SEARCH_TIMEOUT_S", "15"))
+
+
+async def _to_thread_bounded(fn, *args):
+    """Run a blocking Marqo call in a worker thread, bounded by _MARQO_TIMEOUT_S.
+    On timeout raises asyncio.TimeoutError, which callers already treat like any other
+    Marqo failure (hybrid->tensor fallback, then the outer try's graceful degrade)."""
+    return await asyncio.wait_for(asyncio.to_thread(fn, *args), timeout=_MARQO_TIMEOUT_S)
 _index_capabilities_cache: Dict[str, Dict[str, Any]] = {}
 _TOKEN_RE = re.compile(r"[\w\-]+", re.UNICODE)
 _GUJARATI_CHAR_RE = re.compile(r"[\u0A80-\u0AFF]")
@@ -339,7 +352,7 @@ async def search_documents(
         if not index_name:
             raise ValueError("Marqo index name is required")
 
-        capabilities = await asyncio.to_thread(_get_index_capabilities_sync, endpoint_url, index_name)
+        capabilities = await _to_thread_bounded(_get_index_capabilities_sync, endpoint_url, index_name)
         if capabilities.get("exists"):
             logger.info(
                 "Index capabilities: tensor_fields=%s, text_tensor=%s, text_for_embedding_tensor=%s, has_is_reference=%s",
@@ -404,7 +417,7 @@ async def search_documents(
             },
         ) as observation:
             try:
-                results = await asyncio.to_thread(_marqo_search_sync, endpoint_url, index_name, search_params)
+                results = await _to_thread_bounded(_marqo_search_sync, endpoint_url, index_name, search_params)
             except Exception as e:
                 if search_mode == "hybrid":
                     logger.warning("Hybrid search failed, retrying with tensor search for query '%s'", query)
@@ -426,7 +439,7 @@ async def search_documents(
                                 "tool": "search_documents",
                             }
                         )
-                    results = await asyncio.to_thread(_marqo_search_sync, endpoint_url, index_name, fallback_params)
+                    results = await _to_thread_bounded(_marqo_search_sync, endpoint_url, index_name, fallback_params)
                 else:
                     if observation is not None:
                         observation.update(


### PR DESCRIPTION
## Problem
Voice turns calling `search_documents` hung ~59s and were killed by nginx `proxy-read-timeout: 60`, ending the call. The sync `marqo.Client` has **no client-side timeout**; run via `asyncio.to_thread` it blocks forever when a keep-alive TCP flow stalls — server is healthy (prod Marqo: ~243ms median, 5028/5028 HTTP 200 over 8h), it's a silently NAT-dropped pooled connection. The 20s TTFT deadline doesn't catch it (the tool-call event already satisfied it). Same class of bug as the loan-DB pool hang (fixed separately in amul-oan-api #155).

**Detection blind spot:** a 60s cut logs as HTTP 200 with `upstream_response_time: 60.0`, so it's invisible to the usual dashboards.

## Fix
Wrap the 3 Marqo calls (`_get_index_capabilities_sync`, primary + fallback `_marqo_search_sync`) in `asyncio.wait_for(_MARQO_TIMEOUT_S, default 15s)`. On timeout, callers already degrade (hybrid→tensor fallback, then the outer try). 15s ≫ 243ms median, ≪ 60s nginx cut.

## Known limitation / follow-up
`wait_for` cancels the await but the worker thread runs until the blocking call returns (TCP timeout, minutes) — a transient thread leak on the rare stall. A client-level HTTP timeout on `marqo.Client` would prevent that; left as follow-up. **Also:** chat `amul-oan-api` `search.py` has the same pattern (more call sites) — needs the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)