### PR TITLE
N-way routing + dynamic redis config + separate overflow model

### DIFF
--- a/.github/workflows/pipeline-parity.yml
+++ b/.github/workflows/pipeline-parity.yml
@@ -1,0 +1,85 @@
+name: LLM Pipeline Parity
+
+# Guards the unified LLM pipeline core that the voice (voice-oan-api) and chat
+# (amul-oan-api) repos each carry a copy of (app/llm_core/* + the shared fallback
+# walker app/services/fallback.py). Two gates:
+#   1. tests  — runs the llm_core pytest subset (breaker / concurrency / fallback /
+#               split / config); this runs from THIS repo alone.
+#   2. parity — runs scripts/check_pipeline_parity.py, which byte-compares the
+#               MUST-MATCH files and region-checks the tolerated ones across the two
+#               repos. It therefore needs BOTH repos checked out side by side; see the
+#               "Checkout sibling repo" step below.
+
+on:
+  push:
+    paths: &pipeline_paths
+      - "app/llm_core/**"
+      - "app/services/fallback.py"
+      - "app/services/moderation.py"
+      - "scripts/check_pipeline_parity.py"
+      - "scripts/set_pipeline_config.py"
+      - "tests/test_health.py"
+      - "tests/test_concurrency.py"
+      - "tests/test_fallback.py"
+      - "tests/test_split.py"
+      - "tests/test_llm_core.py"
+      - "tests/test_pipeline_trace.py"
+      - "tests/test_config_source.py"
+      - ".github/workflows/pipeline-parity.yml"
+  pull_request:
+    paths: *pipeline_paths
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run the llm_core pytest subset
+        env:
+          # Dummy keys: the factory reads these at import; no real client is built.
+          OPENAI_API_KEY: test-key
+          OSS_INFERENCE_API_KEY: test-oss-key
+        run: |
+          python -m pytest -q \
+            tests/test_health.py \
+            tests/test_concurrency.py \
+            tests/test_fallback.py \
+            tests/test_split.py \
+            tests/test_llm_core.py \
+            tests/test_pipeline_trace.py \
+            tests/test_config_source.py
+
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      # This repo (voice / voice-oan-api) -> ./voice-oan-api
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          path: voice-oan-api
+
+      # The parity script compares the two repos, so it needs the SIBLING (chat)
+      # repo checked out beside this one. The script takes the two roots as argv OR
+      # via PARITY_CHAT_ROOT / PARITY_VOICE_ROOT (used below). If the sibling repo is
+      # private, PARITY_SIBLING_TOKEN must be a PAT/token with read access to it.
+      - name: Checkout sibling repo (chat / amul-oan-api)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/amul-oan-api
+          ref: feat/nway-routing
+          path: amul-oan-api
+          token: ${{ secrets.PARITY_SIBLING_TOKEN }}
+
+      - name: Cross-repo parity check (needs both repos checked out)
+        env:
+          PARITY_CHAT_ROOT: ${{ github.workspace }}/amul-oan-api
+          PARITY_VOICE_ROOT: ${{ github.workspace }}/voice-oan-api
+        run: python voice-oan-api/scripts/check_pipeline_parity.py

--- a/.github/workflows/pipeline-parity.yml
+++ b/.github/workflows/pipeline-parity.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest pytest-asyncio
       - name: Run the llm_core pytest subset
         env:
           # Dummy keys: the factory reads these at import; no real client is built.
@@ -70,7 +71,10 @@ jobs:
       # repo checked out beside this one. The script takes the two roots as argv OR
       # via PARITY_CHAT_ROOT / PARITY_VOICE_ROOT (used below). If the sibling repo is
       # private, PARITY_SIBLING_TOKEN must be a PAT/token with read access to it.
+      # Non-fatal: without PARITY_SIBLING_TOKEN (private sibling) this can't check
+      # out, and the parity step below skips cleanly rather than failing the PR.
       - name: Checkout sibling repo (chat / amul-oan-api)
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/amul-oan-api
@@ -78,8 +82,13 @@ jobs:
           path: amul-oan-api
           token: ${{ secrets.PARITY_SIBLING_TOKEN }}
 
-      - name: Cross-repo parity check (needs both repos checked out)
+      - name: Cross-repo parity check (skips if sibling unavailable)
         env:
           PARITY_CHAT_ROOT: ${{ github.workspace }}/amul-oan-api
           PARITY_VOICE_ROOT: ${{ github.workspace }}/voice-oan-api
-        run: python voice-oan-api/scripts/check_pipeline_parity.py
+        run: |
+          if [ -d "$PARITY_CHAT_ROOT/app/llm_core" ]; then
+            python voice-oan-api/scripts/check_pipeline_parity.py
+          else
+            echo "::warning::sibling repo not checked out (set PARITY_SIBLING_TOKEN to enable); skipping cross-repo parity check"
+          fi

--- a/app/llm_core/concurrency.py
+++ b/app/llm_core/concurrency.py
@@ -250,12 +250,24 @@ async def reprioritize_by_load(
     * the probabilistic shed roll declines this call (below the ramp, or a losing
       draw inside the smooth band).
 
-    When the shed roll fires, the vLLM tiers are STABLY moved behind the non-vLLM
-    (managed) tiers, so the managed tier — already the next tier in the chain — is
-    tried first while the box is hot. In the single vLLM-primary + managed-fallback
-    config this is exactly "deprioritize the primary"; "primary" is only index 0,
-    and no primary/secondary inversion exists (see the module docstring). Shed
-    probability rises with load (``_shed_probability``): a self-proportioning
+    When the shed roll fires, WHERE the shed request is routed depends on the gate
+    (M3 — the overflow target is separately configurable, req #3 "set separately,
+    no mixing of variables from the session-% selection"):
+
+    * ``gate.overflow_tier`` is SET -> the shed request is routed to THAT
+      explicitly chosen model — independent of the session-% profile's own chain.
+      The overflow tier is moved to the FRONT (tried first), the original tiers
+      following as further fallback: ``[overflow_tier, *original]`` (deduped if the
+      overflow tier is already present, so it never appears twice).
+    * ``gate.overflow_tier`` is UNSET (``None``, the default) -> byte-identical to
+      the prior behaviour: the vLLM tiers are STABLY moved behind the non-vLLM
+      (managed) tiers, so the managed tier — already the next tier in the chain —
+      is tried first while the box is hot. In the single vLLM-primary +
+      managed-fallback config this is exactly "deprioritize the primary"; "primary"
+      is only index 0, and no primary/secondary inversion exists (see the module
+      docstring).
+
+    Shed probability rises with load (``_shed_probability``): a self-proportioning
     fraction near the cap, a hard 1.0 at/above it.
 
     Runs on the already-HEALTH-PRUNED inert ``Tier`` list, BEFORE materialize, so
@@ -300,6 +312,31 @@ async def reprioritize_by_load(
     if p <= 0.0 or random.random() >= p:
         _record(False)
         return tiers            # this call does not shed -> primary stays primary
+
+    # ── M3: separately-configurable overflow target ──────────────────────────
+    # The shed roll fired. WHERE the shed request goes depends on the gate:
+    #
+    #   * ``overflow_tier`` SET -> route the shed request to THAT explicitly chosen
+    #     model, independent of the session-% profile's own chain (req #3 "set
+    #     separately, no mixing"). Move the overflow tier to the FRONT (tried first)
+    #     with the original tiers following as further fallback -> [overflow, *orig].
+    #     Dedupe: if the overflow tier is already in the chain, it is lifted to the
+    #     front (removed from its old position) so it never appears twice.
+    #
+    #   * ``overflow_tier`` UNSET (None, the default) -> today's behaviour, byte-
+    #     identical: DEPRIORITIZE the saturated vLLM tier(s) behind the managed
+    #     tier(s) already sitting next in the profile's chain.
+    if gate.overflow_tier is not None:
+        overflow = gate.overflow_tier
+        reordered = [overflow] + [t for t in tiers if t != overflow]
+        logger.info(
+            "concurrency: step=%s vLLM gauge %d vs cap %d (p_shed=%.2f); routing shed request to configured overflow tier %s (front)",
+            getattr(step, "value", step), gauge, gate.max_concurrency, p,
+            getattr(overflow, "label", None) or getattr(overflow, "model", overflow),
+        )
+        _record(True)
+        metrics.record_deprioritized(step)  # no-op if prom lib absent; never raises
+        return reordered
 
     vllm = [t for t in tiers if _is_vllm(t)]
     others = [t for t in tiers if not _is_vllm(t)]

--- a/app/llm_core/config_model.py
+++ b/app/llm_core/config_model.py
@@ -92,10 +92,22 @@ class ConcurrencyGate(BaseModel):
     at/above which this step's vLLM tier is DEPRIORITIZED (reordered toward the
     back) so the managed tier is tried first under load. The gauge only reorders;
     it never drops a tier.
+
+    ``overflow_tier`` (M3) makes the concurrency-overflow target SEPARATELY
+    configurable — a specifically chosen overflow model, independent of the
+    session-% profile's own chain (req #3: "the overflow model is set separately —
+    no mixing of variables from the session-% selection"). It is a full ``Tier``
+    (provider/model/endpoint/api_key_env/timeout). When set AND the shed roll
+    fires, the shed request is routed to THAT tier (moved to the FRONT of the
+    chain, original tiers following as further fallback) rather than merely
+    deprioritizing the saturated vLLM tier behind the profile's managed fallback.
+    Left ``None`` (the default), behaviour is byte-identical to the reorder-behind-
+    managed shed — the overflow is the profile's own fallback, unchanged.
     """
 
     metrics_url: str
     max_concurrency: int = 10
+    overflow_tier: Optional[Tier] = None
 
     model_config = {"frozen": True}
 

--- a/app/llm_core/config_source.py
+++ b/app/llm_core/config_source.py
@@ -1,0 +1,235 @@
+"""M2: redis-backed LIVE pipeline-config source (no-redeploy % changes).
+
+The boot config (``runtime.configure`` — env-shim or ``PIPELINE_CONFIG_PATH``
+YAML) is the initial AND permanent fallback. This module lets an operator PUT a
+new :class:`PipelineConfig` into Redis and have ``get_pipeline()`` pick it up
+within a short TTL — WITHOUT a redeploy — so a weight change (e.g. an OSS profile
+0 -> 50%) goes live in seconds. Because ``split.deterministic_profile`` re-buckets
+every request against the CURRENT weights (no Redis session pin), continuing
+sessions FOLLOW the new % automatically (the refresh-on-change contract).
+
+Design
+------
+* **Redis key** ``llm_pipeline_config:{channel}`` holds the JSON of a
+  ``PipelineConfig`` (``model_dump(mode="json")``). Secrets are NEVER in it — a
+  tier only names its ``api_key_env``; the VALUE is read from the environment at
+  materialize time, exactly as for the boot config.
+* **channel** — ``PIPELINE_CHANNEL`` env, defaulting to the repo's identity
+  (``voice`` if the ``Step`` enum has the voice-only ``non_meaningful`` step,
+  else ``chat``) so each deployment self-identifies without any per-repo code
+  edit. Chat and voice therefore read DISTINCT keys off a shared Redis.
+* **TTL** — ``maybe_refresh`` is gated by ``time.monotonic()``: it touches Redis
+  at most once per ``PIPELINE_CONFIG_REFRESH_S`` (default 10s) window. Inside the
+  window it returns the caller's config unchanged (zero Redis I/O), so calling it
+  on every request is cheap.
+* **Fail-safe (never raises to the caller)** — on ANY failure (redis disabled,
+  client init error, redis down, missing key, invalid JSON, pydantic
+  ``ValidationError``, weights != 100) ``maybe_refresh`` returns the last-good
+  config unchanged and logs a rate-limited WARNING. The last successfully-loaded
+  config + last-refresh time are cached, so a redis blip leaves the last-good
+  config serving; nothing here can break a request path.
+* **Default OFF** — with ``PIPELINE_CONFIG_REDIS_ENABLED`` unset/false,
+  ``maybe_refresh`` is an immediate identity no-op (no redis client is even
+  built), so ``get_pipeline()`` is behaviorally identical to boot-config-only.
+
+Kept import-clean (stdlib + pydantic + ``config_model`` at import time; ``redis``
+and ``app.config`` are imported lazily inside the client builder) so it stays
+byte-identical across the chat and voice repos and the eventual repo-merge is a
+mechanical convergence. The synchronous ``redis`` client is deliberate:
+``get_pipeline()`` is sync and on the request path, and the read is TTL-gated to
+at most once per window with a short socket timeout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Optional
+
+from helpers.utils import get_logger
+from app.llm_core.config_model import PipelineConfig, Step
+
+logger = get_logger(__name__)
+
+# ── env knobs ────────────────────────────────────────────────────────────────
+ENABLED_ENV = "PIPELINE_CONFIG_REDIS_ENABLED"   # default off
+CHANNEL_ENV = "PIPELINE_CHANNEL"                # default self-identifies (chat/voice)
+REFRESH_ENV = "PIPELINE_CONFIG_REFRESH_S"       # TTL seconds, default 10
+
+_DEFAULT_REFRESH_S = 10.0
+_KEY_PREFIX = "llm_pipeline_config:"
+
+# Repo self-identification: the voice Step enum has the voice-only NON_MEANINGFUL
+# step, chat has SUGGESTIONS instead — so this one expression yields "voice" in
+# the voice repo and "chat" in the chat repo with ZERO per-repo code difference.
+_DEFAULT_CHANNEL = "voice" if hasattr(Step, "NON_MEANINGFUL") else "chat"
+
+# Rate-limit the fail-safe WARNING so a persistent redis/config fault (hit once
+# per TTL window) cannot spam the logs.
+_WARN_INTERVAL_S = 60.0
+
+# ── module state (cache) ─────────────────────────────────────────────────────
+_last_refresh_monotonic: float = 0.0   # 0.0 => never refreshed this process
+_last_good: Optional[PipelineConfig] = None
+_last_warn_monotonic: float = 0.0
+_redis_client = None                   # lazily built; None until first use
+_redis_init_failed: bool = False       # latch so we don't retry a broken import
+
+
+def _truthy(name: str) -> bool:
+    v = os.getenv(name)
+    return v is not None and v.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enabled() -> bool:
+    """Whether the live redis config source is turned on (default OFF)."""
+    return _truthy(ENABLED_ENV)
+
+
+def channel() -> str:
+    """The config channel this deployment reads — ``PIPELINE_CHANNEL`` or the
+    repo default (``chat`` / ``voice``). Chat and voice read distinct keys."""
+    v = os.getenv(CHANNEL_ENV)
+    v = v.strip() if v else ""
+    return v or _DEFAULT_CHANNEL
+
+
+def key(chan: Optional[str] = None) -> str:
+    """Redis key for a channel (defaults to this deployment's channel)."""
+    return f"{_KEY_PREFIX}{chan or channel()}"
+
+
+def refresh_interval_s() -> float:
+    """TTL window in seconds (``PIPELINE_CONFIG_REFRESH_S``, default 10). A bad or
+    negative value degrades to the default rather than raising."""
+    raw = os.getenv(REFRESH_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_REFRESH_S
+    try:
+        val = float(raw)
+    except ValueError:
+        return _DEFAULT_REFRESH_S
+    return val if val >= 0 else _DEFAULT_REFRESH_S
+
+
+def _warn(msg: str, *args) -> None:
+    """Rate-limited WARNING — at most once per ``_WARN_INTERVAL_S`` so a stuck
+    fault cannot spam the logs."""
+    global _last_warn_monotonic
+    now = time.monotonic()
+    if _last_warn_monotonic and (now - _last_warn_monotonic) < _WARN_INTERVAL_S:
+        return
+    _last_warn_monotonic = now
+    logger.warning(msg, *args)
+
+
+def build_redis_client():
+    """Build a synchronous redis client from the SAME connection env the app uses
+    (``app.config.settings`` — host/port/db/password), mirroring ``app.core.cache``
+    (``decode_responses=True``, short socket timeouts). Also used by the ops
+    script so the two never drift. Returns ``None`` if redis/config can't import
+    (never raises)."""
+    try:
+        import redis  # sync client; the app already depends on redis (redis.asyncio)
+        from app.config import settings
+
+        return redis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            db=settings.redis_db,
+            password=settings.redis_password,
+            socket_connect_timeout=settings.redis_socket_connect_timeout,
+            socket_timeout=settings.redis_socket_timeout,
+            decode_responses=True,
+        )
+    except Exception as e:  # import / settings failure -> fail-safe (no live source)
+        _warn("pipeline config: redis client build failed: %s", e)
+        return None
+
+
+def _get_redis():
+    """Lazily build + cache the sync redis client. Tests monkeypatch THIS function
+    (return a fake redis) so no real redis is contacted."""
+    global _redis_client, _redis_init_failed
+    if _redis_client is not None:
+        return _redis_client
+    if _redis_init_failed:
+        return None
+    client = build_redis_client()
+    if client is None:
+        _redis_init_failed = True
+        return None
+    _redis_client = client
+    return _redis_client
+
+
+def _try_load() -> Optional[PipelineConfig]:
+    """GET + parse + validate the live config, or ``None`` on ANY failure (the
+    fail-safe signal). Never raises."""
+    client = _get_redis()
+    if client is None:
+        return None
+    k = key()
+    try:
+        raw = client.get(k)
+    except Exception as e:  # redis down / timeout -> fail-safe
+        _warn("pipeline config: redis GET failed for %s: %s; keeping last-good", k, e)
+        return None
+    if raw is None:
+        return None  # key absent -> boot/last-good config stays; not worth warning
+    try:
+        data = json.loads(raw)
+        cfg = PipelineConfig(**data)  # validates weights==100 + unique names
+    except Exception as e:  # invalid JSON / ValidationError / weights!=100 -> fail-safe
+        _warn("pipeline config: invalid live config at %s (%s); keeping last-good", k, e)
+        return None
+    logger.info(
+        "pipeline config: loaded LIVE config from redis %s (profiles=%s)",
+        k, [f"{p.name}:{p.weight}" for p in cfg.profiles],
+    )
+    return cfg
+
+
+def maybe_refresh(current: PipelineConfig) -> PipelineConfig:
+    """Return the live config if the source is enabled and a valid one is present,
+    else ``current`` unchanged. TTL-gated (hits redis at most once per window) and
+    fail-safe (any error keeps the last-good config). NEVER raises.
+
+    Contract:
+      * source disabled -> immediate identity (no redis client built);
+      * within the TTL window -> return ``current`` (zero redis I/O — ``current``
+        is already the last-good config, since ``runtime`` stores our return);
+      * past the TTL -> GET the key; a valid config becomes the new last-good and
+        is returned; any failure keeps the last-good (``current``) serving.
+    """
+    global _last_refresh_monotonic, _last_good
+    if not enabled():
+        return current
+
+    now = time.monotonic()
+    if _last_refresh_monotonic and (now - _last_refresh_monotonic) < refresh_interval_s():
+        # TTL not elapsed: cheap no-op. `current` is what runtime last stored.
+        return current
+
+    _last_refresh_monotonic = now
+    loaded = _try_load()
+    if loaded is not None:
+        _last_good = loaded
+        return loaded
+    # Any failure: keep last-good. Prefer our cached last-good over `current` only
+    # if we somehow have a newer one; normally they are the same object.
+    return _last_good if _last_good is not None else current
+
+
+def reset() -> None:
+    """Clear cached state + client (TEST/ops helper — e.g. after flipping env vars
+    in a test, or to force the next ``maybe_refresh`` to re-read). Not called on
+    the request path."""
+    global _last_refresh_monotonic, _last_good, _last_warn_monotonic
+    global _redis_client, _redis_init_failed
+    _last_refresh_monotonic = 0.0
+    _last_good = None
+    _last_warn_monotonic = 0.0
+    _redis_client = None
+    _redis_init_failed = False

--- a/app/llm_core/config_source.py
+++ b/app/llm_core/config_source.py
@@ -19,15 +19,35 @@ Design
   else ``chat``) so each deployment self-identifies without any per-repo code
   edit. Chat and voice therefore read DISTINCT keys off a shared Redis.
 * **TTL** — ``maybe_refresh`` is gated by ``time.monotonic()``: it touches Redis
-  at most once per ``PIPELINE_CONFIG_REFRESH_S`` (default 10s) window. Inside the
+  at most once per ``PIPELINE_CONFIG_REFRESH_S`` (default 10s; a non-positive value
+  degrades to the default so it can never GET-per-request) window. Inside the
   window it returns the caller's config unchanged (zero Redis I/O), so calling it
   on every request is cheap.
-* **Fail-safe (never raises to the caller)** — on ANY failure (redis disabled,
-  client init error, redis down, missing key, invalid JSON, pydantic
-  ``ValidationError``, weights != 100) ``maybe_refresh`` returns the last-good
-  config unchanged and logs a rate-limited WARNING. The last successfully-loaded
-  config + last-refresh time are cached, so a redis blip leaves the last-good
-  config serving; nothing here can break a request path.
+* **Boot-time validation on the LIVE path (fail-CLOSED on bad content)** — a
+  live config is not merely schema-checked: after parse it is run through
+  ``runtime.validate_content`` (the SAME content gates the boot path applies —
+  provider/step legality + a resolvability probe that builds every profile/step
+  primary handle). A schema-valid but UNBUILDABLE config (vllm tier with no
+  endpoint, absent ``api_key_env``, anthropic/gemini on a RAW_OPENAI step, a
+  profile missing a required step) is therefore REJECTED — treated exactly like a
+  read failure (last-good kept, rate-limited WARNING) so a bad push can never go
+  live and break requests.
+* **Fail-safe (never raises to the caller)** — on a TRANSIENT read failure (redis
+  disabled, client init error, redis down, invalid JSON, ``ValidationError``,
+  weights != 100, content-invalid) ``maybe_refresh`` returns the last-good config
+  unchanged and logs a rate-limited WARNING. The last successfully-loaded config +
+  last-refresh time are cached, so a redis blip leaves the last-good config
+  serving; nothing here can break a request path.
+* **Clear / key-absent reverts to BOOT (emergency rollback)** — when the source is
+  ENABLED but the key is ABSENT (operator ran ``clear``, or it was never set),
+  ``maybe_refresh`` returns ``runtime.BOOT_PIPELINE`` — the config captured at
+  ``configure()`` BEFORE any live refresh — NOT the last LIVE config. So deleting
+  the key is a true rollback to the deploy's boot config. (A present-but-unreadable
+  key is a transient error, above, and keeps last-good — it does not nuke to boot.)
+* **Short dedicated socket timeout** — the config-source redis client is built with
+  its own short connect+socket timeout (``PIPELINE_CONFIG_REDIS_TIMEOUT_S``, default
+  0.5s), NOT the app-wide ``redis_socket_timeout`` (up to 10s), so a slow/down redis
+  costs the request hot path ≤0.5s per TTL window, not up to 10s.
 * **Default OFF** — with ``PIPELINE_CONFIG_REDIS_ENABLED`` unset/false,
   ``maybe_refresh`` is an immediate identity no-op (no redis client is even
   built), so ``get_pipeline()`` is behaviorally identical to boot-config-only.
@@ -56,9 +76,15 @@ logger = get_logger(__name__)
 ENABLED_ENV = "PIPELINE_CONFIG_REDIS_ENABLED"   # default off
 CHANNEL_ENV = "PIPELINE_CHANNEL"                # default self-identifies (chat/voice)
 REFRESH_ENV = "PIPELINE_CONFIG_REFRESH_S"       # TTL seconds, default 10
+TIMEOUT_ENV = "PIPELINE_CONFIG_REDIS_TIMEOUT_S" # dedicated short socket timeout, default 0.5s
 
 _DEFAULT_REFRESH_S = 10.0
+_DEFAULT_REDIS_TIMEOUT_S = 0.5
 _KEY_PREFIX = "llm_pipeline_config:"
+
+# Sentinel: the redis key is ABSENT (cleared / never-set) — distinct from both a
+# valid config and a transient read error (None). Signals a revert to BOOT.
+_KEY_ABSENT = object()
 
 # Repo self-identification: the voice Step enum has the voice-only NON_MEANINGFUL
 # step, chat has SUGGESTIONS instead — so this one expression yields "voice" in
@@ -75,6 +101,11 @@ _last_good: Optional[PipelineConfig] = None
 _last_warn_monotonic: float = 0.0
 _redis_client = None                   # lazily built; None until first use
 _redis_init_failed: bool = False       # latch so we don't retry a broken import
+# Reentrancy guard: the LIVE-path content validation (``runtime.validate_content``)
+# resolves the candidate config through ``resolver`` -> ``runtime.get_pipeline`` ->
+# back into ``maybe_refresh``. While that probe runs, ``maybe_refresh`` must be an
+# identity no-op (return ``current``) so it neither re-reads redis nor recurses.
+_suppress_refresh: bool = False
 
 
 def _truthy(name: str) -> bool:
@@ -102,7 +133,10 @@ def key(chan: Optional[str] = None) -> str:
 
 def refresh_interval_s() -> float:
     """TTL window in seconds (``PIPELINE_CONFIG_REFRESH_S``, default 10). A bad or
-    negative value degrades to the default rather than raising."""
+    NON-POSITIVE value degrades to the default rather than raising — a 0 (or
+    negative) window would otherwise GET redis on EVERY request (defeating the TTL
+    and putting a blocking read on every hot-path call), so clamp it to the
+    default."""
     raw = os.getenv(REFRESH_ENV)
     if raw is None or not raw.strip():
         return _DEFAULT_REFRESH_S
@@ -110,7 +144,23 @@ def refresh_interval_s() -> float:
         val = float(raw)
     except ValueError:
         return _DEFAULT_REFRESH_S
-    return val if val >= 0 else _DEFAULT_REFRESH_S
+    return val if val > 0 else _DEFAULT_REFRESH_S
+
+
+def redis_timeout_s() -> float:
+    """Dedicated SHORT connect+socket timeout for the config-source redis client
+    (``PIPELINE_CONFIG_REDIS_TIMEOUT_S``, default 0.5s). Deliberately independent of
+    the app-wide ``redis_socket_timeout`` (up to 10s): this read sits on the request
+    hot path (once per TTL window), so a slow/down redis must cost ≤0.5s, not 10s. A
+    bad or non-positive value degrades to the default rather than raising."""
+    raw = os.getenv(TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_REDIS_TIMEOUT_S
+    try:
+        val = float(raw)
+    except ValueError:
+        return _DEFAULT_REDIS_TIMEOUT_S
+    return val if val > 0 else _DEFAULT_REDIS_TIMEOUT_S
 
 
 def _warn(msg: str, *args) -> None:
@@ -126,21 +176,24 @@ def _warn(msg: str, *args) -> None:
 
 def build_redis_client():
     """Build a synchronous redis client from the SAME connection env the app uses
-    (``app.config.settings`` — host/port/db/password), mirroring ``app.core.cache``
-    (``decode_responses=True``, short socket timeouts). Also used by the ops
-    script so the two never drift. Returns ``None`` if redis/config can't import
-    (never raises)."""
+    (``app.config.settings`` — host/port/db/password), but with a DEDICATED short
+    connect+socket timeout (``redis_timeout_s()``, default 0.5s) rather than the
+    app-wide ``redis_socket_timeout`` — so a slow/down redis on the request hot path
+    costs ≤0.5s, not up to 10s. ``decode_responses=True`` mirrors ``app.core.cache``.
+    Also used by the ops script so the two never drift. Returns ``None`` if
+    redis/config can't import (never raises)."""
     try:
         import redis  # sync client; the app already depends on redis (redis.asyncio)
         from app.config import settings
 
+        timeout = redis_timeout_s()
         return redis.Redis(
             host=settings.redis_host,
             port=settings.redis_port,
             db=settings.redis_db,
             password=settings.redis_password,
-            socket_connect_timeout=settings.redis_socket_connect_timeout,
-            socket_timeout=settings.redis_socket_timeout,
+            socket_connect_timeout=timeout,
+            socket_timeout=timeout,
             decode_responses=True,
         )
     except Exception as e:  # import / settings failure -> fail-safe (no live source)
@@ -164,25 +217,45 @@ def _get_redis():
     return _redis_client
 
 
-def _try_load() -> Optional[PipelineConfig]:
-    """GET + parse + validate the live config, or ``None`` on ANY failure (the
-    fail-safe signal). Never raises."""
+def _try_load():
+    """GET + parse + fully validate the live config. Tri-state return (never raises):
+
+      * a :class:`PipelineConfig` — a valid, BUILDABLE live config to apply;
+      * ``_KEY_ABSENT`` — the key is absent (cleared / never-set): the caller must
+        revert to BOOT (not last-live);
+      * ``None`` — a TRANSIENT read failure (no client / redis down / invalid JSON /
+        weights!=100 / content-invalid): the caller keeps the last-good config.
+
+    Content validation makes the LIVE path FAIL-CLOSED: a schema-valid but
+    unbuildable config (``runtime.validate_content`` raises) is treated as a read
+    failure so it can never go live."""
     client = _get_redis()
     if client is None:
-        return None
+        return None  # no client -> transient; keep last-good
     k = key()
     try:
         raw = client.get(k)
-    except Exception as e:  # redis down / timeout -> fail-safe
+    except Exception as e:  # redis down / timeout -> transient; keep last-good
         _warn("pipeline config: redis GET failed for %s: %s; keeping last-good", k, e)
         return None
     if raw is None:
-        return None  # key absent -> boot/last-good config stays; not worth warning
+        return _KEY_ABSENT  # cleared / never-set -> caller reverts to BOOT
     try:
         data = json.loads(raw)
         cfg = PipelineConfig(**data)  # validates weights==100 + unique names
-    except Exception as e:  # invalid JSON / ValidationError / weights!=100 -> fail-safe
+    except Exception as e:  # invalid JSON / ValidationError / weights!=100 -> transient
         _warn("pipeline config: invalid live config at %s (%s); keeping last-good", k, e)
+        return None
+    # FAIL-CLOSED content gate: run the SAME checks the boot path applies (provider/
+    # step legality + a resolvability probe that builds each profile/step primary
+    # handle). A schema-valid but unbuildable config is rejected like a read failure
+    # so a bad push cannot go live. ``validate_content`` is per-repo in ``runtime``;
+    # calling ONLY it here keeps this module byte-identical across chat and voice.
+    try:
+        from app.llm_core import runtime
+        runtime.validate_content(cfg)
+    except Exception as e:  # unbuildable content -> fail-closed; keep last-good
+        _warn("pipeline config: content-invalid live config at %s (%s); keeping last-good", k, e)
         return None
     logger.info(
         "pipeline config: loaded LIVE config from redis %s (profiles=%s)",
@@ -193,17 +266,25 @@ def _try_load() -> Optional[PipelineConfig]:
 
 def maybe_refresh(current: PipelineConfig) -> PipelineConfig:
     """Return the live config if the source is enabled and a valid one is present,
-    else ``current`` unchanged. TTL-gated (hits redis at most once per window) and
-    fail-safe (any error keeps the last-good config). NEVER raises.
+    else the appropriate fallback. TTL-gated (hits redis at most once per window)
+    and fail-safe (never raises).
 
     Contract:
       * source disabled -> immediate identity (no redis client built);
+      * a validation probe is in flight (reentrant call) -> identity no-op;
       * within the TTL window -> return ``current`` (zero redis I/O — ``current``
         is already the last-good config, since ``runtime`` stores our return);
-      * past the TTL -> GET the key; a valid config becomes the new last-good and
-        is returned; any failure keeps the last-good (``current``) serving.
+      * past the TTL -> GET the key:
+          - a valid, BUILDABLE config becomes the new last-good and is returned;
+          - key ABSENT (cleared / never-set) -> ``runtime.BOOT_PIPELINE`` (revert to
+            the deploy's boot config — emergency rollback, NOT the last-live config);
+          - a transient failure (redis down / invalid / content-invalid) keeps the
+            last-good (``current``) serving.
     """
-    global _last_refresh_monotonic, _last_good
+    global _last_refresh_monotonic, _last_good, _suppress_refresh
+    if _suppress_refresh:
+        # Reentrant call from a content-validation probe: never re-read or recurse.
+        return current
     if not enabled():
         return current
 
@@ -213,12 +294,27 @@ def maybe_refresh(current: PipelineConfig) -> PipelineConfig:
         return current
 
     _last_refresh_monotonic = now
-    loaded = _try_load()
+    _suppress_refresh = True  # guard the validate_content probe inside _try_load
+    try:
+        loaded = _try_load()
+    finally:
+        _suppress_refresh = False
+
+    if loaded is _KEY_ABSENT:
+        # Cleared / never-set -> revert to the BOOT config (NOT the last LIVE one),
+        # so `clear` is a true emergency rollback. Guard against BOOT not yet
+        # captured (pre-configure) by degrading to `current`.
+        from app.llm_core import runtime
+        boot = runtime.BOOT_PIPELINE
+        if boot is not None:
+            _last_good = boot
+            return boot
+        return current
     if loaded is not None:
         _last_good = loaded
         return loaded
-    # Any failure: keep last-good. Prefer our cached last-good over `current` only
-    # if we somehow have a newer one; normally they are the same object.
+    # Transient failure: keep last-good. Prefer our cached last-good over `current`
+    # only if we somehow have a newer one; normally they are the same object.
     return _last_good if _last_good is not None else current
 
 
@@ -227,9 +323,10 @@ def reset() -> None:
     in a test, or to force the next ``maybe_refresh`` to re-read). Not called on
     the request path."""
     global _last_refresh_monotonic, _last_good, _last_warn_monotonic
-    global _redis_client, _redis_init_failed
+    global _redis_client, _redis_init_failed, _suppress_refresh
     _last_refresh_monotonic = 0.0
     _last_good = None
     _last_warn_monotonic = 0.0
     _redis_client = None
     _redis_init_failed = False
+    _suppress_refresh = False

--- a/app/llm_core/health.py
+++ b/app/llm_core/health.py
@@ -17,7 +17,14 @@ Two composable pieces feed one per-endpoint breaker, and one filter consumes it:
   A cooldown lets ONE half-open probe through (a single in-flight probe token —
   the FIRST caller after the cooldown probes; concurrent callers still see the
   endpoint open and are pruned, so the dead box is not re-flooded during the
-  probe window). A real success resets it ``closed`` immediately.
+  probe window). A real success resets it ``closed`` immediately. The probe token
+  is freed on ANY terminal outcome of the probed request: the fallback walkers
+  call ``release_probe`` in a ``finally`` for every chain tier, so a probe that
+  ended without a definitive success / ``BREAKER_EVIDENCE`` failure (a 4xx / caller
+  ``TypeError`` -> UNKNOWN, or BAD_OUTPUT) — or a probed tier a concurrency reorder
+  left unexecuted — cannot leak the token and pin the endpoint HALF_OPEN forever. A
+  ``HEALTH_PROBE_MAX_S`` time-box in ``is_open`` is the backstop that auto-releases
+  a lost token, so a recovered box can never be pruned forever.
 * **Active poller** (``app.tasks.health_poller``): periodically GETs the LB
   ``/health`` and reports ``record_healthy_poll`` / ``record_failed_poll``.
   Failback carries **hysteresis** — ``K`` consecutive healthy polls are required
@@ -82,6 +89,12 @@ class BreakerConfig:
     # this is purely the "40–60% flaky box that never trips consecutively" case.
     fail_rate_window: int = 20       # rolling outcome window size (0 disables the rate trip)
     fail_rate_threshold: float = 0.5  # failure share (>, strict) over a FULL window -> open
+    # Half-open probe time-box (backstop). A granted probe token is normally freed by
+    # the fallback walker's ``finally`` (``release_probe``) on ANY terminal outcome; if
+    # that release is ever missed (a lost token), ``is_open`` auto-releases the token
+    # after this many seconds so a recovered endpoint can be re-probed instead of
+    # staying HALF_OPEN (and thus pruned) forever.
+    probe_max_s: float = 30.0
 
 
 @dataclass
@@ -97,6 +110,10 @@ class _EndpointState:
     # probe after the cooldown elapsed. Concurrent callers see the endpoint as
     # still open (pruned) until the probe resolves (success->closed / failure->open).
     probe_in_flight: bool = False
+    # Monotonic timestamp when the current half-open probe token was granted; lets
+    # ``is_open`` time-box a lost probe (see BreakerConfig.probe_max_s). None whenever
+    # no probe is in flight.
+    probe_started_at: Optional[float] = None
 
 
 class HealthRegistry:
@@ -175,6 +192,7 @@ class HealthRegistry:
             st.state = BreakerState.OPEN
             st.opened_at = now
             st.probe_in_flight = False
+            st.probe_started_at = None
             self._emit(endpoint, BreakerState.OPEN)
             logger.warning("health: endpoint %s re-opened (half-open probe failed)", endpoint)
             return
@@ -217,12 +235,32 @@ class HealthRegistry:
         st.consecutive_failures = 0
         st.consecutive_healthy_polls = 0
         st.probe_in_flight = False
+        st.probe_started_at = None
         st.state = BreakerState.CLOSED
         st.opened_at = None
         self._push_outcome(st, ok=True)
         if was_open:
             self._emit(endpoint, BreakerState.CLOSED)
             logger.info("health: endpoint %s reset CLOSED on live success", endpoint)
+
+    def release_probe(self, endpoint: str) -> None:
+        """Idempotently free the single half-open probe token for ``endpoint``.
+
+        Called by the fallback walkers in a ``finally`` for every chain tier so a
+        probe granted by ``is_open`` (on the open->half_open transition) is released
+        no matter HOW the probed request ended — a clean success, ANY classified
+        failure, a caller cancellation, or a tier that never ran because a
+        concurrency reorder moved it and an earlier tier already returned/raised.
+        This ONLY clears the probe slot (and its time-box stamp); it deliberately
+        does NOT touch breaker state / counters / the rolling window, so it can never
+        perturb the ``record_success`` / ``record_failure`` transitions. No-op when no
+        probe is in flight (or the endpoint is unknown / untracked)."""
+        if not endpoint:
+            return
+        st = self._by_endpoint.get(endpoint)
+        if st is not None and st.probe_in_flight:
+            st.probe_in_flight = False
+            st.probe_started_at = None
 
     # ── active poller feed ───────────────────────────────────────────────────
     def record_healthy_poll(self, endpoint: str) -> None:
@@ -247,6 +285,7 @@ class HealthRegistry:
             st.consecutive_healthy_polls = 0
             st.opened_at = None
             st.probe_in_flight = False
+            st.probe_started_at = None
             self._emit(endpoint, BreakerState.CLOSED)
 
     def record_failed_poll(self, endpoint: str, *, now: Optional[float] = None) -> None:
@@ -276,16 +315,36 @@ class HealthRegistry:
             if st.opened_at is not None and (now - st.opened_at) >= self._config.cooldown_s:
                 st.state = BreakerState.HALF_OPEN
                 st.probe_in_flight = True          # grant the single probe to THIS caller
+                st.probe_started_at = now
                 self._emit(endpoint, BreakerState.HALF_OPEN)
                 logger.info("health: endpoint %s HALF_OPEN (cooldown elapsed, single probe allowed)", endpoint)
                 return False
             return True
         if st.state is BreakerState.HALF_OPEN:
+            now = time.monotonic() if now is None else now
+            # Time-box backstop: if the probe token has been held longer than
+            # ``probe_max_s`` the fallback walker's ``finally`` release was missed
+            # (a lost token). Auto-release it here so the endpoint is re-probed
+            # instead of staying HALF_OPEN — and thus pruned — forever (the exact
+            # failure this system prevents when the poller is off).
+            if (
+                st.probe_in_flight
+                and st.probe_started_at is not None
+                and (now - st.probe_started_at) >= self._config.probe_max_s
+            ):
+                st.probe_in_flight = False
+                st.probe_started_at = None
+                logger.warning(
+                    "health: endpoint %s half-open probe token timed out after %.0fs; "
+                    "auto-releasing (backstop)", endpoint, self._config.probe_max_s,
+                )
             if st.probe_in_flight:
                 return True                        # another caller holds the probe -> prune
-            # Probe token free (e.g. a prior probe resolved without a definitive
-            # success/failure) -> grant it to THIS caller.
+            # Probe token free (a prior probe resolved without a definitive
+            # success/failure, was released by the walker, or timed out above) ->
+            # grant it to THIS caller.
             st.probe_in_flight = True
+            st.probe_started_at = now
             return False
         return False
 
@@ -317,6 +376,7 @@ def _default_config() -> BreakerConfig:
         healthy_polls_required=settings.health_poller_healthy_polls,
         fail_rate_window=int(os.getenv("HEALTH_FAIL_RATE_WINDOW", "20")),
         fail_rate_threshold=float(os.getenv("HEALTH_FAIL_RATE_THRESHOLD", "0.5")),
+        probe_max_s=float(os.getenv("HEALTH_PROBE_MAX_S", "30")),
     )
 
 
@@ -347,6 +407,16 @@ def record_success(endpoint: str) -> None:
     if not settings.health_breaker_enabled:
         return
     _registry.record_success(endpoint)
+
+
+def release_probe(endpoint: str) -> None:
+    """Free any half-open probe token held for ``endpoint`` (idempotent).
+
+    Self-gated on the same flags that let ``prune_unhealthy`` grant a probe in the
+    first place, so the flags-off path stays byte-identical (no-op)."""
+    if not (settings.health_breaker_enabled or settings.health_poller_enabled):
+        return
+    _registry.release_probe(endpoint)
 
 
 def record_healthy_poll(endpoint: str) -> None:

--- a/app/llm_core/resolver.py
+++ b/app/llm_core/resolver.py
@@ -1,15 +1,15 @@
 """Resolver — the single seam the engine consumes (voice repo).
 
-``resolve_chain(step, variant)`` selects the profile for a session's resolved
-variant, looks up the step's tiers (profile override, else defaults), and
-materializes them into ``list[MaterializedTier]`` (primary first, never empty).
+``resolve_chain(step, profile_name)`` selects the named profile DIRECTLY, looks up
+the step's tiers (profile override, else defaults), and materializes them into
+``list[MaterializedTier]`` (primary first, never empty).
 
-P0 has **no weighted split yet**: the variant is resolved upstream exactly as
-today (``pipeline_router.resolve_pipeline_variant``) and passed in; here we just
-map ``variant -> profile`` ("oss" -> profile ``oss``, anything else -> ``managed``,
-fail-safe to managed when the OSS profile is absent). The chain shape ([oss,
-managed] for OSS, [managed] otherwise) matches ``fallback.attempt_chain`` so P1
-can drop the weighted split + config-driven tiers in behind this same API.
+The routing token is the actual profile NAME (the N-way split's output), selected
+via ``pipeline.by_name(profile_name)`` with a fail-safe to ``managed`` then
+``profiles[0]``. There is no longer a 2-way ``variant`` collapse: a 3rd profile
+(e.g. ``qwen``) is served with ITS tiers, not bucketed back to oss/managed. An
+absent/stale name resolves to ``managed`` — identical to the old variant mapping,
+so threading ``"oss"``/``"legacy"`` remains bit-identical (``"legacy"`` -> managed).
 
 Voice deviation from chat: ``MODERATION`` and ``NON_MEANINGFUL`` materialize to
 the RAW_OPENAI client kind (voice moderation / non-meaningful are bare
@@ -39,15 +39,21 @@ STEP_CLIENT_KIND: dict[Step, StepClientKind] = {
 }
 
 
-def _profile_name_for_variant(variant: str) -> str:
-    return "oss" if variant == "oss" else "managed"
+def _profile(pipeline, profile_name: str):
+    """The named profile, fail-safe to ``managed`` then ``profiles[0]``. An absent
+    name (e.g. the legacy ``"legacy"`` sentinel, or a stale/capped name) resolves to
+    ``managed`` — identical to the removed ``_profile_name_for_variant`` mapping."""
+    return pipeline.by_name(profile_name) or pipeline.by_name("managed") or pipeline.profiles[0]
 
 
-def resolve_chain(step: Step, variant: str = "legacy") -> list[MaterializedTier]:
-    """Materialized tier chain for a step under a session's resolved variant."""
+def resolve_chain(step: Step, profile_name: str = "managed") -> list[MaterializedTier]:
+    """Materialized tier chain for a step under a session's resolved profile NAME.
+
+    ``profile_name`` is the routing token (the actual configured profile name, e.g.
+    ``oss``/``managed``/``qwen``); the profile is selected DIRECTLY, so a 3rd profile
+    is served — not collapsed back to oss/managed via a variant string."""
     pipeline = runtime.get_pipeline()
-    name = _profile_name_for_variant(variant)
-    profile = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
+    profile = _profile(pipeline, profile_name)
 
     step_cfg = pipeline.step_config(profile, step)
     if step_cfg is None:
@@ -63,7 +69,7 @@ def resolve_chain(step: Step, variant: str = "legacy") -> list[MaterializedTier]
     return chain
 
 
-def post_translation_tiers(variant: str = "legacy") -> list[Tier]:
+def post_translation_tiers(profile_name: str = "managed") -> list[Tier]:
     """The INERT POST_TRANSLATION tier chain — NOT materialized.
 
     Post-translation is unique: TranslateGemma serves ~every turn, and its cheap
@@ -82,30 +88,30 @@ def post_translation_tiers(variant: str = "legacy") -> list[Tier]:
     the agent-step ``resolve_chain``) to "managed". The step chain is still recorded
     by the translation adapter's ``_post_translation_chain`` via ``record_step_chain``."""
     pipeline = runtime.get_pipeline()
-    name = _profile_name_for_variant(variant)
-    profile = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
+    profile = _profile(pipeline, profile_name)
     step_cfg = pipeline.step_config(profile, Step.POST_TRANSLATION)
     if step_cfg is None:
         raise ValueError("no config for step=post_translation")
     return list(step_cfg.tiers)
 
 
-def chain_for(step: Step, variant: str = "legacy") -> list[MaterializedTier]:
+def chain_for(step: Step, profile_name: str = "managed") -> list[MaterializedTier]:
     """Thin alias kept for the API shape P1 will generalize (weighted split)."""
-    return resolve_chain(step, variant)
+    return resolve_chain(step, profile_name)
 
 
-def primary_tier(step: Step, variant: str = "legacy") -> MaterializedTier:
-    """The primary (index-0) materialized tier — identity with today's
-    ``get_model_for_variant`` single-model selection at a non-fallback call site."""
-    return resolve_chain(step, variant)[0]
+def primary_tier(step: Step, profile_name: str = "managed") -> MaterializedTier:
+    """The primary (index-0) materialized tier for a session's resolved profile NAME
+    — identity with today's ``get_model_for_variant`` single-model selection at a
+    non-fallback call site, generalized to N profiles."""
+    return resolve_chain(step, profile_name)[0]
 
 
-def primary_handle(step: Step, variant: str = "legacy") -> Any:
+def primary_handle(step: Step, profile_name: str = "managed") -> Any:
     """Primary tier's live handle (pydantic-ai Model / AsyncOpenAI / TGDescriptor)."""
-    return primary_tier(step, variant).handle
+    return primary_tier(step, profile_name).handle
 
 
-def primary_provider(step: Step, variant: str = "legacy") -> str:
+def primary_provider(step: Step, profile_name: str = "managed") -> str:
     """Primary tier's provider string (identity with ``provider_for_variant``)."""
-    return primary_tier(step, variant).provider
+    return primary_tier(step, profile_name).provider

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -167,6 +167,21 @@ def configure(*, run_self_check: bool = True) -> PipelineConfig:
     # REQUIRE_OVERFLOW_ARMED). Placed after config load so a hard-gate raise fires
     # before the (non-fatal) self-check.
     _assert_boot_posture()
+    # M2: note whether the live redis-backed config source is enabled (default OFF).
+    # When on, weight changes PUT to the channel key take effect within the TTL with
+    # no redeploy; when off, get_pipeline() serves the boot config only.
+    from app.llm_core import config_source
+    if config_source.enabled():
+        logger.info(
+            "llm_core: live redis config source ENABLED (channel=%s key=%s refresh=%ss) "
+            "— weight changes PUT to that key take effect within the TTL, no redeploy",
+            config_source.channel(), config_source.key(), config_source.refresh_interval_s(),
+        )
+    else:
+        logger.info(
+            "llm_core: live redis config source disabled (%s unset) — serving boot config only",
+            config_source.ENABLED_ENV,
+        )
     if run_self_check:
         try:
             self_check()
@@ -176,9 +191,17 @@ def configure(*, run_self_check: bool = True) -> PipelineConfig:
 
 
 def get_pipeline() -> PipelineConfig:
+    global PIPELINE
     if PIPELINE is None:
         configure(run_self_check=False)
     assert PIPELINE is not None
+    # M2 (live config): consult the redis-backed source. TTL-gated (hits redis at
+    # most once per PIPELINE_CONFIG_REFRESH_S window) and fail-safe (any error ->
+    # returns the last-good PIPELINE unchanged, never raises). When
+    # PIPELINE_CONFIG_REDIS_ENABLED is unset/false this is an immediate identity
+    # no-op, so behaviour is byte-identical to boot-config-only.
+    from app.llm_core import config_source
+    PIPELINE = config_source.maybe_refresh(PIPELINE)
     return PIPELINE
 
 

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -26,6 +26,11 @@ from app.llm_core.legacy_shim import synthesize_from_env
 logger = get_logger(__name__)
 
 PIPELINE: Optional[PipelineConfig] = None
+# The config captured at ``configure()`` BEFORE any live (redis) refresh can
+# override it — the deploy's permanent boot fallback. ``config_source`` reverts to
+# THIS (not the last live config) when the live key is cleared/absent, so `clear`
+# is a true emergency rollback to the boot config.
+BOOT_PIPELINE: Optional[PipelineConfig] = None
 
 # Providers the RAW_OPENAI factory can actually build (bare AsyncOpenAI clients).
 # anthropic/gemini/translategemma are rejected for a RAW_OPENAI-kind step.
@@ -77,6 +82,47 @@ def validate_config(pipeline: PipelineConfig) -> None:
             "tier) to a supported provider. (anthropic/gemini RAW pretranslation is "
             "a tracked enhancement, not yet supported.)"
         )
+
+
+def validate_content(cfg: PipelineConfig) -> None:
+    """Run the SAME content gates the boot path applies against a CANDIDATE config
+    (a live redis config, or an ops-script payload) BEFORE it goes live — raising on
+    any unbuildable content. This is the single validator both ``config_source``
+    (fail-CLOSED live load) and ``scripts/set_pipeline_config.py`` (refuse-to-write)
+    call, so a schema-valid but unbuildable config can never go live and break
+    requests.
+
+    Two checks, mirroring boot:
+      (a) ``validate_config(cfg)`` — provider/step legality (an anthropic/gemini tier
+          on a RAW_OPENAI step, etc.); raises ``PipelineConfigError``; and
+      (b) a resolvability probe — for every profile, for every CONFIGURED step, build
+          the primary tier handle via ``resolver.primary_tier``; the factory raises on
+          an unbuildable tier (vllm tier with no endpoint, azure tier missing
+          api_key_env/api_version, etc.), exactly as the boot self-check would.
+
+    The resolver reads ``runtime.get_pipeline()``, so the probe is run with ``cfg``
+    temporarily installed as ``PIPELINE`` and the live source suppressed (so the
+    nested ``get_pipeline`` neither re-reads redis nor recurses); both are restored
+    in a ``finally``. Raises (never swallows) so callers can fail closed."""
+    global PIPELINE
+    validate_config(cfg)
+
+    from app.llm_core import resolver, config_source
+
+    prev_pipeline = PIPELINE
+    prev_suppress = config_source._suppress_refresh
+    PIPELINE = cfg
+    config_source._suppress_refresh = True
+    try:
+        for profile in cfg.profiles:
+            for step in Step:
+                if cfg.step_config(profile, step) is None:
+                    continue  # a profile need not configure every step (probe only what's set)
+                # Builds the primary handle; raises on an unbuildable tier.
+                resolver.primary_tier(step, profile.name)
+    finally:
+        config_source._suppress_refresh = prev_suppress
+        PIPELINE = prev_pipeline
 
 
 def _load_from_yaml(path: str) -> PipelineConfig:
@@ -143,7 +189,7 @@ def _assert_boot_posture() -> None:
 
 def configure(*, run_self_check: bool = True) -> PipelineConfig:
     """Load / synthesize the pipeline config, validate, store, self-check."""
-    global PIPELINE
+    global PIPELINE, BOOT_PIPELINE
     path = os.getenv("PIPELINE_CONFIG_PATH")
     if path and os.path.exists(path):
         logger.info("llm_core: loading pipeline config from %s", path)
@@ -158,6 +204,11 @@ def configure(*, run_self_check: bool = True) -> PipelineConfig:
     # P4 (the LLM_CORE_ENABLED kill-switch was removed), so this config always
     # drives requests and must always be buildable: validate unconditionally.
     validate_config(PIPELINE)
+    # Capture the boot config as the permanent fallback BEFORE any live redis
+    # refresh can override PIPELINE (get_pipeline -> config_source.maybe_refresh).
+    # config_source reverts to THIS on a cleared/absent live key (emergency
+    # rollback), never to a stale last-live config.
+    BOOT_PIPELINE = PIPELINE
     # Tracing-only: dump the COMPLETE loaded config (all profiles, step tiers,
     # triggers) as one structured boot log line so the full wiring is greppable
     # in logs even before any turn arrives (`grep llm_core.full_config`).

--- a/app/llm_core/runtime.py
+++ b/app/llm_core/runtime.py
@@ -208,13 +208,14 @@ def self_check() -> None:
     failures: list[str] = []
 
     for profile in pipeline.profiles:
-        variant = "oss" if profile.name == "oss" else "legacy"
         for step in Step:
             step_cfg = pipeline.step_config(profile, step)
             if step_cfg is None:
                 continue  # a profile need not configure every step (post-trans lives in defaults)
             try:
-                mt = resolver.primary_tier(step, variant)
+                # Resolve BY PROFILE NAME (N-way): a broken 3rd-profile tier (bad
+                # provider/endpoint/key) is caught here at boot, not just oss/managed.
+                mt = resolver.primary_tier(step, profile.name)
                 logger.info(
                     "llm_core self-check profile=%s step=%s -> provider=%s base_url=%s model=%s timeout=%s",
                     profile.name, step.value, mt.provider, _base_url(mt.handle), mt.model_name, mt.timeout,

--- a/app/llm_core/split.py
+++ b/app/llm_core/split.py
@@ -42,15 +42,6 @@ logger = get_logger(__name__)
 
 
 
-def profile_for_variant(variant: str) -> str:
-    """Inverse of :func:`variant_for_profile`: the profile a resolved legacy
-    ``"oss"``/``"legacy"`` variant selects — ``oss`` -> the OSS-primary profile
-    (``"oss"``), anything else -> the managed profile (``"managed"``). Mirrors
-    ``resolver._profile_name_for_variant`` so the router-resolved variant and the
-    fallback chain agree on the profile."""
-    return "oss" if variant == "oss" else "managed"
-
-
 def _bucket(session_id: str) -> int:
     """The exact bucket voice pipeline_router uses: 0-99 from a stable sha256 of
     the id. Kept character-for-character identical to
@@ -106,29 +97,29 @@ async def resolve_chain(
     step: Step,
     pipeline: Optional[PipelineConfig] = None,
     *,
-    variant: Optional[str] = None,
+    profile_name: Optional[str] = None,
 ) -> list[MaterializedTier]:
     """The P1 seam: (session, step) -> ordered materialized tier chain.
 
     Resolves the session's sticky weighted profile, looks up the step's tiers
     (profile override, else ``defaults``), and materializes them via the P0
     factory (primary first, never empty). This is the config-driven successor to
-    ``fallback.attempt_chain(variant, pipeline)``; ``MaterializedTier`` satisfies
-    the ``Attempt`` interface the fallback walkers read (``.kind`` / ``.model`` /
-    ``.model_name`` / ``.provider`` / ``.endpoint`` / ``.timeout``).
+    ``fallback.attempt_chain``; ``MaterializedTier`` satisfies the ``Attempt``
+    interface the fallback walkers read (``.kind`` / ``.model`` / ``.model_name`` /
+    ``.provider`` / ``.endpoint`` / ``.timeout``).
 
-    ``variant`` (when given) is the variant ALREADY resolved at the router seam
-    (``split.resolve_variant``): the profile is selected directly from it
-    (``profile_for_variant``) with NO independent re-bucketing, so the fallback
-    chain can never pick a different profile than the primary request path for the
-    same session id. When ``variant`` is None (direct callers / tests), the sticky
-    weighted profile is resolved from ``session_id`` as before.
+    ``profile_name`` (when given) is the profile NAME ALREADY resolved at the router
+    seam (``split.resolve_profile``): that profile is selected DIRECTLY (via
+    ``_profile_for``, fail-safe to managed) with NO independent re-bucketing, so the
+    fallback chain can never pick a different profile than the primary request path
+    for the same session id. When ``profile_name`` is None (direct callers / tests),
+    the sticky weighted profile is resolved from ``session_id`` as before.
 
     Fixed composition order (plan §2): health-prune -> concurrency-reorder ->
     materialize -> classify-walk."""
     pipeline = pipeline or runtime.get_pipeline()
-    if variant is not None:
-        name = profile_for_variant(variant)
+    if profile_name is not None:
+        name = profile_name
     else:
         name = await resolve_profile(session_id, pipeline)
     profile = _profile_for(pipeline, name)
@@ -163,24 +154,3 @@ async def resolve_chain(
     # tracing-only: the resolved primary tier + full chain for this step.
     _trace.record_step_chain(step, chain)
     return chain
-
-
-def variant_for_profile(name: str) -> str:
-    """Back-compat bridge: map a profile name to the legacy variant string the
-    downstream voice code still branches on (``is_oss`` / prompt selection /
-    token caps). The shim names the OSS profile ``oss`` and the closed-source
-    profile ``managed``; every non-``oss`` profile reads as ``legacy``. P4 removes
-    this bridge once downstream consumes the resolved profile/config directly."""
-    return "oss" if name == "oss" else "legacy"
-
-
-async def resolve_variant(
-    session_id: str, pipeline: Optional[PipelineConfig] = None
-) -> str:
-    """Weighted-split analog of ``pipeline_router.resolve_pipeline_variant``.
-
-    Same sticky assignment as :func:`resolve_profile`, mapped back to the legacy
-    ``"oss"``/``"legacy"`` variant string so the existing downstream code path is
-    unchanged. With the shim's seeded 2-profile config this is distribution-
-    identical to ``resolve_pipeline_variant`` (same bit-compatible bucket)."""
-    return variant_for_profile(await resolve_profile(session_id, pipeline))

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -83,7 +83,6 @@ class PipelineTrace:
     """Accumulates one turn's resolved profile, per-step tiers and trigger
     outcomes. Built by :func:`begin`; drained by :meth:`to_metadata`."""
 
-    variant: Optional[str] = None
     profile_name: Optional[str] = None
     profile_weight: Optional[int] = None
     steps: dict[str, StepRecord] = field(default_factory=dict)
@@ -105,7 +104,6 @@ class PipelineTrace:
             profile = {"name": self.profile_name, "weight": self.profile_weight}
         return {
             "profile": profile,
-            "variant": self.variant,
             "flags": self.flags,
             "steps": {name: rec.to_dict() for name, rec in self.steps.items()},
         }

--- a/app/llm_core/trace.py
+++ b/app/llm_core/trace.py
@@ -130,11 +130,13 @@ def snapshot_flags() -> dict:
     }
 
 
-def begin(variant: Optional[str] = None) -> PipelineTrace:
+def begin(profile_name: Optional[str] = None) -> PipelineTrace:
     """Open a fresh per-turn recorder and install it in the context. Idempotent
     per turn: the chat/voice request path calls this once, near the top, as soon
-    as the resolved variant is known."""
-    pt = PipelineTrace(variant=variant, flags=snapshot_flags())
+    as the resolved profile NAME is known. ``profile_name`` seeds the profile so
+    ``pipeline_profile`` lands even before ``populate``/``record_profile`` refine it
+    (with the authoritative weight)."""
+    pt = PipelineTrace(profile_name=profile_name, flags=snapshot_flags())
     _CTX.set(pt)
     return pt
 
@@ -195,27 +197,29 @@ def populate(
     pt: Optional[PipelineTrace],
     pipeline: Any,
     primary_tier_fn: Any,
-    variant: Optional[str],
+    profile_name: Optional[str],
     steps: Any,
 ) -> None:
     """Explicitly (contextvar-independent) populate the fields the emit MUST carry:
-    the resolved profile (from the pipeline + variant) and each step's PRIMARY tier
-    (resolved via ``primary_tier_fn(step, variant)``). Best-effort per step; a
-    resolve failure for one step is skipped, never raised into the request path.
+    the resolved profile (selected by NAME from the pipeline) and each step's PRIMARY
+    tier (resolved via ``primary_tier_fn(step, profile_name)``). Best-effort per step;
+    a resolve failure for one step is skipped, never raised into the request path.
 
-    ``pipeline`` and ``primary_tier_fn`` are passed in (duck-typed) so this module
-    stays import-clean — it never imports resolver/runtime itself."""
+    ``profile_name`` is the routing token (the actual profile name); the profile is
+    selected DIRECTLY (fail-safe to managed), so a 3rd profile records its own name +
+    weight instead of collapsing to oss/managed. ``pipeline`` and ``primary_tier_fn``
+    are passed in (duck-typed) so this module stays import-clean — it never imports
+    resolver/runtime itself."""
     if pt is None:
         return
     try:
-        name = "oss" if variant == "oss" else "managed"
-        prof = pipeline.by_name(name) or pipeline.by_name("managed") or pipeline.profiles[0]
+        prof = pipeline.by_name(profile_name) or pipeline.by_name("managed") or pipeline.profiles[0]
         set_profile(pt, prof.name, prof.weight)
     except Exception as e:  # pragma: no cover - defensive
         logger.debug("llm_core.trace: profile populate skipped: %s", e)
     for step in steps:
         try:
-            set_step_primary(pt, step, primary_tier_fn(step, variant))
+            set_step_primary(pt, step, primary_tier_fn(step, profile_name))
         except Exception:
             continue
 

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -66,10 +66,10 @@ async def voice_endpoint(
     logger.debug(f"Retrieved message history for session {session_id} - length: {len(history)}")
 
     # Sticky per-session routing via the unified weighted named-profile split
-    # (the only path). Mapped back to the "oss"/"legacy" variant string the
-    # downstream voice pipeline branches on. Distribution-identical to the removed
-    # pipeline_router (same sha256 bucket + Redis-sticky assignment).
-    pipeline_variant = await _llm_split.resolve_variant(session_id)
+    # (the only path). The routing token is the actual profile NAME (N-way), threaded
+    # downstream and served DIRECTLY (no oss/legacy collapse). Distribution-identical
+    # to the removed pipeline_router (same sha256 bucket assignment).
+    pipeline_profile = await _llm_split.resolve_profile(session_id)
 
     return StreamingResponse(
         stream_voice_message(
@@ -85,7 +85,7 @@ async def voice_endpoint(
             owner=owner,
             http_request=http_request,
             trace=trace,
-            pipeline_variant=pipeline_variant,
+            pipeline_profile=pipeline_profile,
         ),
         media_type='text/event-stream'
     )

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -177,11 +177,14 @@ async def _resolve_chain(*, pipeline: str, session_id: str, profile_name: str) -
     if step is not None:
         try:
             from app.llm_core import split
-            # Honor the profile NAME ALREADY resolved at the router (split.resolve_profile)
-            # with the SAME session id — the chain selects THAT profile directly, never
-            # independently re-buckets, so the fallback chain and the primary request
-            # path can't diverge onto different profiles.
-            return await split.resolve_chain(session_id, step, profile_name=profile_name)  # health-pruned inside
+            # (C) Honor the profile NAME the router already resolved from the FULL
+            # session id. The walkers receive a 200-char-capped session id, so
+            # re-bucketing here on that capped id could pick a different profile
+            # than the primary path — threading the name selects the same profile
+            # without a second (divergent) bucket.
+            return await split.resolve_chain(
+                session_id, step, profile_name=profile_name
+            )  # health-pruned inside
         except Exception as exc:  # never break the fallback path on a config edge
             logger.warning(
                 "fallback: config chain resolve failed (pipeline=%s): %s; "
@@ -383,68 +386,80 @@ async def execute_with_fallback(
     pretranslation safe-default, suggestions ``[]``) stays the terminal net.
     """
     chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, profile_name=profile_name)
-    for i, attempt in enumerate(chain):
-        is_last = i == len(chain) - 1
-        # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped.
-        sem = _get_managed_sem() if attempt.kind == "managed" else None
-        retried_rate_limit = False
-        while True:
-            t0 = time.monotonic()
-            acquired = False
-            try:
-                if sem is not None:
-                    acquired = await _acquire_managed_slot(sem)
-                if attempt.timeout is None:
-                    result = await run(attempt)
-                else:
-                    with anyio.fail_after(attempt.timeout):
+    try:
+        for i, attempt in enumerate(chain):
+            is_last = i == len(chain) - 1
+            # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped.
+            sem = _get_managed_sem() if attempt.kind == "managed" else None
+            retried_rate_limit = False
+            while True:
+                t0 = time.monotonic()
+                acquired = False
+                try:
+                    if sem is not None:
+                        acquired = await _acquire_managed_slot(sem)
+                    if attempt.timeout is None:
                         result = await run(attempt)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                reason = classify(exc)
-                will_fall_back = reason in FALLBACKABLE and not is_last
-                # (G) FALLBACKABLE decides fall-to-next-tier; only BREAKER_EVIDENCE
-                # (never UNKNOWN) feeds the health breaker, so a caller error / 4xx
-                # overflow can't trip the OSS breaker. Self-gated: a no-op unless
-                # HEALTH_BREAKER_ENABLED, so flag-off behaviour is identical.
-                if reason in BREAKER_EVIDENCE:
-                    health.record_failure(attempt.endpoint)
-                emit(
-                    FallbackEvent(
-                        pipeline=pipeline,
-                        session_id=session_id,
-                        from_variant=attempt.kind,
-                        to_variant=chain[i + 1].kind if will_fall_back else None,
-                        reason=reason,
-                        error_class=type(exc).__name__,
-                        error_detail=str(exc)[:500],
-                        oss_endpoint=attempt.endpoint,
-                        oss_model=attempt.model_name,
-                        latency_ms=int((time.monotonic() - t0) * 1000),
-                        fell_back=will_fall_back,
-                    )
-                )
-                # (F) Last tier hit 429 with nothing behind it: ONE bounded retry
-                # honoring Retry-After (capped + jittered) before giving up.
-                if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
-                    retried_rate_limit = True
-                    await asyncio.sleep(_retry_after_seconds(exc))
-                    continue
-                if not will_fall_back:
+                    else:
+                        with anyio.fail_after(attempt.timeout):
+                            result = await run(attempt)
+                except asyncio.CancelledError:
                     raise
-                break  # fall to the next tier
-            else:
-                # Clean success resets the breaker for this endpoint (P2). No-op unless
-                # HEALTH_BREAKER_ENABLED.
-                health.record_success(attempt.endpoint)
-                _record_served(pipeline, attempt.kind, i)
-                from app import metrics
-                metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
-                return result
-            finally:
-                if acquired:
-                    sem.release()
+                except Exception as exc:
+                    reason = classify(exc)
+                    will_fall_back = reason in FALLBACKABLE and not is_last
+                    # (G) FALLBACKABLE decides fall-to-next-tier; only BREAKER_EVIDENCE
+                    # (never UNKNOWN) feeds the health breaker, so a caller error / 4xx
+                    # overflow can't trip the OSS breaker. Self-gated: a no-op unless
+                    # HEALTH_BREAKER_ENABLED, so flag-off behaviour is identical.
+                    if reason in BREAKER_EVIDENCE:
+                        health.record_failure(attempt.endpoint)
+                    emit(
+                        FallbackEvent(
+                            pipeline=pipeline,
+                            session_id=session_id,
+                            from_variant=attempt.kind,
+                            to_variant=chain[i + 1].kind if will_fall_back else None,
+                            reason=reason,
+                            error_class=type(exc).__name__,
+                            error_detail=str(exc)[:500],
+                            oss_endpoint=attempt.endpoint,
+                            oss_model=attempt.model_name,
+                            latency_ms=int((time.monotonic() - t0) * 1000),
+                            fell_back=will_fall_back,
+                        )
+                    )
+                    # (F) Last tier hit 429 with nothing behind it: ONE bounded retry
+                    # honoring Retry-After (capped + jittered) before giving up.
+                    if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
+                        retried_rate_limit = True
+                        await asyncio.sleep(_retry_after_seconds(exc))
+                        continue
+                    if not will_fall_back:
+                        raise
+                    break  # fall to the next tier
+                else:
+                    # Clean success resets the breaker for this endpoint (P2). No-op unless
+                    # HEALTH_BREAKER_ENABLED.
+                    health.record_success(attempt.endpoint)
+                    _record_served(pipeline, attempt.kind, i)
+                    from app import metrics
+                    metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
+                    return result
+                finally:
+                    if acquired:
+                        sem.release()
+    finally:
+        # (Finding #3) Free any half-open probe token granted during chain resolution
+        # (``prune_unhealthy`` -> ``is_open``) for EVERY tier in the chain, no matter
+        # how the walk ended: a tier that succeeded / failed on any classified reason,
+        # a caller cancellation, OR a tier that never executed because an earlier tier
+        # returned/raised (a concurrency reorder can move the just-probed tier off
+        # index 0). ``release_probe`` is idempotent + self-gated (no-op unless a health
+        # flag is on) and only frees the probe slot — it never perturbs the
+        # record_success/record_failure breaker transitions above.
+        for _tier in chain:
+            health.release_probe(_tier.endpoint)
 
 
 async def with_first_token_deadline(attempt: MaterializedTier, agen: AsyncIterator[Any]) -> AsyncIterator[Any]:
@@ -556,100 +571,112 @@ async def stream_with_fallback(
     """
     chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, profile_name=profile_name)
     last_exc: Optional[BaseException] = None
-    for i, attempt in enumerate(chain):
-        is_last = i == len(chain) - 1
-        # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped. The slot
-        # is held for the whole managed stream and released in `finally` — including on
-        # a client disconnect / aclose, which unwinds through this frame's finally.
-        sem = _get_managed_sem() if attempt.kind == "managed" else None
-        retried_rate_limit = False
-        while True:
-            t0 = time.monotonic()
-            committed = False
-            acquired = False
+    try:
+        for i, attempt in enumerate(chain):
+            is_last = i == len(chain) - 1
+            # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped. The slot
+            # is held for the whole managed stream and released in `finally` — including on
+            # a client disconnect / aclose, which unwinds through this frame's finally.
+            sem = _get_managed_sem() if attempt.kind == "managed" else None
+            retried_rate_limit = False
+            while True:
+                t0 = time.monotonic()
+                committed = False
+                acquired = False
 
-            # IMPORTANT: consume make_stream here with a plain `async for` and never
-            # wrap THIS loop in an external timeout/cancel scope — pydantic-ai's
-            # run_stream opens an anyio cancel scope inside make_stream that stays open
-            # across the `yield`, so any scope spanning these yields unwinds out of order
-            # on aclose/disconnect ("cancel scope in a different task"). The plain
-            # semaphore `finally` below is NOT a cancel scope, so it is disconnect-safe.
-            # The time-to-first-token deadline is applied by callers wrapping make_stream
-            # in `with_first_token_deadline`, which isolates run_stream in its own task +
-            # queue precisely so no anyio scope is ever open at a `yield`.
-            try:
-                if sem is not None:
-                    acquired = await _acquire_managed_slot(sem)
-                async for chunk in make_stream(attempt):
-                    committed = True
-                    yield chunk
-                # Clean stream finish resets the breaker for this endpoint (P2).
-                health.record_success(attempt.endpoint)
-                _record_served(pipeline, attempt.kind, i)
-                from app import metrics
-                metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
-                return  # stream finished cleanly
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                reason = classify(exc)
-                if committed:
-                    # Client already received output — a transparent swap is impossible.
+                # IMPORTANT: consume make_stream here with a plain `async for` and never
+                # wrap THIS loop in an external timeout/cancel scope — pydantic-ai's
+                # run_stream opens an anyio cancel scope inside make_stream that stays open
+                # across the `yield`, so any scope spanning these yields unwinds out of order
+                # on aclose/disconnect ("cancel scope in a different task"). The plain
+                # semaphore `finally` below is NOT a cancel scope, so it is disconnect-safe.
+                # The time-to-first-token deadline is applied by callers wrapping make_stream
+                # in `with_first_token_deadline`, which isolates run_stream in its own task +
+                # queue precisely so no anyio scope is ever open at a `yield`.
+                try:
+                    if sem is not None:
+                        acquired = await _acquire_managed_slot(sem)
+                    async for chunk in make_stream(attempt):
+                        committed = True
+                        yield chunk
+                    # Clean stream finish resets the breaker for this endpoint (P2).
+                    health.record_success(attempt.endpoint)
+                    _record_served(pipeline, attempt.kind, i)
+                    from app import metrics
+                    metrics.record_served(pipeline, attempt.kind, attempt.provider, attempt.model_name)
+                    return  # stream finished cleanly
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    reason = classify(exc)
+                    if committed:
+                        # Client already received output — a transparent swap is impossible.
+                        emit(
+                            FallbackEvent(
+                                pipeline=pipeline,
+                                session_id=session_id,
+                                from_variant=attempt.kind,
+                                to_variant=None,
+                                reason=reason,
+                                error_class=type(exc).__name__,
+                                error_detail=str(exc)[:500],
+                                oss_endpoint=attempt.endpoint,
+                                oss_model=attempt.model_name,
+                                latency_ms=int((time.monotonic() - t0) * 1000),
+                                fell_back=False,
+                                committed=True,
+                            )
+                        )
+                        raise
+                    will_fall_back = reason in FALLBACKABLE and not is_last
+                    # (G) Only PRE-commit BREAKER_EVIDENCE feeds the breaker: a post-commit
+                    # failure (handled above) is NOT evidence — the box answered and
+                    # streamed tokens — and neither is UNKNOWN (a caller/context problem).
+                    # Self-gated (no-op unless HEALTH_BREAKER_ENABLED).
+                    if reason in BREAKER_EVIDENCE:
+                        health.record_failure(attempt.endpoint)
                     emit(
                         FallbackEvent(
                             pipeline=pipeline,
                             session_id=session_id,
                             from_variant=attempt.kind,
-                            to_variant=None,
+                            to_variant=chain[i + 1].kind if will_fall_back else None,
                             reason=reason,
                             error_class=type(exc).__name__,
                             error_detail=str(exc)[:500],
                             oss_endpoint=attempt.endpoint,
                             oss_model=attempt.model_name,
                             latency_ms=int((time.monotonic() - t0) * 1000),
-                            fell_back=False,
-                            committed=True,
+                            fell_back=will_fall_back,
+                            committed=False,
                         )
                     )
+                    last_exc = exc
+                    # (F) Last tier hit 429 pre-commit with nothing behind it: ONE bounded
+                    # retry honoring Retry-After. Safe because committed is False (no output
+                    # reached the caller), so the retried stream can't duplicate anything.
+                    if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
+                        retried_rate_limit = True
+                        await asyncio.sleep(_retry_after_seconds(exc))
+                        continue
+                    if will_fall_back:
+                        break  # fall to the next tier
                     raise
-                will_fall_back = reason in FALLBACKABLE and not is_last
-                # (G) Only PRE-commit BREAKER_EVIDENCE feeds the breaker: a post-commit
-                # failure (handled above) is NOT evidence — the box answered and
-                # streamed tokens — and neither is UNKNOWN (a caller/context problem).
-                # Self-gated (no-op unless HEALTH_BREAKER_ENABLED).
-                if reason in BREAKER_EVIDENCE:
-                    health.record_failure(attempt.endpoint)
-                emit(
-                    FallbackEvent(
-                        pipeline=pipeline,
-                        session_id=session_id,
-                        from_variant=attempt.kind,
-                        to_variant=chain[i + 1].kind if will_fall_back else None,
-                        reason=reason,
-                        error_class=type(exc).__name__,
-                        error_detail=str(exc)[:500],
-                        oss_endpoint=attempt.endpoint,
-                        oss_model=attempt.model_name,
-                        latency_ms=int((time.monotonic() - t0) * 1000),
-                        fell_back=will_fall_back,
-                        committed=False,
-                    )
-                )
-                last_exc = exc
-                # (F) Last tier hit 429 pre-commit with nothing behind it: ONE bounded
-                # retry honoring Retry-After. Safe because committed is False (no output
-                # reached the caller), so the retried stream can't duplicate anything.
-                if is_last and reason is FallbackReason.RATE_LIMITED and not retried_rate_limit:
-                    retried_rate_limit = True
-                    await asyncio.sleep(_retry_after_seconds(exc))
-                    continue
-                if will_fall_back:
-                    break  # fall to the next tier
-                raise
-            finally:
-                if acquired:
-                    sem.release()
+                finally:
+                    if acquired:
+                        sem.release()
 
+    finally:
+        # (Finding #3) Free any half-open probe token granted during chain
+        # resolution (``prune_unhealthy`` -> ``is_open``) for EVERY tier, no matter
+        # how the stream ended: a clean finish, any classified pre/post-commit
+        # failure, a client disconnect / aclose unwinding through here, OR a tier
+        # that never ran because an earlier tier committed/returned (a concurrency
+        # reorder can move the just-probed tier off index 0). ``release_probe`` is
+        # idempotent + self-gated and only frees the probe slot — it never perturbs
+        # the record_success/record_failure breaker transitions above.
+        for _tier in chain:
+            health.release_probe(_tier.endpoint)
     # All tiers failed before commit (every fallbackable tier swapped, last raised).
     if last_exc is not None:
         raise last_exc

--- a/app/services/fallback.py
+++ b/app/services/fallback.py
@@ -157,7 +157,7 @@ _PIPELINE_TO_STEP = {
 }
 
 
-async def _resolve_chain(*, pipeline: str, session_id: str, variant: str) -> list:
+async def _resolve_chain(*, pipeline: str, session_id: str, profile_name: str) -> list:
     """How the walkers receive their chain — always the config-driven pipeline.
 
     Resolves the session's sticky weighted profile, looks up the step's tiers, and
@@ -165,8 +165,8 @@ async def _resolve_chain(*, pipeline: str, session_id: str, variant: str) -> lis
     FILTER) and concurrency reordering happen inside ``split.resolve_chain`` — a
     no-op unless a HEALTH_* / CONCURRENCY_GAUGE flag is on.
 
-    ``variant`` is kept in the signature (walker call sites + telemetry) but the
-    chain is driven by the session's sticky profile, not the variant string.
+    ``profile_name`` is the routing token (the actual profile NAME) already resolved
+    at the router seam; the chain selects THAT profile directly.
 
     A config/Redis edge case must never break the fallback path: on any failure
     (or an unmapped pipeline) it degrades to the resolver's managed-tier chain for
@@ -177,11 +177,11 @@ async def _resolve_chain(*, pipeline: str, session_id: str, variant: str) -> lis
     if step is not None:
         try:
             from app.llm_core import split
-            # Honor the variant ALREADY resolved at the router (split.resolve_variant)
-            # with the SAME session id — the chain selects its profile from that
-            # variant, never independently re-buckets, so the fallback chain and the
-            # primary request path can't diverge onto different profiles.
-            return await split.resolve_chain(session_id, step, variant=variant)  # health-pruned inside
+            # Honor the profile NAME ALREADY resolved at the router (split.resolve_profile)
+            # with the SAME session id — the chain selects THAT profile directly, never
+            # independently re-buckets, so the fallback chain and the primary request
+            # path can't diverge onto different profiles.
+            return await split.resolve_chain(session_id, step, profile_name=profile_name)  # health-pruned inside
         except Exception as exc:  # never break the fallback path on a config edge
             logger.warning(
                 "fallback: config chain resolve failed (pipeline=%s): %s; "
@@ -190,7 +190,7 @@ async def _resolve_chain(*, pipeline: str, session_id: str, variant: str) -> lis
 
     from app.llm_core import resolver as _resolver
     degrade_step = step or Step.AGENT
-    return _resolver.resolve_chain(degrade_step, "legacy")
+    return _resolver.resolve_chain(degrade_step)
 
 
 @dataclass
@@ -370,7 +370,7 @@ async def execute_with_fallback(
     *,
     pipeline: str,
     session_id: str,
-    variant: str,
+    profile_name: str,
     run: Callable[[MaterializedTier], Awaitable[Any]],
 ) -> Any:
     """Run ``run(attempt)`` against each tier of the chain, falling back on a
@@ -382,7 +382,7 @@ async def execute_with_fallback(
     exhausted, so the caller's existing degrade path (moderation fail-closed,
     pretranslation safe-default, suggestions ``[]``) stays the terminal net.
     """
-    chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, variant=variant)
+    chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, profile_name=profile_name)
     for i, attempt in enumerate(chain):
         is_last = i == len(chain) - 1
         # (F) Cap concurrent MANAGED-tier admission; OSS tiers stay uncapped.
@@ -534,7 +534,7 @@ async def stream_with_fallback(
     *,
     pipeline: str,
     session_id: str,
-    variant: str,
+    profile_name: str,
     make_stream: Callable[[MaterializedTier], AsyncIterator[Any]],
 ) -> AsyncIterator[Any]:
     """Stream a chain tier with *first-token commit* semantics.
@@ -554,7 +554,7 @@ async def stream_with_fallback(
     Every classified failure is recorded via ``emit`` (``committed`` distinguishes
     pre- from post-commit).
     """
-    chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, variant=variant)
+    chain = await _resolve_chain(pipeline=pipeline, session_id=session_id, profile_name=profile_name)
     last_exc: Optional[BaseException] = None
     for i, attempt in enumerate(chain):
         is_last = i == len(chain) - 1

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -326,7 +326,20 @@ async def check_moderation(
     # unified config, so a 3rd profile's kind is honoured (vllm -> "oss"; managed
     # provider -> "managed"), not collapsed via a variant string. The actual walk
     # (execute_with_fallback) resolves the config-driven chain internally.
-    requested_kind = _llm_resolver.primary_tier(_LlmStep.MODERATION, profile_name).kind
+    #
+    # Finding voice#1 (fail-CLOSED): this resolution MUST NOT escape check_moderation.
+    # It sat outside the fail-closed try below, so a resolver error (e.g. an N-way
+    # config whose profile omits the ``moderation`` step -> ``resolve_chain`` raises
+    # ``ValueError("no config for step=moderation")``) propagated to voice's
+    # ``_resolve_moderation`` handler, which fails OPEN -> moderation bypassed. Default
+    # to a managed kind on ANY error: a managed default NEVER bypasses, and the walk
+    # below still fail-CLOSEs if every tier is unavailable.
+    try:
+        from app.llm_core import resolver as _llm_resolver
+        from app.llm_core.config_model import Step as _LlmStep
+        requested_kind = _llm_resolver.primary_tier(_LlmStep.MODERATION, profile_name).kind
+    except Exception:
+        requested_kind = "managed"
     _, requested_model, requested_provider = _client_model_for_kind(requested_kind)
     attempts: list[dict[str, object]] = []
     actual_tier = requested_kind

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -279,11 +279,11 @@ async def check_moderation(
     text: str,
     source_lang: str,
     recent_history_text: str = "",
-    variant: str = "legacy",
+    profile_name: str = "managed",
     session_id: str = "",
     user_id: str = "",
     process_id: str = "",
-    pipeline_variant: str = "",
+    pipeline_profile: str = "",
 ) -> ModerationVerdict:
     """Classify a caller utterance. Returns a ModerationVerdict.
 
@@ -319,14 +319,14 @@ async def check_moderation(
             session_id=session_id,
             user_id=user_id,
             process_id=process_id,
-            pipeline_variant=pipeline_variant,
+            pipeline_profile=pipeline_profile,
         )
 
-    # Requested (primary) tier for this session's variant. Identity with the
-    # removed ``attempt_chain(variant, "moderation")[0].kind``: an OSS session's
-    # primary is the vLLM tier, everything else is the managed tier. The actual
-    # walk (execute_with_fallback) resolves the config-driven chain internally.
-    requested_kind = "oss" if variant == "oss" else "managed"
+    # Requested (primary) tier for this session's profile — resolved by NAME from the
+    # unified config, so a 3rd profile's kind is honoured (vllm -> "oss"; managed
+    # provider -> "managed"), not collapsed via a variant string. The actual walk
+    # (execute_with_fallback) resolves the config-driven chain internally.
+    requested_kind = _llm_resolver.primary_tier(_LlmStep.MODERATION, profile_name).kind
     _, requested_model, requested_provider = _client_model_for_kind(requested_kind)
     attempts: list[dict[str, object]] = []
     actual_tier = requested_kind
@@ -363,7 +363,7 @@ async def check_moderation(
         verdict = await execute_with_fallback(
             pipeline="moderation",
             session_id=session_id or "",
-            variant=variant,
+            profile_name=profile_name,
             run=_run,
         )
         fallback_used = len(attempts) > 1 and attempts[0].get("status") == "error"
@@ -406,7 +406,7 @@ async def _check_moderation_legacy(
     session_id: str = "",
     user_id: str = "",
     process_id: str = "",
-    pipeline_variant: str = "",
+    pipeline_profile: str = "",
 ) -> ModerationVerdict:
     """Legacy moderation: single global provider (VOICE_MODERATION_PROVIDER),
     fails OPEN. Used when ``settings.fallback_enabled`` is false."""

--- a/app/services/non_meaningful.py
+++ b/app/services/non_meaningful.py
@@ -37,7 +37,7 @@ def _non_meaningful_client_and_model() -> tuple[AsyncOpenAI, str, str]:
     config synthesis. Fail-open behaviour is unchanged."""
     from app.llm_core import resolver as _llm_resolver
     from app.llm_core.config_model import Step as _LlmStep
-    mt = _llm_resolver.primary_tier(_LlmStep.NON_MEANINGFUL, "legacy")
+    mt = _llm_resolver.primary_tier(_LlmStep.NON_MEANINGFUL)  # profile-invariant (defaults)
     return mt.handle, mt.model_name, mt.provider
 
 

--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -609,7 +609,7 @@ def _post_translation_chain():
     is ``open`` and is contractually never-empty (all-open -> chain returned
     unchanged), and it is a settings-gated identity no-op when the health flags are
     off, so the flags-off path is byte-identical."""
-    tiers = _llm_resolver.post_translation_tiers("legacy")
+    tiers = _llm_resolver.post_translation_tiers()  # profile-invariant (lives in defaults)
     tiers = _llm_health.prune_unhealthy(_Step.POST_TRANSLATION, tiers)
     chain = [_PostTranslationTier(t) for t in tiers]
     _llm_trace.record_step_chain(_Step.POST_TRANSLATION, chain)
@@ -1469,7 +1469,7 @@ async def translate_to_english_with_gpt5_mini(
     session_id: str = "",
     user_id: str = "",
     process_id: str = "",
-    pipeline_variant: str = "",
+    pipeline_profile: str = "",
 ) -> str:
     """Pretranslate to English via the managed OpenAI client (legacy sessions).
 
@@ -1496,12 +1496,12 @@ async def translate_to_english_with_oss_vllm(
     session_id: str = "",
     user_id: str = "",
     process_id: str = "",
-    pipeline_variant: str = "",
+    pipeline_profile: str = "",
 ) -> str:
     """Pretranslate via the OSS vLLM endpoint (per-request, sticky 'oss' sessions).
 
     Thin wrapper over the unified ``_translate_to_english_pretranslation`` body;
-    supplies the OSS (client, model, label) + the ``pipeline_variant`` observation
+    supplies the OSS (client, model, label) + the ``pipeline_profile`` observation
     tag. Behaviour-identical to the former twin. Legacy sessions never hit this.
     """
     return await _translate_to_english_pretranslation(
@@ -1511,7 +1511,7 @@ async def translate_to_english_with_oss_vllm(
         model=OSS_PRETRANSLATION_MODEL,
         label="OSS vLLM",
         translation_provider_label="vllm",
-        extra_metadata={"pipeline_variant": pipeline_variant or "oss"},
+        extra_metadata={"pipeline_profile": pipeline_profile or "oss"},
         max_tokens=max_tokens,
     )
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -998,24 +998,25 @@ async def stream_voice_message(
     owner: Optional[SessionRequestOwner] = None,
     http_request: Optional[Request] = None,
     trace: Optional[VoiceTrace] = None,
-    pipeline_variant: str = "legacy",
+    pipeline_profile: str = "managed",
 #    background_tasks: BackgroundTasks,
 
 ) -> AsyncGenerator[str, None]:
     """Async generator for streaming chat messages."""
     request_started_at = time.monotonic()
-    # OSS sticky variant => run the dev OSS path (vLLM gemma agent + vLLM
-    # gemma pretranslation). 'legacy' keeps current prod behaviour byte-for-byte;
-    # with OSS_PIPELINE_PCT=0 (or OSS endpoint unset) every session is 'legacy'.
-    is_oss = pipeline_variant == "oss"
     # Model selection is resolved by the unified pipeline (the only path): the agent
     # handle, provider, and display model name all come from the resolved primary
-    # AGENT tier for this session's variant. For the current env this is the same
+    # AGENT tier for this session's profile NAME. For the current env this is the same
     # provider/base_url/model the removed get_model_for_variant/provider_for_variant
-    # returned, generalized to the weighted-profile split. ``is_oss`` is retained
-    # only as a variant-string flag for downstream tier-kind telemetry labels +
-    # pretranslation dispatch (it no longer selects the model).
-    _agent_tier = _llm_resolver.primary_tier(_LlmStep.AGENT, pipeline_variant)
+    # returned, generalized to the weighted-profile split.
+    _agent_tier = _llm_resolver.primary_tier(_LlmStep.AGENT, pipeline_profile)
+    # oss-vs-managed behavioural split from the resolved AGENT primary tier KIND, not
+    # a variant string: a vllm/self-hosted primary (gemma, qwen, ...) -> kind "oss";
+    # a managed provider (openai/anthropic/gemini) -> "managed". With the 2-way
+    # env-shim (profile named oss/managed) this equals the old
+    # ``pipeline_variant == "oss"`` bit exactly. Retained downstream for tier-kind
+    # telemetry labels + pretranslation dispatch (it no longer selects the model).
+    is_oss = _agent_tier.kind == "oss"
     request_model = _agent_tier.handle
     request_provider = _agent_tier.provider
     request_model_name = _agent_tier.model_name
@@ -1037,7 +1038,7 @@ async def stream_voice_message(
     # (Langfuse v4: "Operations that depend on an active span will be
     # skipped"; mirror of amul-oan-api#70).
     try:
-        trace.metadata["pipeline_variant"] = pipeline_variant
+        trace.metadata["pipeline_profile"] = pipeline_profile
         trace.metadata["request_model"] = request_model_name
         trace.metadata["request_provider"] = request_provider
     except Exception:  # pragma: no cover - never break the call
@@ -1052,9 +1053,9 @@ async def stream_voice_message(
         from app.llm_core import trace as _pipeline_trace
         from app.llm_core import resolver as _lr, runtime as _lrt
         from app.llm_core.config_model import Step as _LS
-        _pt = _pipeline_trace.begin(pipeline_variant)
+        _pt = _pipeline_trace.begin(pipeline_profile)
         _pipeline_trace.populate(
-            _pt, _lrt.get_pipeline(), _lr.primary_tier, pipeline_variant,
+            _pt, _lrt.get_pipeline(), _lr.primary_tier, pipeline_profile,
             (_LS.PRE_TRANSLATION, _LS.MODERATION, _LS.NON_MEANINGFUL, _LS.AGENT, _LS.POST_TRANSLATION),
         )
         _pipeline_trace.add_compact_metadata(_pt, trace.metadata)
@@ -1063,7 +1064,7 @@ async def stream_voice_message(
     logger.info(
         "voice request_variant session_id=%s variant=%s model=%s provider=%s",
         session_id,
-        pipeline_variant,
+        pipeline_profile,
         request_model_name,
         request_provider,
     )
@@ -1151,7 +1152,7 @@ async def stream_voice_message(
         # generator so downstream model calls and pydantic-ai spans nest under
         # this agent_journey.
         with trace.request_context():
-            # Emit the per-session pipeline_variant categorical score from
+            # Emit the per-session pipeline_profile categorical score from
             # *inside* the trace context (chat #70 fix). score_id is
             # deterministic per session so subsequent voice turns in the
             # same session upsert the same score (no duplicates).
@@ -1159,14 +1160,14 @@ async def stream_voice_message(
                 try:
                     _lf = _get_langfuse_client()
                     _lf.score_current_trace(
-                        name="pipeline_variant",
-                        value=pipeline_variant,
+                        name="pipeline_profile",
+                        value=pipeline_profile,
                         data_type="CATEGORICAL",
                         score_id=f"voice-variant-{(session_id or '')[:180]}",
                         comment="Sticky pipeline variant for this voice session",
                     )
                 except Exception as e:  # pragma: no cover
-                    logger.debug("Langfuse: voice pipeline_variant score failed: %s", e)
+                    logger.debug("Langfuse: voice pipeline_profile score failed: %s", e)
             requested_source_lang = (source_lang or "gu").strip().lower()
             requested_target_lang = (target_lang or "gu").strip().lower()
             trace.set_language(requested_source_lang, requested_target_lang)
@@ -1409,11 +1410,11 @@ async def stream_voice_message(
                     text=query,
                     source_lang=requested_source_lang,
                     recent_history_text=moderation_recent_history,
-                    variant=pipeline_variant,
+                    profile_name=pipeline_profile,
                     session_id=session_id,
                     user_id=user_id,
                     process_id=process_id or "",
-                    pipeline_variant=pipeline_variant,
+                    pipeline_profile=pipeline_profile,
                 )
             )
             moderation_task.add_done_callback(
@@ -1438,7 +1439,7 @@ async def stream_voice_message(
                 # OSS session's primary is the vLLM/OSS-model tier, else the
                 # managed/OpenAI-model tier). The per-attempt dispatch below routes
                 # to the OSS vs managed pretranslation twin by the tier kind.
-                _pre_mt = _llm_resolver.primary_tier(_LlmStep.PRE_TRANSLATION, pipeline_variant)
+                _pre_mt = _llm_resolver.primary_tier(_LlmStep.PRE_TRANSLATION, pipeline_profile)
                 _pretrans_provider_label = "vllm" if _pre_mt.kind == "oss" else "openai"
                 _pretrans_model = _pre_mt.model_name
                 _pretrans_requested_tier = _pre_mt.kind
@@ -1451,7 +1452,7 @@ async def stream_voice_message(
                     "Translation pipeline enabled; pretranslating %s -> en with %s (variant=%s)",
                     requested_source_lang,
                     _pretrans_model,
-                    pipeline_variant,
+                    pipeline_profile,
                 )
                 if await _request_is_stale("before_query_pretranslation"):
                     moderation_task.cancel()
@@ -1481,7 +1482,7 @@ async def stream_voice_message(
                                         session_id=session_id,
                                         user_id=user_id,
                                         process_id=process_id or "",
-                                        pipeline_variant=pipeline_variant,
+                                        pipeline_profile=pipeline_profile,
                                     )
                                 else:
                                     translated = await translate_to_english_with_gpt5_mini(
@@ -1490,7 +1491,7 @@ async def stream_voice_message(
                                         session_id=session_id,
                                         user_id=user_id,
                                         process_id=process_id or "",
-                                        pipeline_variant=pipeline_variant,
+                                        pipeline_profile=pipeline_profile,
                                     )
                             except Exception as _attempt_exc:
                                 attempt_info["status"] = "error"
@@ -1510,14 +1511,14 @@ async def stream_voice_message(
                             metadata={
                                 "provider": _pretrans_provider_label,
                                 "source_lang": requested_source_lang,
-                                "pipeline_variant": pipeline_variant,
+                                "pipeline_profile": pipeline_profile,
                             },
                             model=_pretrans_model,
                         ):
                             processing_query = await execute_with_fallback(
                                 pipeline="pretranslation",
                                 session_id=session_id,
-                                variant=pipeline_variant,
+                                profile_name=pipeline_profile,
                                 run=_run_pretranslation_attempt,
                             )
                         _pretranslation_fallback_used = (
@@ -1581,7 +1582,7 @@ async def stream_voice_message(
                             metadata={
                                 "provider": _pretrans_provider_label,
                                 "source_lang": requested_source_lang,
-                                "pipeline_variant": pipeline_variant,
+                                "pipeline_profile": pipeline_profile,
                             },
                             model=_pretrans_model,
                         ):
@@ -1592,7 +1593,7 @@ async def stream_voice_message(
                                     session_id=session_id,
                                     user_id=user_id,
                                     process_id=process_id or "",
-                                    pipeline_variant=pipeline_variant,
+                                    pipeline_profile=pipeline_profile,
                                 )
                             else:
                                 processing_query = await translate_to_english_with_gpt5_mini(
@@ -1601,7 +1602,7 @@ async def stream_voice_message(
                                     session_id=session_id,
                                     user_id=user_id,
                                     process_id=process_id or "",
-                                    pipeline_variant=pipeline_variant,
+                                    pipeline_profile=pipeline_profile,
                                 )
                         _legacy_primary_attempt["status"] = "ok"
                         _pretranslation_actual_tier = _pretrans_requested_tier
@@ -1791,7 +1792,7 @@ async def stream_voice_message(
                         "duration_ms": round(moderation_duration_ms, 2),
                         "status": moderation_status,
                         "source_lang": requested_source_lang,
-                        "pipeline_variant": pipeline_variant,
+                        "pipeline_profile": pipeline_profile,
                         "requested_tier": moderation_payload.get("requested_tier"),
                         "requested_provider": moderation_payload.get("requested_provider"),
                         "requested_model": moderation_payload.get("requested_model"),
@@ -2468,7 +2469,7 @@ async def stream_voice_message(
                     _src = stream_with_fallback(
                         pipeline="chat",
                         session_id=session_id,
-                        variant=pipeline_variant,
+                        profile_name=pipeline_profile,
                         make_stream=_make_stream,
                     ).__aiter__()
 
@@ -2627,7 +2628,7 @@ async def stream_voice_message(
                     (time.monotonic() - agent_started_at) * 1000.0,
                     signed_in=bool(signed_in and mobile),
                     request_limit=usage_limits.request_limit,
-                    pipeline_variant=pipeline_variant,
+                    pipeline_profile=pipeline_profile,
                     requested_tier=_agent_requested_tier,
                     requested_model=request_model_name,
                     requested_provider=request_provider,

--- a/app/services/voice_trace.py
+++ b/app/services/voice_trace.py
@@ -257,10 +257,10 @@ class VoiceTrace:
                     tags=[
                         "voice",
                         str(self.provider or "api"),
-                        # Mirror chat's `variant:<oss|legacy>` trace tag so voice
-                        # sessions are sliceable by pipeline variant in Langfuse.
-                        # pipeline_variant is set on metadata before this opens.
-                        f"variant:{self.metadata.get('pipeline_variant') or 'legacy'}",
+                        # Mirror chat's `pipeline_profile:<name>` trace tag so voice
+                        # sessions are sliceable per profile (N-way) in Langfuse.
+                        # pipeline_profile is set on metadata before this opens.
+                        f"pipeline_profile:{self.metadata.get('pipeline_profile') or 'managed'}",
                     ],
                     trace_name="agent_journey",
                 )

--- a/example.env
+++ b/example.env
@@ -24,6 +24,30 @@
 # deploy can never ship dark. The boot always logs a loud one-line posture summary:
 #   llm_core posture: overflow=ARMED fallback=on health_breaker=on health_poller=on concurrency=...
 # REQUIRE_OVERFLOW_ARMED=true
+#
+# ── M2: LIVE redis-backed config (no-redeploy % changes) ────────────────────
+# Turn this ON to change profile weights (and per-step tiers) at runtime WITHOUT a
+# redeploy. When enabled, get_pipeline() reads a PipelineConfig JSON from the Redis
+# key `llm_pipeline_config:<channel>` at most once per refresh window; a valid
+# config takes effect within the TTL and the deterministic split RE-BUCKETS
+# continuing sessions onto the new % (e.g. an OSS profile 0 -> 50% moves ~half of
+# in-flight sessions — no session is pinned). DEFAULT OFF: unset => get_pipeline()
+# serves the BOOT config only and behaves exactly as today. FAIL-SAFE: redis down /
+# missing key / invalid JSON / weights != 100 keep the last-good config, never
+# break a request, never raise. Secrets are NEVER in the key (tiers name
+# api_key_env only; values stay in this env).
+# PIPELINE_CONFIG_REDIS_ENABLED=false   # master switch (default off)
+# PIPELINE_CHANNEL=voice                # redis key suffix; defaults to this repo (voice)
+# PIPELINE_CONFIG_REFRESH_S=10          # TTL seconds — max staleness + redis read cadence
+#
+# Operator flow (uses the SAME redis env the app uses — REDIS_HOST/PORT/DB/PASSWORD):
+#   1. set PIPELINE_CONFIG_REDIS_ENABLED=true (one-time).
+#   2. edit weights (must sum to 100) into a PipelineConfig .json.
+#   3. python scripts/set_pipeline_config.py set voice ./new.json   # validates, then PUTs
+#   4. within ~PIPELINE_CONFIG_REFRESH_S the app reloads it live (grep log
+#      "pipeline config: loaded LIVE"); continuing sessions re-bucket, no redeploy.
+#   5. revert: python scripts/set_pipeline_config.py clear voice     # falls back to boot config
+#   (inspect: python scripts/set_pipeline_config.py get voice)
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Pre-flight health FILTER (per-endpoint circuit breaker). Two independent

--- a/pipeline.example.yaml
+++ b/pipeline.example.yaml
@@ -32,7 +32,19 @@ profiles:
         tiers:
           - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 8000,  label: gemma-agent}
           - {provider: openai, model: gpt-4.1,        api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
-        triggers: {ttft_deadline_ms: 8000}
+        # M3: the concurrency-overflow model is set SEPARATELY from the session-%
+        # selection ("no mixing of variables"). When the gemma vLLM box saturates
+        # (in-flight >= max_concurrency) and the probabilistic shed fires, the shed
+        # request is routed to THIS explicitly chosen overflow model — moved to the
+        # FRONT of the chain — NOT the profile's own managed fallback. It then falls
+        # back to the profile's chain. Independent of which profile the session %
+        # picked. Omit `overflow_tier` to keep the reorder-behind-managed default.
+        triggers:
+          ttft_deadline_ms: 8000
+          concurrency_gate:
+            metrics_url: http://gemma:8020/metrics
+            max_concurrency: 10
+            overflow_tier: {provider: openai, model: gpt-4o-mini, api_key_env: OPENAI_API_KEY, timeout_ms: 20000, label: concurrency-overflow}
       moderation:
         tiers:
           - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 5000,  label: gemma-moderation}

--- a/pipeline.example.yaml
+++ b/pipeline.example.yaml
@@ -1,0 +1,91 @@
+# Example N-way ("nxn") pipeline config for the VOICE repo.
+#
+# OPT-IN ONLY: this file is loaded ONLY when PIPELINE_CONFIG_PATH points at it.
+# Leave that env var UNSET to keep the env-shim default (OSS_PIPELINE_PCT ->
+# [oss, managed]) so prod/dev stay 2-way and byte-unchanged.
+#
+# It defines THREE weighted profiles, each served DIRECTLY by NAME (there is no
+# oss/managed 2-way collapse — a 3rd profile gets ITS own model):
+#   gemma (5%)  -> self-hosted vLLM gemma-4-31b-it   (agent tier kind = "oss")
+#   qwen  (10%) -> self-hosted vLLM qwen2.5-32b       (agent tier kind = "oss")
+#   gpt   (85%) -> managed OpenAI gpt-4.1             (agent tier kind = "managed")
+#
+# Weights MUST sum to 100 (enforced by PipelineConfig). Each vLLM profile's chain
+# is [its vLLM primary, managed OpenAI fallback]; the gpt profile is a single
+# managed tier. Post-translation (TranslateGemma) is profile-invariant and lives in
+# `defaults`. api_key_env NAMES the secret env var — the value is read at
+# materialize time and never stored here.
+#
+# Voice steps: agent / moderation / non_meaningful / pre_translation (+ post_translation
+# in defaults). Voice moderation + non_meaningful + pre_translation materialize as
+# RAW_OPENAI clients, so their tiers must be vllm / openai / azure-openai (never
+# anthropic/gemini). The chat repo swaps `non_meaningful` for `suggestions`.
+
+sticky_ttl_s: 604800
+fallback_enabled: true
+
+profiles:
+  - name: gemma
+    weight: 5
+    steps:
+      agent:
+        tiers:
+          - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 8000,  label: gemma-agent}
+          - {provider: openai, model: gpt-4.1,        api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+        triggers: {ttft_deadline_ms: 8000}
+      moderation:
+        tiers:
+          - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 5000,  label: gemma-moderation}
+          - {provider: openai, model: gpt-4.1,        api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+      non_meaningful:
+        tiers:
+          - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 5000,  label: gemma-non-meaningful}
+          - {provider: openai, model: gpt-4.1,        api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+      pre_translation:
+        tiers:
+          - {provider: vllm,   model: gemma-4-31b-it, endpoint: http://gemma:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 10000, label: gemma-pretranslation}
+          - {provider: openai, model: gpt-4.1-mini,   api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-pretranslation}
+
+  - name: qwen
+    weight: 10
+    steps:
+      agent:
+        tiers:
+          - {provider: vllm,   model: qwen2.5-32b-instruct, endpoint: http://qwen:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 8000,  label: qwen-agent}
+          - {provider: openai, model: gpt-4.1,              api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+        triggers: {ttft_deadline_ms: 8000}
+      moderation:
+        tiers:
+          - {provider: vllm,   model: qwen2.5-32b-instruct, endpoint: http://qwen:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 5000,  label: qwen-moderation}
+          - {provider: openai, model: gpt-4.1,              api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+      non_meaningful:
+        tiers:
+          - {provider: vllm,   model: qwen2.5-32b-instruct, endpoint: http://qwen:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 5000,  label: qwen-non-meaningful}
+          - {provider: openai, model: gpt-4.1,              api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-fallback}
+      pre_translation:
+        tiers:
+          - {provider: vllm,   model: qwen2.5-32b-instruct, endpoint: http://qwen:8020/v1, api_key_env: OSS_INFERENCE_API_KEY, timeout_ms: 10000, label: qwen-pretranslation}
+          - {provider: openai, model: gpt-4.1-mini,         api_key_env: OPENAI_API_KEY,     timeout_ms: 20000, label: managed-pretranslation}
+
+  - name: gpt
+    weight: 85
+    steps:
+      agent:
+        tiers:
+          - {provider: openai, model: gpt-4.1, api_key_env: OPENAI_API_KEY, timeout_ms: 20000, label: gpt-agent}
+        triggers: {ttft_deadline_ms: 20000}
+      moderation:
+        tiers:
+          - {provider: openai, model: gpt-4.1, api_key_env: OPENAI_API_KEY, timeout_ms: 20000, label: gpt-moderation}
+      non_meaningful:
+        tiers:
+          - {provider: openai, model: gpt-4.1, api_key_env: OPENAI_API_KEY, timeout_ms: 20000, label: gpt-non-meaningful}
+      pre_translation:
+        tiers:
+          - {provider: openai, model: gpt-4.1-mini, api_key_env: OPENAI_API_KEY, timeout_ms: 20000, label: gpt-pretranslation}
+
+defaults:
+  post_translation:
+    tiers:
+      - {provider: translategemma, model: translategemma-27b-base, endpoint: http://translategemma:18002/v1, api_style: text_completion, timeout_ms: 60000, ttft_ms: 5000, label: translategemma}
+      - {provider: openai,         model: gpt-4.1,                 api_key_env: OPENAI_API_KEY, api_style: chat, timeout_ms: 30000, label: llm-fallback}

--- a/scripts/check_pipeline_parity.py
+++ b/scripts/check_pipeline_parity.py
@@ -22,9 +22,11 @@ It splits the pipeline files into two sets:
     a ``non_meaningful`` step and RAW_OPENAI moderation). For these we still want
     to catch *unexpected* drift, so each file declares a WHITELIST of the regions
     that are ALLOWED to differ:
-      - "region-whitelisted" files (``config_model.py``, ``resolver.py``): only the
-        named regions (the ``Step`` enum / ``StepClientKind`` block; the
-        ``STEP_CLIENT_KIND`` map) may differ. Each whitelisted region is collapsed
+      - "region-whitelisted" files (``config_model.py``, ``resolver.py``,
+        ``fallback.py``): only the named regions (the ``Step`` enum /
+        ``StepClientKind`` block; the ``STEP_CLIENT_KIND`` map; the fallback
+        ``_PIPELINE_TO_STEP`` map + its docstring mention) may differ. Each
+        whitelisted region is collapsed
         to a single sentinel line in BOTH files and the REMAINDER is compared; a
         difference outside every whitelisted region is un-whitelisted drift and
         fails CI. If a whitelist anchor no longer matches (file restructured) the
@@ -38,10 +40,14 @@ WHY THE SPLIT IS SAFE
 =====================
 The MUST-MATCH set is chosen so that a divergence there is always a bug: the
 circuit breaker (``health.py``), the concurrency gauge (``concurrency.py``), the
-boot-config tracer (``trace.py``) and the fallback walker (``fallback.py``) encode
-shared cross-cutting behavior. The TOLERATED set is exactly the files whose
-per-repo divergence is a deliberate, documented product difference — and even those
-are pinned down to the specific regions allowed to move.
+boot-config tracer (``trace.py``), the pipeline config source (``config_source.py``)
+and the config-writer CLI (``set_pipeline_config.py``) encode shared cross-cutting
+behavior. The fallback walker (``fallback.py``) is region-tolerated rather than
+MUST-MATCH: it is byte-identical apart from the two spans that carry voice's lack of
+a ``suggestions`` pipeline (the ``_PIPELINE_TO_STEP`` map + a docstring mention), so a
+byte-compare could never pass — but every OTHER line is still pinned. The TOLERATED
+set is exactly the files whose per-repo divergence is a deliberate, documented product
+difference — and even those are pinned down to the specific regions allowed to move.
 
 USAGE
 =====
@@ -65,10 +71,15 @@ from dataclasses import dataclass
 
 # ── files that MUST stay byte-identical across the two repos ──────────────────
 MUST_MATCH: list[str] = [
-    "app/llm_core/health.py",       # P2 passive circuit breaker
-    "app/llm_core/concurrency.py",  # P3 concurrency gauge / reorder
-    "app/llm_core/trace.py",        # boot full-config tracer
-    "app/services/fallback.py",     # OSS->managed fallback walker
+    "app/llm_core/health.py",         # P2 passive circuit breaker
+    "app/llm_core/concurrency.py",    # P3 concurrency gauge / reorder
+    "app/llm_core/trace.py",          # boot full-config tracer
+    "app/llm_core/config_source.py",  # pipeline config source (its docstring claims byte-identity)
+    "scripts/set_pipeline_config.py", # config-writer CLI (its docstring claims byte-identity)
+    # NOTE: ``app/services/fallback.py`` is NOT here — it is region-tolerated below.
+    # It is otherwise byte-identical but voice has no ``suggestions`` pipeline, so two
+    # small spans (the ``_PIPELINE_TO_STEP`` map + a docstring mention) legitimately
+    # differ and would make a byte-compare fail forever.
 ]
 
 
@@ -106,6 +117,29 @@ REGION_TOLERATED: dict[str, list[Region]] = {
         # NON_MEANINGFUL are RAW_OPENAI-kind. This map is the single seam that
         # encodes that product difference.
         Region("STEP_CLIENT_KIND map", "STEP_CLIENT_KIND: dict", "}", include_end=True),
+    ],
+    "app/services/fallback.py": [
+        # The OSS->managed fallback WALKER is byte-identical EXCEPT for the fact that
+        # voice has no ``suggestions`` pipeline / ``Step.SUGGESTIONS``. Exactly two
+        # spans carry that single product difference:
+        #  (1) the ``_PIPELINE_TO_STEP`` map — chat maps ``"suggestions": Step.SUGGESTIONS``;
+        #      voice omits it (and carries a 2-line comment saying why). Anchored on the
+        #      shared comment line above the map so voice's extra comment lines are
+        #      absorbed into the region too.
+        Region(
+            "_PIPELINE_TO_STEP map (voice omits the suggestions->SUGGESTIONS entry)",
+            "MaterializedTier (the drop-in successor to the removed",
+            "}",
+            include_end=True,
+        ),
+        #  (2) the ``_resolve_chain`` docstring's terminal-net list — chat names
+        #      ``suggestions ``[]```; voice omits it (and re-wraps the line).
+        Region(
+            "_resolve_chain docstring terminal-net list (voice omits the suggestions mention)",
+            "so callers still get a non-empty chain and their terminal net",
+            'defence."""',
+            include_end=True,
+        ),
     ],
 }
 

--- a/scripts/set_pipeline_config.py
+++ b/scripts/set_pipeline_config.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Ops helper: PUT / GET / CLEAR the LIVE pipeline config in Redis (M2).
+
+The app's ``app/llm_core/config_source.py`` reads a ``PipelineConfig`` JSON from
+the Redis key ``llm_pipeline_config:{channel}`` and applies it within the refresh
+TTL (``PIPELINE_CONFIG_REFRESH_S``, default 10s) — WITHOUT a redeploy — provided
+the deployment has ``PIPELINE_CONFIG_REDIS_ENABLED=true``. Because the split
+re-buckets every request against the current weights, continuing sessions follow
+the new % automatically (e.g. an OSS profile 0 -> 50% moves ~half of them).
+
+This script uses the SAME redis connection env the app uses (via
+``config_source.build_redis_client()`` -> ``app.config.settings``) and validates
+with the SAME ``PipelineConfig`` model before writing, so an invalid config can
+never reach the key. Secrets are never in the config (tiers name ``api_key_env``
+only) — do not put key VALUES in the JSON.
+
+Usage
+-----
+    python scripts/set_pipeline_config.py set   <channel> <path-to-config.json>
+    python scripts/set_pipeline_config.py get   <channel>
+    python scripts/set_pipeline_config.py clear <channel>
+
+``<channel>`` is normally ``chat`` or ``voice`` (each app reads its own key). Omit
+nothing — the channel is explicit so you can target either service from one host.
+
+Exact ops flow (hot % change, no redeploy)
+------------------------------------------
+  1. Confirm the deployment is armed: ``PIPELINE_CONFIG_REDIS_ENABLED=true`` in
+     the app env (default OFF -> the app ignores the key entirely). One-time.
+  2. Capture the CURRENT boot config to edit from. Easiest source is the app's
+     boot log line ``llm_core.full_config`` / ``pipeline config: loaded LIVE ...``,
+     or hand-author a PipelineConfig JSON (profiles + weights + per-step tiers).
+  3. Edit the weights (they MUST sum to 100; names unique) and save to a .json.
+  4. ``python scripts/set_pipeline_config.py set <channel> ./new.json``
+     -> validates via PipelineConfig(**data); refuses to write if invalid.
+  5. Within ``PIPELINE_CONFIG_REFRESH_S`` (~10s) the app's get_pipeline() reloads
+     it; the split re-buckets continuing sessions onto the new %. Verify with
+     ``get <channel>`` and the app's ``pipeline config: loaded LIVE ...`` log.
+  6. To REVERT to the boot (env/YAML) config: ``clear <channel>`` deletes the key;
+     within the TTL the app falls back to its boot config (last-good until then).
+
+No real network is required to import this module; the redis client is built only
+when a subcommand runs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Make the repo root importable when run as ``python scripts/set_pipeline_config.py``.
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from app.llm_core import config_source
+from app.llm_core.config_model import PipelineConfig
+
+
+def _client():
+    client = config_source.build_redis_client()
+    if client is None:
+        print("ERROR: could not build a redis client (check app.config redis_* env)", file=sys.stderr)
+        raise SystemExit(2)
+    return client
+
+
+def cmd_set(channel: str, path: str) -> int:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        cfg = PipelineConfig(**data)  # validates weights==100 + unique profile names
+    except Exception as e:
+        print(f"REFUSED: invalid PipelineConfig in {path}: {e}", file=sys.stderr)
+        return 1
+    key = config_source.key(channel)
+    payload = json.dumps(cfg.model_dump(mode="json"))
+    _client().set(key, payload)
+    print(f"OK: set {key} ({len(payload)} bytes) profiles={[f'{p.name}:{p.weight}' for p in cfg.profiles]}")
+    print("   live within PIPELINE_CONFIG_REFRESH_S on any deployment with PIPELINE_CONFIG_REDIS_ENABLED=true")
+    return 0
+
+
+def cmd_get(channel: str) -> int:
+    key = config_source.key(channel)
+    raw = _client().get(key)
+    if raw is None:
+        print(f"(no live config at {key} — app is serving its boot config)")
+        return 0
+    try:
+        parsed = json.loads(raw)
+        print(json.dumps(parsed, indent=2, ensure_ascii=False))
+    except Exception:
+        print(raw)  # print whatever is there even if unparseable (aids debugging)
+    return 0
+
+
+def cmd_clear(channel: str) -> int:
+    key = config_source.key(channel)
+    deleted = _client().delete(key)
+    if deleted:
+        print(f"OK: cleared {key} — app reverts to its boot config within the TTL")
+    else:
+        print(f"(nothing to clear at {key})")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 3 and argv[1] == "set" and len(argv) == 4:
+        return cmd_set(argv[2], argv[3])
+    if len(argv) == 3 and argv[1] == "get":
+        return cmd_get(argv[2])
+    if len(argv) == 3 and argv[1] == "clear":
+        return cmd_clear(argv[2])
+    print(__doc__)
+    print("\nERROR: bad arguments.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/set_pipeline_config.py
+++ b/scripts/set_pipeline_config.py
@@ -10,9 +10,11 @@ the new % automatically (e.g. an OSS profile 0 -> 50% moves ~half of them).
 
 This script uses the SAME redis connection env the app uses (via
 ``config_source.build_redis_client()`` -> ``app.config.settings``) and validates
-with the SAME ``PipelineConfig`` model before writing, so an invalid config can
-never reach the key. Secrets are never in the config (tiers name ``api_key_env``
-only) — do not put key VALUES in the JSON.
+with the SAME gates the APP applies before writing — schema (``PipelineConfig``)
+AND content (``runtime.validate_content``: provider/step legality + a resolvability
+probe that builds every profile/step primary handle) — so neither an invalid nor a
+schema-valid-but-UNBUILDABLE config can ever reach the key. Secrets are never in
+the config (tiers name ``api_key_env`` only) — do not put key VALUES in the JSON.
 
 Usage
 -----
@@ -32,12 +34,14 @@ Exact ops flow (hot % change, no redeploy)
      or hand-author a PipelineConfig JSON (profiles + weights + per-step tiers).
   3. Edit the weights (they MUST sum to 100; names unique) and save to a .json.
   4. ``python scripts/set_pipeline_config.py set <channel> ./new.json``
-     -> validates via PipelineConfig(**data); refuses to write if invalid.
+     -> validates schema (PipelineConfig(**data)) AND content
+     (runtime.validate_content); refuses to write if either fails.
   5. Within ``PIPELINE_CONFIG_REFRESH_S`` (~10s) the app's get_pipeline() reloads
      it; the split re-buckets continuing sessions onto the new %. Verify with
      ``get <channel>`` and the app's ``pipeline config: loaded LIVE ...`` log.
   6. To REVERT to the boot (env/YAML) config: ``clear <channel>`` deletes the key;
-     within the TTL the app falls back to its boot config (last-good until then).
+     within the TTL the app falls back to its BOOT config (the config captured at
+     startup — an emergency rollback, NOT the last live config it was serving).
 
 No real network is required to import this module; the redis client is built only
 when a subcommand runs.
@@ -54,7 +58,7 @@ _ROOT = Path(__file__).resolve().parents[1]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from app.llm_core import config_source
+from app.llm_core import config_source, runtime
 from app.llm_core.config_model import PipelineConfig
 
 
@@ -72,6 +76,14 @@ def cmd_set(channel: str, path: str) -> int:
         cfg = PipelineConfig(**data)  # validates weights==100 + unique profile names
     except Exception as e:
         print(f"REFUSED: invalid PipelineConfig in {path}: {e}", file=sys.stderr)
+        return 1
+    # Content gate (SAME as the app's live-load path): reject a schema-valid but
+    # UNBUILDABLE config (bad provider/step, unresolvable tier) BEFORE writing, so a
+    # bad push can never reach the key and go live.
+    try:
+        runtime.validate_content(cfg)
+    except Exception as e:
+        print(f"REFUSED: config in {path} failed content validation: {e}", file=sys.stderr)
         return 1
     key = config_source.key(channel)
     payload = json.dumps(cfg.model_dump(mode="json"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ def install_variant_chain(monkeypatch, fb, *, oss_handle=None, managed_handle=No
     config-driven weighted-profile resolver (exercised in test_split); the walker
     tests only need a deterministic chain to drive the classify/first-token-commit
     logic, so they stub this seam."""
-    def _chain(variant):
-        if variant == "oss":
+    def _chain(profile_name):
+        if profile_name == "oss":
             return [
                 make_materialized_tier("oss", oss_handle, timeout=oss_timeout,
                                        endpoint=oss_endpoint),
@@ -36,8 +36,8 @@ def install_variant_chain(monkeypatch, fb, *, oss_handle=None, managed_handle=No
             ]
         return [make_materialized_tier("managed", managed_handle, timeout=managed_timeout)]
 
-    async def _resolve_chain(*, pipeline, session_id, variant):
-        return _chain(variant)
+    async def _resolve_chain(*, pipeline, session_id, profile_name):
+        return _chain(profile_name)
 
     monkeypatch.setattr(fb, "_resolve_chain", _resolve_chain)
     return _chain

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -63,6 +63,18 @@ def _gate(max_concurrency=10):
     return ConcurrencyGate(metrics_url=METRICS_URL, max_concurrency=max_concurrency)
 
 
+def _overflow_tier():
+    """The separately-configured M3 overflow model (a managed openai tier), chosen
+    independently of the session-% profile's own chain."""
+    return Tier(provider=Provider.OPENAI, model="gpt-4o-mini", api_key_env="OPENAI_API_KEY",
+                timeout_ms=20000, label="concurrency-overflow")
+
+
+def _gate_with_overflow(max_concurrency=10, overflow=None):
+    return ConcurrencyGate(metrics_url=METRICS_URL, max_concurrency=max_concurrency,
+                           overflow_tier=overflow or _overflow_tier())
+
+
 @pytest.fixture
 def gauge_on(monkeypatch):
     monkeypatch.setattr(concurrency.settings, "concurrency_gauge_enabled", True)
@@ -301,3 +313,106 @@ def test_resolve_chain_untouched_when_gauge_off(monkeypatch):
     chain = asyncio.run(split.resolve_chain("", Step.AGENT, _gated_config()))
     assert [c.provider for c in chain] == ["vllm", "openai"]       # primary stays primary
     assert [c.kind for c in chain] == ["oss", "managed"]
+
+
+# ── (M3) separately-configurable concurrency-overflow model ───────────────────
+# The overflow target is set SEPARATELY from the session-% selection (req #3 "no
+# mixing of variables"): when the shed roll fires AND gate.overflow_tier is set,
+# the shed request is routed to THAT tier at the FRONT, original chain following.
+# overflow_tier defaults None -> behaviour byte-identical to the reorder-behind-
+# managed shed (pinned by test_no_overflow_falls_back_to_reorder_behind_managed).
+
+def test_saturated_overflow_tier_routed_to_front(gauge_on):
+    """Gauge tripped + overflow_tier set -> the CONFIGURED overflow tier is at index
+    0 (tried first), the original tiers follow as fallback, record_deprioritized
+    fires."""
+    fired = []
+    gauge_on.setattr(concurrency.metrics, "record_deprioritized",
+                     lambda step: fired.append(step))
+    _inject_gauge(gauge_on, 12)                                     # >= 10 -> saturated
+    overflow = _overflow_tier()
+    tiers = [_oss_tier(), _managed_tier()]
+    out = asyncio.run(concurrency.reprioritize_by_load(
+        Step.AGENT, tiers, _gate_with_overflow(10, overflow)))
+    assert out[0] == overflow                                      # overflow tried first
+    assert out[1:] == tiers                                        # original chain follows as fallback
+    assert len(out) == 3                                           # nothing dropped
+    assert fired == [Step.AGENT]                                   # record_deprioritized fired
+
+
+def test_no_overflow_falls_back_to_reorder_behind_managed(gauge_on):
+    """Gauge tripped + overflow_tier NOT set -> byte-identical to today's reorder:
+    the vLLM tier is deprioritized behind the managed tier, no tier prepended."""
+    _inject_gauge(gauge_on, 12)                                    # saturated
+    tiers = [_oss_tier(), _managed_tier()]
+    out = asyncio.run(concurrency.reprioritize_by_load(Step.AGENT, tiers, _gate(10)))
+    assert [t.provider for t in out] == [Provider.OPENAI, Provider.VLLM]  # reorder, not overflow
+    assert len(out) == 2                                           # no overflow tier prepended
+
+
+def test_overflow_not_used_when_gauge_not_tripped(gauge_on):
+    """Gauge below the ramp + overflow_tier set -> tiers unchanged (identity); the
+    overflow only engages when the shed roll actually fires."""
+    _inject_gauge(gauge_on, 3)                                     # < 10 -> not saturated
+    tiers = [_oss_tier(), _managed_tier()]
+    out = asyncio.run(concurrency.reprioritize_by_load(
+        Step.AGENT, tiers, _gate_with_overflow(10)))
+    assert out is tiers                                            # unchanged, overflow untouched
+
+
+def test_overflow_tier_already_in_chain_no_duplicate(gauge_on):
+    """Overflow tier already present in the chain -> it is lifted to the FRONT and
+    removed from its old position; it never appears twice."""
+    _inject_gauge(gauge_on, 12)                                    # saturated
+    overflow = _overflow_tier()
+    tiers = [_oss_tier(), overflow, _managed_tier()]
+    out = asyncio.run(concurrency.reprioritize_by_load(
+        Step.AGENT, tiers, _gate_with_overflow(10, overflow)))
+    assert out[0] == overflow
+    assert out.count(overflow) == 1                               # no duplicate
+    assert out == [overflow, tiers[0], tiers[2]]                  # lifted to front, rest in order
+
+
+def test_concurrency_gate_overflow_parses_from_dict():
+    """ConcurrencyGate(overflow_tier=...) parses from a YAML/dict payload (pydantic),
+    materializing a full nested Tier; omitting it defaults to None (pre-M3)."""
+    gate = ConcurrencyGate.model_validate({
+        "metrics_url": METRICS_URL,
+        "max_concurrency": 10,
+        "overflow_tier": {
+            "provider": "openai", "model": "gpt-4o-mini",
+            "api_key_env": "OPENAI_API_KEY", "timeout_ms": 20000,
+            "label": "concurrency-overflow",
+        },
+    })
+    assert isinstance(gate.overflow_tier, Tier)
+    assert gate.overflow_tier.provider is Provider.OPENAI
+    assert gate.overflow_tier.model == "gpt-4o-mini"
+    # default: omitted -> None (byte-identical to pre-M3 config)
+    assert ConcurrencyGate(metrics_url=METRICS_URL).overflow_tier is None
+
+
+def _overflow_gated_config():
+    """OSS profile whose AGENT step carries a gate with a SEPARATE overflow tier."""
+    oss_steps = {
+        Step.AGENT: StepConfig(
+            tiers=[_oss_tier(), _managed_tier()],
+            triggers=Triggers(concurrency_gate=_gate_with_overflow(10)),
+        ),
+    }
+    return PipelineConfig(profiles=[NamedProfile(name="oss", weight=100, steps=oss_steps)])
+
+
+def test_resolve_chain_overflow_tier_materializes_at_front(monkeypatch):
+    """End-to-end: saturated box + configured overflow_tier -> resolve_chain
+    materializes the overflow tier as a managed AGENT model at the FRONT, original
+    tiers following (proves the prepended tier flows through materialize cleanly)."""
+    monkeypatch.setattr(concurrency.settings, "concurrency_gauge_enabled", True)
+    monkeypatch.setattr(health.settings, "health_breaker_enabled", False)
+    monkeypatch.setattr(health.settings, "health_poller_enabled", False)
+    _inject_gauge(monkeypatch, 20)                                 # saturated
+
+    chain = asyncio.run(split.resolve_chain("", Step.AGENT, _overflow_gated_config()))
+    assert [c.model_name for c in chain] == ["gpt-4o-mini", "gemma", "gpt-4.1"]
+    assert [c.provider for c in chain] == ["openai", "vllm", "openai"]
+    assert [c.kind for c in chain] == ["managed", "oss", "managed"]  # overflow is a managed AGENT model

--- a/tests/test_config_source.py
+++ b/tests/test_config_source.py
@@ -1,0 +1,291 @@
+"""Unit tests for M2: the redis-backed LIVE pipeline-config source
+(``app/llm_core/config_source.py``) + its ``runtime.get_pipeline`` wiring.
+
+The bar these pin:
+  (a) DEFAULT OFF is behaviorally identical to boot-config-only — with
+      ``PIPELINE_CONFIG_REDIS_ENABLED`` unset, ``maybe_refresh`` is an identity
+      no-op that never even builds a redis client, and ``get_pipeline`` returns
+      the boot config unchanged.
+  (b) Enabled + a VALID config in a fake redis -> ``get_pipeline`` returns the new
+      config after the TTL, and a WEIGHT change re-buckets a fixed session
+      (``deterministic_profile`` maps it differently before/after) — the hot-reload
+      + refresh-on-change contract.
+  (c) FAIL-SAFE: missing key / invalid JSON / weights != 100 / redis GET raising
+      all keep the last-good config, log a WARNING, and NEVER raise.
+  (d) TTL: two calls within one window hit redis AT MOST once (call counter on the
+      fake), so calling ``maybe_refresh`` per request is cheap.
+
+Zero real network: the redis client seam (``config_source._get_redis``) is
+monkeypatched to an in-memory fake; no test contacts a real redis. Dummy keys are
+set before importing app code to match the other llm_core test modules (the
+factory reads keys at build time), though these tests never materialize a tier.
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+os.environ.setdefault("OSS_INFERENCE_API_KEY", "test-oss-key")
+
+import json
+
+import pytest
+
+from app.llm_core import config_source, split
+from app.llm_core.config_model import (
+    NamedProfile,
+    PipelineConfig,
+    Provider,
+    Step,
+    StepConfig,
+    Tier,
+)
+
+
+# ── config builders (independent of test_split's) ─────────────────────────────
+
+def _oss_tier():
+    return Tier(provider=Provider.VLLM, model="gemma", endpoint="http://oss:8020/v1",
+                api_key_env="OSS_INFERENCE_API_KEY", timeout_ms=8000)
+
+
+def _managed_tier():
+    return Tier(provider=Provider.OPENAI, model="gpt-4.1", api_key_env="OPENAI_API_KEY",
+                timeout_ms=20000)
+
+
+def _two_profile(pct: int) -> PipelineConfig:
+    """``[oss(pct), managed(100-pct)]`` — the seeded 2-profile split."""
+    return PipelineConfig(profiles=[
+        NamedProfile(name="oss", weight=pct,
+                     steps={Step.AGENT: StepConfig(tiers=[_oss_tier(), _managed_tier()])}),
+        NamedProfile(name="managed", weight=100 - pct,
+                     steps={Step.AGENT: StepConfig(tiers=[_managed_tier()])}),
+    ])
+
+
+def _json_of(cfg: PipelineConfig) -> str:
+    """Exactly what the ops script / config_source round-trip through redis."""
+    return json.dumps(cfg.model_dump(mode="json"))
+
+
+# ── fake redis (in-memory, with a GET call counter) ───────────────────────────
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.get_calls = 0
+        self.raise_on_get = False
+
+    def get(self, key):
+        self.get_calls += 1
+        if self.raise_on_get:
+            raise RuntimeError("redis down")
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+@pytest.fixture(autouse=True)
+def _clean_source(monkeypatch):
+    """Reset module state + strip M2 env before each test so tests don't leak
+    cached last-good / last-refresh state into each other."""
+    monkeypatch.delenv(config_source.ENABLED_ENV, raising=False)
+    monkeypatch.delenv(config_source.CHANNEL_ENV, raising=False)
+    monkeypatch.delenv(config_source.REFRESH_ENV, raising=False)
+    config_source.reset()
+    yield
+    config_source.reset()
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    r = FakeRedis()
+    monkeypatch.setattr(config_source, "_get_redis", lambda: r)
+    return r
+
+
+def _enable(monkeypatch, *, refresh="0"):
+    monkeypatch.setenv(config_source.ENABLED_ENV, "true")
+    monkeypatch.setenv(config_source.REFRESH_ENV, refresh)
+
+
+# ── (a) default OFF is identity — never builds a client, returns current ───────
+
+def test_disabled_is_identity_noop(monkeypatch):
+    def _boom():
+        raise AssertionError("_get_redis must not be called when the source is disabled")
+    monkeypatch.setattr(config_source, "_get_redis", _boom)
+
+    boot = _two_profile(30)
+    assert config_source.maybe_refresh(boot) is boot   # same object, no redis touched
+
+
+def test_channel_default_self_identifies_and_key_format(monkeypatch):
+    # The default channel is derived from the repo's Step enum (voice has
+    # non_meaningful; chat has suggestions) — identical assertion in both repos.
+    expected = "voice" if hasattr(Step, "NON_MEANINGFUL") else "chat"
+    assert config_source.channel() == expected
+    assert config_source.key() == f"llm_pipeline_config:{expected}"
+    # explicit override + explicit-channel key
+    monkeypatch.setenv(config_source.CHANNEL_ENV, "staging")
+    assert config_source.channel() == "staging"
+    assert config_source.key() == "llm_pipeline_config:staging"
+    assert config_source.key("other") == "llm_pipeline_config:other"
+
+
+def test_refresh_interval_default_and_bad_value(monkeypatch):
+    assert config_source.refresh_interval_s() == 10.0
+    monkeypatch.setenv(config_source.REFRESH_ENV, "3")
+    assert config_source.refresh_interval_s() == 3.0
+    monkeypatch.setenv(config_source.REFRESH_ENV, "not-a-number")
+    assert config_source.refresh_interval_s() == 10.0   # degrades, never raises
+
+
+# ── enabled + key absent -> current unchanged ─────────────────────────────────
+
+def test_enabled_key_absent_returns_current(monkeypatch, fake):
+    _enable(monkeypatch)
+    boot = _two_profile(30)
+    assert config_source.maybe_refresh(boot) is boot
+    assert fake.get_calls == 1   # it DID consult redis (past TTL), found nothing
+
+
+# ── (b) hot reload + re-bucket ────────────────────────────────────────────────
+
+def test_enabled_loads_new_config_and_rebuckets_fixed_session(monkeypatch, fake):
+    _enable(monkeypatch, refresh="0")   # every call past TTL -> reload
+    # find a session whose bucket sits in [30,60) so a 40->20 pct flip crosses it
+    sid = next(f"pick-{i}" for i in range(10_000) if 30 <= split._bucket(f"pick-{i}") < 60)
+    bucket = split._bucket(sid)
+
+    boot = _two_profile(bucket + 5)   # bucket < pct -> 'oss'
+    live = _two_profile(bucket - 5)   # bucket >= pct -> 'managed'
+    fake.store[config_source.key()] = _json_of(live)
+
+    assert split.deterministic_profile(sid, boot) == "oss"      # before
+    refreshed = config_source.maybe_refresh(boot)
+    assert split.deterministic_profile(sid, refreshed) == "managed"  # after (re-bucketed)
+    assert [(p.name, p.weight) for p in refreshed.profiles] == [("oss", bucket - 5), ("managed", 100 - (bucket - 5))]
+
+
+def test_get_pipeline_returns_boot_when_disabled(monkeypatch):
+    from app.llm_core import runtime
+    boot = _two_profile(30)
+    monkeypatch.setattr(runtime, "PIPELINE", boot)
+    # disabled (default) -> get_pipeline serves the boot config, byte-identical
+    assert runtime.get_pipeline() is boot
+
+
+def test_get_pipeline_live_after_ttl_via_runtime(monkeypatch, fake):
+    from app.llm_core import runtime
+    _enable(monkeypatch, refresh="0")
+    sid = next(f"rt-{i}" for i in range(10_000) if 30 <= split._bucket(f"rt-{i}") < 60)
+    bucket = split._bucket(sid)
+
+    boot = _two_profile(bucket + 5)   # sid -> 'oss'
+    live = _two_profile(bucket - 5)   # sid -> 'managed'
+    monkeypatch.setattr(runtime, "PIPELINE", boot)
+    fake.store[config_source.key()] = _json_of(live)
+
+    assert split.deterministic_profile(sid, runtime.get_pipeline()) == "managed"
+    # and runtime's stored PIPELINE is now the live config (get_pipeline stores it)
+    assert runtime.PIPELINE.by_name("oss").weight == bucket - 5
+
+
+# ── (c) fail-safe: invalid JSON / weights!=100 / redis raising -> keep last-good ─
+
+def test_invalid_json_keeps_last_good_and_warns(monkeypatch, fake, caplog):
+    import logging
+    _enable(monkeypatch, refresh="0")
+    boot = _two_profile(30)
+    fake.store[config_source.key()] = "{ this is not valid json"
+    with caplog.at_level(logging.WARNING):
+        out = config_source.maybe_refresh(boot)   # must NOT raise
+    assert out is boot
+    assert "invalid live config" in caplog.text
+
+
+def test_weights_not_100_keeps_last_good(monkeypatch, fake):
+    _enable(monkeypatch, refresh="0")
+    boot = _two_profile(30)
+    # craft raw JSON whose weights sum to 110 (bypasses the model builder)
+    bad = _two_profile(40).model_dump(mode="json")
+    bad["profiles"][1]["weight"] = 70          # 40 + 70 = 110 != 100
+    fake.store[config_source.key()] = json.dumps(bad)
+    out = config_source.maybe_refresh(boot)     # PipelineConfig validator rejects -> last-good
+    assert out is boot
+
+
+def test_redis_get_raising_keeps_last_good(monkeypatch, fake):
+    _enable(monkeypatch, refresh="0")
+    fake.raise_on_get = True
+    boot = _two_profile(30)
+    out = config_source.maybe_refresh(boot)     # GET raises -> caught -> last-good
+    assert out is boot
+
+
+def test_no_redis_client_keeps_last_good(monkeypatch):
+    _enable(monkeypatch, refresh="0")
+    monkeypatch.setattr(config_source, "_get_redis", lambda: None)  # e.g. redis import failed
+    boot = _two_profile(30)
+    assert config_source.maybe_refresh(boot) is boot
+
+
+# ── (d) TTL: two calls within one window hit redis at most once ────────────────
+
+def test_ttl_hits_redis_at_most_once_per_window(monkeypatch, fake):
+    _enable(monkeypatch, refresh="1000")   # huge window -> second call must not re-read
+    boot = _two_profile(30)
+    live = _two_profile(50)
+    fake.store[config_source.key()] = _json_of(live)
+
+    first = config_source.maybe_refresh(boot)
+    second = config_source.maybe_refresh(first)
+    assert fake.get_calls == 1              # only the first call past TTL touched redis
+    # first call loaded the live config; second returned it unchanged (within window)
+    assert first.by_name("oss").weight == 50
+    assert second is first
+
+
+# ── ops script round-trips through the same fake redis ────────────────────────
+
+def _load_ops_module():
+    import importlib.util
+    from pathlib import Path
+    root = Path(config_source.__file__).resolve().parents[2]
+    path = root / "scripts" / "set_pipeline_config.py"
+    spec = importlib.util.spec_from_file_location("set_pipeline_config", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_ops_script_set_get_clear_roundtrip(monkeypatch, tmp_path, fake, capsys):
+    ops = _load_ops_module()
+    monkeypatch.setattr(config_source, "build_redis_client", lambda: fake)
+
+    good = tmp_path / "good.json"
+    good.write_text(_json_of(_two_profile(50)), encoding="utf-8")
+    assert ops.cmd_set("chat", str(good)) == 0
+    assert fake.store["llm_pipeline_config:chat"]
+
+    assert ops.cmd_get("chat") == 0
+    assert '"weight": 50' in capsys.readouterr().out
+
+    assert ops.cmd_clear("chat") == 0
+    assert "llm_pipeline_config:chat" not in fake.store
+
+
+def test_ops_script_refuses_invalid_config(monkeypatch, tmp_path, fake):
+    ops = _load_ops_module()
+    monkeypatch.setattr(config_source, "build_redis_client", lambda: fake)
+    bad = _two_profile(40).model_dump(mode="json")
+    bad["profiles"][1]["weight"] = 70          # sum 110 -> invalid
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(bad), encoding="utf-8")
+    assert ops.cmd_set("chat", str(p)) == 1     # refused
+    assert "llm_pipeline_config:chat" not in fake.store   # nothing written

--- a/tests/test_config_source.py
+++ b/tests/test_config_source.py
@@ -63,6 +63,21 @@ def _two_profile(pct: int) -> PipelineConfig:
     ])
 
 
+def _content_invalid() -> PipelineConfig:
+    """SCHEMA-valid (weight sums to 100, unique names) but UNBUILDABLE: a vllm AGENT
+    tier with NO endpoint. ``PipelineConfig(**data)`` accepts it, but the factory
+    raises at materialize time (``resolver.primary_tier`` -> build_handle), so the
+    boot-parity content probe in ``runtime.validate_content`` rejects it. AGENT is a
+    RAW-independent step configured identically in chat and voice, so this fixture is
+    byte-identical across the two repos."""
+    return PipelineConfig(profiles=[
+        NamedProfile(name="oss", weight=100,
+                     steps={Step.AGENT: StepConfig(tiers=[
+                         Tier(provider=Provider.VLLM, model="gemma", endpoint=None,
+                              api_key_env="OSS_INFERENCE_API_KEY", timeout_ms=8000)])}),
+    ])
+
+
 def _json_of(cfg: PipelineConfig) -> str:
     """Exactly what the ops script / config_source round-trip through redis."""
     return json.dumps(cfg.model_dump(mode="json"))
@@ -145,13 +160,75 @@ def test_refresh_interval_default_and_bad_value(monkeypatch):
     assert config_source.refresh_interval_s() == 10.0   # degrades, never raises
 
 
+def test_refresh_interval_clamps_nonpositive_to_default(monkeypatch):
+    # A 0/negative window would GET redis on EVERY request (blocking hot-path read);
+    # clamp non-positive values to the default instead.
+    monkeypatch.setenv(config_source.REFRESH_ENV, "0")
+    assert config_source.refresh_interval_s() == 10.0
+    monkeypatch.setenv(config_source.REFRESH_ENV, "-5")
+    assert config_source.refresh_interval_s() == 10.0
+
+
+def test_redis_client_uses_short_dedicated_socket_timeout(monkeypatch):
+    # The config-source client gets a short dedicated connect+socket timeout
+    # (default 0.5s), NOT the app-wide redis_socket_timeout (up to 10s), so a
+    # slow/down redis on the hot path costs <=0.5s.
+    import sys
+
+    captured: dict = {}
+
+    class _FakeRedisModule:
+        class Redis:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "redis", _FakeRedisModule)
+    assert config_source.redis_timeout_s() == 0.5             # default
+    client = config_source.build_redis_client()
+    assert client is not None
+    assert captured["socket_timeout"] == 0.5
+    assert captured["socket_connect_timeout"] == 0.5
+    # env override is honored
+    captured.clear()
+    monkeypatch.setenv(config_source.TIMEOUT_ENV, "2")
+    assert config_source.redis_timeout_s() == 2.0
+    config_source.build_redis_client()
+    assert captured["socket_timeout"] == 2.0
+    assert captured["socket_connect_timeout"] == 2.0
+
+
 # ── enabled + key absent -> current unchanged ─────────────────────────────────
 
-def test_enabled_key_absent_returns_current(monkeypatch, fake):
+def test_enabled_key_absent_reverts_to_boot(monkeypatch, fake):
+    from app.llm_core import runtime
     _enable(monkeypatch)
     boot = _two_profile(30)
-    assert config_source.maybe_refresh(boot) is boot
+    monkeypatch.setattr(runtime, "BOOT_PIPELINE", boot)  # captured at configure()
+    assert config_source.maybe_refresh(boot) is boot   # key absent -> BOOT config
     assert fake.get_calls == 1   # it DID consult redis (past TTL), found nothing
+
+
+def test_clear_or_absent_reverts_to_boot_not_last_live(monkeypatch, fake):
+    """`clear` (and a never-set key) reverts to the BOOT config captured at
+    configure() — NOT the last LIVE config that was serving. Emergency rollback."""
+    from app.llm_core import runtime
+    _enable(monkeypatch)
+    boot = _two_profile(30)
+    live = _two_profile(70)
+    monkeypatch.setattr(runtime, "BOOT_PIPELINE", boot)  # boot captured at configure()
+
+    # 1) a live config is present and loads (distinct from boot)
+    fake.store[config_source.key()] = _json_of(live)
+    loaded = config_source.maybe_refresh(boot)
+    assert loaded is not boot
+    assert loaded.by_name("oss").weight == 70            # last-LIVE is serving
+
+    # 2) operator clears the key -> next refresh reverts to BOOT, not last-live
+    del fake.store[config_source.key()]
+    monkeypatch.setattr(config_source, "_last_refresh_monotonic", 0.0)  # force TTL elapse
+    reverted = config_source.maybe_refresh(loaded)       # current is the last-LIVE cfg
+    assert reverted is boot                              # BOOT, not last-live
+    assert reverted.by_name("oss").weight == 30
 
 
 # ── (b) hot reload + re-bucket ────────────────────────────────────────────────
@@ -235,6 +312,20 @@ def test_no_redis_client_keeps_last_good(monkeypatch):
     assert config_source.maybe_refresh(boot) is boot
 
 
+def test_content_invalid_live_config_kept_last_good_and_warns(monkeypatch, fake, caplog):
+    """FAIL-CLOSED on bad CONTENT: a schema-valid but UNBUILDABLE live config
+    (validate_content raises via the resolvability probe) is treated like a read
+    failure — last-good kept, WARNING logged, never applied, never raised."""
+    import logging
+    _enable(monkeypatch, refresh="0")
+    boot = _two_profile(30)
+    fake.store[config_source.key()] = _json_of(_content_invalid())
+    with caplog.at_level(logging.WARNING):
+        out = config_source.maybe_refresh(boot)   # must NOT raise; must NOT apply
+    assert out is boot                             # kept last-good (fail-closed)
+    assert "content-invalid" in caplog.text
+
+
 # ── (d) TTL: two calls within one window hit redis at most once ────────────────
 
 def test_ttl_hits_redis_at_most_once_per_window(monkeypatch, fake):
@@ -288,4 +379,15 @@ def test_ops_script_refuses_invalid_config(monkeypatch, tmp_path, fake):
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad), encoding="utf-8")
     assert ops.cmd_set("chat", str(p)) == 1     # refused
+    assert "llm_pipeline_config:chat" not in fake.store   # nothing written
+
+
+def test_ops_script_refuses_content_invalid_config(monkeypatch, tmp_path, fake):
+    """The ops script applies the SAME content gate as the app: a schema-valid but
+    UNBUILDABLE config is refused (content probe raises) and nothing is written."""
+    ops = _load_ops_module()
+    monkeypatch.setattr(config_source, "build_redis_client", lambda: fake)
+    p = tmp_path / "content_bad.json"
+    p.write_text(_json_of(_content_invalid()), encoding="utf-8")
+    assert ops.cmd_set("chat", str(p)) == 1     # refused on the content probe
     assert "llm_pipeline_config:chat" not in fake.store   # nothing written

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -83,7 +83,7 @@ def test_falls_back_to_managed_on_connection_error(oss_enabled):
         return "managed-result"
 
     result = asyncio.run(
-        execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+        execute_with_fallback(pipeline="moderation", session_id="s1", profile_name="oss", run=run)
     )
     assert result == "managed-result"
     assert len(oss_enabled) == 1
@@ -102,7 +102,7 @@ def test_does_not_fall_back_on_bad_output(oss_enabled):
 
     with pytest.raises(UnexpectedModelBehavior):
         asyncio.run(
-            execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+            execute_with_fallback(pipeline="moderation", session_id="s1", profile_name="oss", run=run)
         )
     # Recorded for visibility, but not a fallback.
     assert len(oss_enabled) == 1
@@ -115,7 +115,7 @@ def test_success_on_oss_emits_nothing(oss_enabled):
         return f"ok-{attempt.kind}"
 
     result = asyncio.run(
-        execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+        execute_with_fallback(pipeline="moderation", session_id="s1", profile_name="oss", run=run)
     )
     assert result == "ok-oss"
     assert oss_enabled == []
@@ -127,7 +127,7 @@ def test_both_tiers_fail_raises_and_records_both(oss_enabled):
 
     with pytest.raises(ConnectionError):
         asyncio.run(
-            execute_with_fallback(pipeline="moderation", session_id="s1", variant="oss", run=run)
+            execute_with_fallback(pipeline="moderation", session_id="s1", profile_name="oss", run=run)
         )
     assert len(oss_enabled) == 2
     assert oss_enabled[0].fell_back is True   # oss -> managed
@@ -143,7 +143,7 @@ def test_legacy_session_no_fallback_attempted(oss_enabled):
 
     with pytest.raises(ConnectionError):
         asyncio.run(
-            execute_with_fallback(pipeline="moderation", session_id="s1", variant="legacy", run=run)
+            execute_with_fallback(pipeline="moderation", session_id="s1", profile_name="legacy", run=run)
         )
     assert calls == ["managed"]  # only one tier for legacy sessions
     assert len(oss_enabled) == 1 and oss_enabled[0].fell_back is False
@@ -162,7 +162,7 @@ def test_stream_success_on_oss_no_fallback(oss_enabled):
 
     chunks = asyncio.run(
         _collect(fb.stream_with_fallback(
-            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream))
+            pipeline="chat", session_id="s", profile_name="oss", make_stream=make_stream))
     )
     assert chunks == ["oss:a", "oss:b", "oss:c"]
     assert oss_enabled == []
@@ -178,7 +178,7 @@ def test_stream_precommit_failure_swaps_to_managed(oss_enabled):
 
     chunks = asyncio.run(
         _collect(fb.stream_with_fallback(
-            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream))
+            pipeline="chat", session_id="s", profile_name="oss", make_stream=make_stream))
     )
     assert chunks == ["managed:x", "managed:y"]
     assert len(oss_enabled) == 1
@@ -195,7 +195,7 @@ def test_stream_postcommit_failure_propagates(oss_enabled):
 
     async def drive():
         async for c in fb.stream_with_fallback(
-            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream
+            pipeline="chat", session_id="s", profile_name="oss", make_stream=make_stream
         ):
             got.append(c)
 
@@ -216,7 +216,7 @@ def test_stream_precommit_bad_output_does_not_swap(oss_enabled):
 
     with pytest.raises(UnexpectedModelBehavior):
         asyncio.run(_collect(fb.stream_with_fallback(
-            pipeline="chat", session_id="s", variant="oss", make_stream=make_stream)))
+            pipeline="chat", session_id="s", profile_name="oss", make_stream=make_stream)))
     assert len(oss_enabled) == 1
     assert oss_enabled[0].committed is False and oss_enabled[0].fell_back is False
 
@@ -281,7 +281,7 @@ def test_ttft_timeout_triggers_fallback_to_managed(oss_enabled, install_chain):
     # Tight oss first-token timeout so the test is fast; managed has no deadline.
     install_chain(oss_timeout=0.05)
     chunks = asyncio.run(_collect(fb.stream_with_fallback(
-        pipeline="chat", session_id="s", variant="oss", make_stream=make_stream)))
+        pipeline="chat", session_id="s", profile_name="oss", make_stream=make_stream)))
     assert chunks == ["managed:ok"]
     reasons = [e.reason for e in oss_enabled]
     assert FallbackReason.TIMEOUT in reasons

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -365,7 +365,7 @@ def test_fallback_resolve_chain_prunes_when_breaker_on(monkeypatch):
     health._registry.record_failure("http://oss:8020/v1")            # OSS endpoint down
 
     # session_id="" -> deterministic profile (no Redis); oss weight 100 -> [oss, managed]
-    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="", variant="oss"))
+    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="", profile_name="oss"))
     assert [a.kind for a in chain] == ["managed"]                    # oss pruned
     health.reset()
 
@@ -384,6 +384,6 @@ def test_fallback_resolve_chain_untouched_when_health_off(monkeypatch):
     health.reset(_cfg(n=1))
     health._registry.record_failure("http://oss:8020/v1", now=0.0)
 
-    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="", variant="oss"))
+    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="", profile_name="oss"))
     assert [a.kind for a in chain] == ["oss", "managed"]
     health.reset()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -99,6 +99,45 @@ def test_success_interrupts_failure_streak():
     assert r.state_of(AGENT_EP) is BreakerState.CLOSED     # 2 < 3 after reset
 
 
+# ── (a') half-open probe token: release + time-box (Finding #3) ───────────────
+
+def test_release_probe_frees_slot_idempotently():
+    """release_probe frees ONLY the probe slot (state/counters untouched) and is a
+    no-op when no probe is in flight or the endpoint is unknown; once freed, the
+    NEXT caller may probe again."""
+    r = HealthRegistry(_cfg(n=1, cooldown=10.0))
+    r.record_failure(AGENT_EP, now=0.0)                    # -> OPEN
+    assert r.is_open(AGENT_EP, now=20.0) is False          # -> HALF_OPEN + probe granted
+    assert r.snapshot()[AGENT_EP]["probe_in_flight"] is True
+
+    r.release_probe(AGENT_EP)                              # frees the slot
+    assert r.snapshot()[AGENT_EP]["probe_in_flight"] is False
+    assert r.state_of(AGENT_EP) is BreakerState.HALF_OPEN  # only the slot freed; state unchanged
+
+    r.release_probe(AGENT_EP)                              # idempotent no-op
+    r.release_probe("http://never-seen:9/v1")             # unknown endpoint -> no-op
+    assert r.state_of(AGENT_EP) is BreakerState.HALF_OPEN
+
+    # A freed slot -> the next caller re-probes instead of being pruned forever.
+    assert r.is_open(AGENT_EP, now=21.0) is False
+    assert r.snapshot()[AGENT_EP]["probe_in_flight"] is True
+
+
+def test_probe_time_box_auto_releases_lost_token():
+    """Backstop: a probe token never released by a walker finally (lost token) is
+    auto-released by ``is_open`` after ``probe_max_s`` so a recovered endpoint is
+    re-probed rather than pinned HALF_OPEN (pruned) forever."""
+    r = HealthRegistry(BreakerConfig(fail_threshold=1, cooldown_s=10.0, probe_max_s=30.0))
+    r.record_failure(AGENT_EP, now=0.0)                    # -> OPEN at t=0
+    assert r.is_open(AGENT_EP, now=20.0) is False          # -> HALF_OPEN + probe granted at t=20
+    assert r.is_open(AGENT_EP, now=25.0) is True           # 25-20 < 30 -> probe still held -> pruned
+    # Token leaked (no finally, no success/failure ever cleared it). Past probe_max_s
+    # the backstop auto-releases AND re-grants, so THIS caller probes again.
+    assert r.is_open(AGENT_EP, now=51.0) is False          # 51-20 >= 30 -> auto-release + re-grant
+    assert r.state_of(AGENT_EP) is BreakerState.HALF_OPEN
+    assert r.snapshot()[AGENT_EP]["probe_in_flight"] is True
+
+
 # ── (b) poller hysteresis ─────────────────────────────────────────────────────
 
 def test_poller_hysteresis_requires_k_healthy_polls():
@@ -387,3 +426,136 @@ def test_fallback_resolve_chain_untouched_when_health_off(monkeypatch):
     chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="", profile_name="oss"))
     assert [a.kind for a in chain] == ["oss", "managed"]
     health.reset()
+
+
+# ── walker frees the half-open probe on ANY terminal outcome (Finding #3) ─────
+# A probe token is granted to a tier's endpoint during chain resolution
+# (prune_unhealthy -> is_open). It is released by record_success / a BREAKER_EVIDENCE
+# record_failure — but NOT by a non-evidence failure (UNKNOWN / BAD_OUTPUT) nor by a
+# tier a reorder left unexecuted. The walkers' finally sweep must free it regardless,
+# or a recovered endpoint stays pruned forever. (importorskip-guarded like the other
+# fallback-composition tests: run in CI, skip locally under the pydantic-ai mismatch.)
+
+OSS_EP = "http://oss:8020/v1"
+
+
+def _grant_probe(r, ep=OSS_EP):
+    """Trip ``ep`` then let the cooldown elapse so is_open grants it the probe."""
+    r.record_failure(ep, now=0.0)                          # -> OPEN (n=1)
+    assert r.is_open(ep, now=100.0) is False               # cooldown elapsed -> HALF_OPEN + probe
+    assert r.snapshot()[ep]["probe_in_flight"] is True
+
+
+def test_walker_releases_probe_on_non_evidence_failure(monkeypatch, install_chain):
+    """OSS probe fails on UNKNOWN (a caller bug / 4xx) -> fallbackable but NOT breaker
+    evidence, so record_failure never fires; only the finally can free the probe."""
+    fb = pytest.importorskip("app.services.fallback")
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_breaker_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_poller_enabled", False)
+    monkeypatch.setattr(fb, "emit", lambda e: None)
+    r = health.reset(_cfg(n=1, cooldown=10.0))
+    install_chain()                                        # profile 'oss' -> [oss, managed]
+    _grant_probe(r)
+
+    async def run(attempt):
+        if attempt.kind == "oss":
+            raise ValueError("caller bug")                 # classify -> UNKNOWN
+        return "managed-ok"
+
+    result = asyncio.run(fb.execute_with_fallback(
+        pipeline="moderation", session_id="s", profile_name="oss", run=run))
+    assert result == "managed-ok"
+    assert r.snapshot()[OSS_EP]["probe_in_flight"] is False   # freed by the finally
+    assert r.state_of(OSS_EP) is BreakerState.HALF_OPEN       # only the slot freed
+    health.reset()
+
+
+def test_walker_releases_probe_on_bad_output_raise(monkeypatch, install_chain):
+    """BAD_OUTPUT is non-fallbackable, so the walker RAISES on the first tier; the
+    probe must still be freed on the way out."""
+    fb = pytest.importorskip("app.services.fallback")
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_breaker_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_poller_enabled", False)
+    monkeypatch.setattr(fb, "emit", lambda e: None)
+    r = health.reset(_cfg(n=1, cooldown=10.0))
+    install_chain()
+    _grant_probe(r)
+
+    class UnexpectedModelBehavior(Exception):
+        pass
+
+    async def run(attempt):
+        raise UnexpectedModelBehavior("schema mismatch")   # classify -> BAD_OUTPUT
+
+    with pytest.raises(UnexpectedModelBehavior):
+        asyncio.run(fb.execute_with_fallback(
+            pipeline="moderation", session_id="s", profile_name="oss", run=run))
+    assert r.snapshot()[OSS_EP]["probe_in_flight"] is False   # freed despite the raise
+    health.reset()
+
+
+def test_walker_releases_probe_on_not_run_reordered_tier(monkeypatch, materialized_tier):
+    """The crux: a concurrency reorder moved the just-probed OSS tier off index 0,
+    so the managed tier returns first and the OSS tier NEVER executes — yet its probe
+    must STILL be freed (only the whole-chain finally sweep does this)."""
+    fb = pytest.importorskip("app.services.fallback")
+    monkeypatch.setattr(fb.settings, "fallback_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_breaker_enabled", True)
+    monkeypatch.setattr(fb.settings, "health_poller_enabled", False)
+    monkeypatch.setattr(fb, "emit", lambda e: None)
+    r = health.reset(_cfg(n=1, cooldown=10.0))
+
+    async def _reordered_chain(*, pipeline, session_id, profile_name):
+        return [
+            materialized_tier("managed", None),                       # index 0: runs first
+            materialized_tier("oss", None, endpoint=OSS_EP),          # index 1: never reached
+        ]
+    monkeypatch.setattr(fb, "_resolve_chain", _reordered_chain)
+    _grant_probe(r)                                        # OSS probed, then reorder shifted it
+
+    async def run(attempt):
+        return f"ok-{attempt.kind}"                        # managed (index 0) succeeds
+
+    result = asyncio.run(fb.execute_with_fallback(
+        pipeline="chat", session_id="s", profile_name="x", run=run))
+    assert result == "ok-managed"                          # OSS tier never ran
+    assert r.snapshot()[OSS_EP]["probe_in_flight"] is False   # ...yet its probe was freed
+    health.reset()
+
+
+# ── voice#1: moderation fails CLOSED (never OPEN) on a resolver error ─────────
+
+def test_moderation_requested_kind_resolver_error_defaults_managed(monkeypatch):
+    """Finding voice#1: a resolver error while computing the requested tier must NOT
+    escape check_moderation (which fails OPEN in _resolve_moderation -> moderation
+    bypassed). It must be caught and default to a managed kind (never a bypass)."""
+    # pydantic-ai 0.2.4 vs 1.x shim (see test_voice_moderation_fallback): alias the
+    # renamed model class so importing moderation -> agents.models succeeds locally.
+    import pydantic_ai.models.openai as _pai_openai
+    if not hasattr(_pai_openai, "OpenAIChatModel"):
+        _pai_openai.OpenAIChatModel = _pai_openai.OpenAIModel
+    from app.services import moderation as mod
+    from app.llm_core import resolver as _res
+
+    monkeypatch.setattr(mod.settings, "fallback_enabled", True)
+
+    # (1) primary_tier raises for the requested-kind resolution — an N-way profile
+    #     whose config omits the moderation step (resolve_chain-style ValueError).
+    def _boom(step, profile_name="managed"):
+        raise ValueError("no config for step=moderation in profile=nway")
+    monkeypatch.setattr(_res, "primary_tier", _boom)
+
+    # (2) isolate the walk so the test targets ONLY the requested-kind seam.
+    monkeypatch.setattr(mod, "_client_model_for_kind",
+                        lambda kind: (object(), "gpt-test", "openai"))
+
+    async def _walk(*, pipeline, session_id, profile_name, run):
+        return mod._parse_verdict_strict('{"category": "in_scope", "reason": "ok"}')
+    monkeypatch.setattr(mod, "execute_with_fallback", _walk)
+
+    # Did NOT raise -> moderation was NOT bypassed; requested tier defaulted to managed.
+    v = asyncio.run(mod.check_moderation("hello", "gu", profile_name="nway", session_id="s"))
+    assert v.requested_tier == "managed"
+    assert v.category == "in_scope"

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -87,7 +87,6 @@ def test_resolve_chain_populates_profile_and_step(monkeypatch):
 
     md = trace.current().to_metadata()
     assert md["profile"] == {"name": "oss", "weight": 100}
-    assert md["variant"] == "oss"
     step = md["steps"]["agent"]
     assert step["provider"] == "vllm"
     assert step["model"] == "gemma"
@@ -170,7 +169,7 @@ def test_fallback_walker_records_served_index(monkeypatch):
         return "answer"
 
     out = asyncio.run(fb.execute_with_fallback(
-        pipeline="chat", session_id="s", variant="oss", run=_run))
+        pipeline="chat", session_id="s", profile_name="oss", run=_run))
     assert out == "answer"
     served = trace.current().to_metadata()["steps"]["agent"]["tier_served"]
     assert served == {"kind": "managed", "index": 1}

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -128,15 +128,34 @@ def test_two_profile_shim_reproduces_oss_pct_boundary_exactly():
             assert split.deterministic_profile(sid, cfg) == expected
 
 
-def test_split_variant_is_bit_compatible_independent():
-    """variant_for_profile(weighted-split) == the independently-recomputed voice
-    pipeline_router boundary for every pct (proof needs no legacy import)."""
-    for pct in (1, 25, 80, 100):
+def test_2way_parity_name_threading_is_bit_identical():
+    """HARD no-regression bar: at the 2-way env-shim config (profiles named
+    oss/managed) threading the resolved profile NAME is bit-identical to the old
+    ``variant='oss'`` path:
+
+      * bucket < pct  -> name 'oss',    AGENT primary kind 'oss'    (is_oss True)
+      * bucket >= pct -> name 'managed', AGENT primary kind 'managed' (is_oss False)
+
+    and threading that NAME through ``resolve_chain(profile_name=...)`` yields the
+    SAME chain (kinds + models) as the sticky ``resolve_profile`` path — proving the
+    N->2 ``variant`` collapse is gone with zero behaviour change. ``is_oss`` is now
+    derived from the AGENT primary tier KIND (the serving-path change), and here it
+    matches the old ``bucket < pct`` bit exactly."""
+    import asyncio
+
+    for pct in (0, 30, 100):
         cfg = two_profile_config(pct)
-        for i in range(500):
-            sid = f"compat-{pct}-{i}"
-            new = split.variant_for_profile(split.deterministic_profile(sid, cfg))
-            assert new == _ref_variant(sid, pct), f"pct={pct} sid={sid}"
+        for i in range(300):
+            sid = f"parity-{pct}-{i}"
+            in_oss = _ref_bucket(sid) < pct
+            name = split.deterministic_profile(sid, cfg)
+            assert name == ("oss" if in_oss else "managed")
+            sticky = asyncio.run(split.resolve_chain(sid, Step.AGENT, cfg))
+            is_oss = sticky[0].kind == "oss"          # the new is_oss-from-kind bit
+            assert is_oss is in_oss                   # == old bucket<pct variant bit
+            named = asyncio.run(split.resolve_chain(sid, Step.AGENT, cfg, profile_name=name))
+            assert [c.kind for c in named] == [c.kind for c in sticky]
+            assert [c.model_name for c in named] == [c.model_name for c in sticky]
 
 
 def test_cumulative_buckets_over_three_profiles():
@@ -256,13 +275,13 @@ def test_fallback_chain_uses_split(monkeypatch):
 
     sentinel = ["MATERIALIZED_TIER"]
 
-    async def _spy(session_id, step, *, variant=None):
+    async def _spy(session_id, step, *, profile_name=None):
         assert step is Step.MODERATION
-        assert variant == "oss"   # the router-resolved variant is threaded through
+        assert profile_name == "oss"   # the router-resolved profile NAME is threaded through
         return sentinel
 
     monkeypatch.setattr(split, "resolve_chain", _spy)
-    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="s", variant="oss"))
+    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="s", profile_name="oss"))
     assert chain is sentinel
 
 
@@ -275,10 +294,80 @@ def test_fallback_chain_degrades_to_managed_on_split_error(monkeypatch):
 
     runtime.configure(run_self_check=False)   # synthesized (managed-only) config
 
-    async def _boom(session_id, step, *, variant=None):
+    async def _boom(session_id, step, *, profile_name=None):
         raise RuntimeError("config blew up")
 
     monkeypatch.setattr(split, "resolve_chain", _boom)
-    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="s", variant="oss"))
+    chain = asyncio.run(fb._resolve_chain(pipeline="moderation", session_id="s", profile_name="oss"))
     assert len(chain) >= 1                       # degrade chain is never empty
     assert chain[-1].kind == "managed"
+
+
+# ── N-way ("nxn"): the 3-profile yaml is loaded, distributed AND served ────────
+# The proof that a 3rd profile is actually SERVED (not collapsed to oss/managed):
+# deterministic_profile buckets across all 3 by weight, and each profile's AGENT
+# primary tier resolves to ITS configured model (gemma/qwen/gpt) with the right kind.
+
+import os as _os
+
+_EXAMPLE_YAML = _os.path.join(
+    _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))), "pipeline.example.yaml"
+)
+
+
+def test_nway_three_profile_yaml_distributes_and_serves(monkeypatch):
+    from app.llm_core import runtime, resolver
+
+    monkeypatch.setenv("PIPELINE_CONFIG_PATH", _EXAMPLE_YAML)
+    cfg = runtime.configure(run_self_check=False)   # parse N NamedProfiles w/ per-step tiers
+    try:
+        assert {p.name for p in cfg.profiles} == {"gemma", "qwen", "gpt"}
+        assert [p.weight for p in cfg.profiles] == [5, 10, 85]
+
+        # (1) deterministic_profile distributes across ALL THREE by weight (5/10/85).
+        n = 8000
+        counts = {"gemma": 0, "qwen": 0, "gpt": 0}
+        for i in range(n):
+            counts[split.deterministic_profile(f"nway-{i}", cfg)] += 1
+        assert 0.03 < counts["gemma"] / n < 0.07
+        assert 0.07 < counts["qwen"] / n < 0.13
+        assert 0.80 < counts["gpt"] / n < 0.90
+
+        # (2) each profile's AGENT primary tier is ITS model + kind — served, not
+        # collapsed. A qwen-on-vLLM profile is "oss"; the gpt profile is "managed".
+        gemma = resolver.primary_tier(Step.AGENT, "gemma")
+        qwen = resolver.primary_tier(Step.AGENT, "qwen")
+        gpt = resolver.primary_tier(Step.AGENT, "gpt")
+        assert (gemma.model_name, gemma.kind) == ("gemma-4-31b-it", "oss")
+        assert (qwen.model_name, qwen.kind) == ("qwen2.5-32b-instruct", "oss")
+        assert (gpt.model_name, gpt.kind) == ("gpt-4.1", "managed")
+        # unknown name fail-safes: managed if present, else profiles[0] (here gemma,
+        # since this N-way config has no "managed" profile) — never raises.
+        assert resolver.primary_tier(Step.AGENT, "does-not-exist").model_name == "gemma-4-31b-it"
+    finally:
+        # delenv BEFORE reconfigure so the global is restored to the env-shim (not the
+        # yaml) for later tests — monkeypatch's own teardown runs only after this.
+        monkeypatch.delenv("PIPELINE_CONFIG_PATH", raising=False)
+        runtime.configure(run_self_check=False)
+
+
+# ── self_check over ALL profiles: a broken 3rd-profile tier is reported, non-fatal ─
+
+def test_self_check_reports_broken_third_profile_nonfatal(monkeypatch, caplog):
+    """runtime.self_check iterates EVERY profile by name and resolves each configured
+    step's primary tier, so a broken 3rd-profile tier (here: a vLLM agent tier with no
+    endpoint -> factory raises at build) is caught at boot. It must WARN, not raise."""
+    import logging
+    from app.llm_core import runtime
+
+    broken_agent = Tier(provider=Provider.VLLM, model="broken", endpoint=None,
+                        api_key_env="OSS_INFERENCE_API_KEY", timeout_ms=8000)
+    cfg = PipelineConfig(profiles=[
+        NamedProfile(name="oss", weight=45, steps={Step.AGENT: StepConfig(tiers=[_oss_tier(), _managed_tier()])}),
+        NamedProfile(name="managed", weight=45, steps={Step.AGENT: StepConfig(tiers=[_managed_tier()])}),
+        NamedProfile(name="broken", weight=10, steps={Step.AGENT: StepConfig(tiers=[broken_agent])}),
+    ])
+    monkeypatch.setattr(runtime, "PIPELINE", cfg)
+    with caplog.at_level(logging.WARNING):
+        runtime.self_check()                 # must NOT raise (non-fatal)
+    assert "broken/agent" in caplog.text     # the broken 3rd profile is reported


### PR DESCRIPTION
## N-way ("nxn") routing + dynamic redis config + separate overflow model

Completes the operator routing requirements: route sessions across **N** weighted models (not just 2), change the split **without a redeploy**, and set the concurrency-overflow model **independently**. Three milestones, both repos in sync.

### M1 — N-way weighted-profile routing (req #1)
Retire the 2-way `variant` string; thread the profile **name** so a 3rd+ profile is served by its own tiers instead of collapsing to the managed chain. `resolver.primary_tier`/`split.resolve_chain`/`post_translation_tiers` select by name; `is_oss` derives from the resolved agent tier `.kind`; `self_check` iterates all profiles; `pipeline.example.yaml` ships 3 profiles.

### M2 — dynamic redis-backed config (req #5 + #4)
`app/llm_core/config_source.py`: channel-scoped redis key `llm_pipeline_config:{chat|voice}` holds the PipelineConfig JSON; `get_pipeline()` TTL-refreshes (~10s), fail-safe to last-good (redis down / invalid / weights≠100 → never raise). Live weight change re-buckets continuing sessions with no redeploy. `scripts/set_pipeline_config.py` = ops set/get/clear (validates before write).

### M3 — separately-configurable overflow model (req #3)
`ConcurrencyGate.overflow_tier`: when the gauge trips and it's set, the shed request routes to that specific model, independent of the session profile's fallback.

### Safety
All opt-in, default-off (`PIPELINE_CONFIG_REDIS_ENABLED`, `PIPELINE_CONFIG_PATH`, `overflow_tier` unset) → a plain deploy is byte-identical to the current 2-way pipeline (proven by a 2-way bit-parity test).

### Validation (live on dev, chat)
2-way no-regression (coherent gu/en, served by gemma); N-way (3-profile config → `/metrics step="chat"` served by 3 distinct models, no collapse); redis hot-reload (flip gemma→0% via redis, no redeploy → gemma stops being served). Tests green both repos. Voice built + unit-tested; not yet live-deployed (smoke after deploy recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)