### PR TITLE
promote(voice): AI technician context truncation fix to prod (AMUL-39)

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -766,7 +766,9 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
         lines.append("- For AI booking, first ask which farmer name the caller wants to use.")
         lines.append("- Use the selected farmer's society and codes only after the farmer is identified.")
 
-    for index, record in enumerate(envelope.farmers[:5], start=1):
+    # No cap: a farmer omitted here cannot be selected for booking, and its
+    # technician group in _build_ai_technician_summary becomes unreachable.
+    for index, record in enumerate(envelope.farmers, start=1):
         record_data = record.model_dump()
         farmer_name = record_data.get("farmerName") or "Unknown farmer"
         society_name = record_data.get("societyName") or "Unknown society"
@@ -887,6 +889,23 @@ async def _build_union_scheme_summary(farmer_unions: list[str]) -> str:
     return "\n".join(lines)
 
 
+def _dedupe_technicians(technicians: list[dict]) -> list[dict]:
+    """Drop duplicate technician rows, preserving order.
+
+    The upstream GetAITUserDetailsBySocietyCode endpoint can return the same
+    technician more than once; chat dedupes identically in
+    agents/farmer_context.py. Keyed on userId, falling back to name+mobile when
+    the id is absent.
+    """
+    unique: dict[str, dict] = {}
+    for technician in technicians:
+        key = technician.get("userId") or (
+            f"{technician.get('fullName')}|{technician.get('mobileNumber')}"
+        )
+        unique.setdefault(key, technician)
+    return list(unique.values())
+
+
 def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
     if envelope is None:
         return ""
@@ -901,7 +920,10 @@ def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
         lines.append("- When asking the farmer to choose a technician, use the technician full name in natural spoken form.")
         lines.append("- Do not ask by technician position, number, option index, or ordinal words such as first, second, or third.")
         lines.append("- Mention phone only if a disambiguating mobile number is needed.")
-        for group in technician_groups[:5]:
+        # Every group and every technician is listed. A cap here is silent: the
+        # model cannot offer a technician it never saw, nor match one the caller
+        # names, and nothing marks the list as partial (AMUL-39).
+        for group in technician_groups:
             farmer_name = group.get("farmerName") or "Unknown farmer"
             society_name = group.get("societyName") or "Unknown society"
             society_code = group.get("societyCode")
@@ -910,11 +932,11 @@ def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
                 f"- Technician group: farmer_name={farmer_name}, society_name={society_name}, "
                 f"union_code={union_code}, society_code={society_code}"
             )
-            technicians = group.get("technicians") or []
+            technicians = _dedupe_technicians(group.get("technicians") or [])
             if not technicians:
                 lines.append("- AI technician option: none available for this farmer group.")
                 continue
-            for technician in technicians[:5]:
+            for technician in technicians:
                 name = technician.get("fullName")
                 mobile = technician.get("mobileNumber")
                 user_id = technician.get("userId")

--- a/tests/test_ai_technician_summary_no_truncation.py
+++ b/tests/test_ai_technician_summary_no_truncation.py
@@ -1,0 +1,102 @@
+"""Regression tests for AMUL-39.
+
+Voice silently capped the AI technician context at 5 groups and 5 technicians
+per group, so the agent could neither offer nor recognise technicians past the
+cap. Chat (agents/farmer_context.py) never capped, which is why the same query
+worked there.
+"""
+
+from app.services.voice import _build_ai_technician_summary, _dedupe_technicians
+from agents.models.farmer import FarmerDataEnvelope
+
+
+def _technician(index: int) -> dict:
+    return {
+        "userId": f"AIT{index:03d}",
+        "fullName": f"Technician {index}",
+        "mobileNumber": f"90000000{index:02d}",
+    }
+
+
+def _group(index: int, technicians: list[dict]) -> dict:
+    return {
+        "farmerName": f"Farmer {index}",
+        "farmerCode": f"FC{index:03d}",
+        "societyName": f"Society {index}",
+        "societyCode": f"SC{index:03d}",
+        "unionCode": "BANAS",
+        "technicians": technicians,
+    }
+
+
+def _envelope(groups: list[dict]) -> FarmerDataEnvelope:
+    envelope = FarmerDataEnvelope()
+    envelope.aiTechnicians = groups
+    return envelope
+
+
+class TestNoTruncation:
+    def test_all_technicians_listed_beyond_legacy_cap(self):
+        technicians = [_technician(i) for i in range(1, 9)]
+        summary = _build_ai_technician_summary(_envelope([_group(1, technicians)]))
+
+        for technician in technicians:
+            assert technician["fullName"] in summary, (
+                f"{technician['fullName']} missing — technician list is truncated"
+            )
+            assert technician["userId"] in summary
+
+    def test_all_groups_listed_beyond_legacy_cap(self):
+        groups = [_group(i, [_technician(i)]) for i in range(1, 8)]
+        summary = _build_ai_technician_summary(_envelope(groups))
+
+        for index in range(1, 8):
+            assert f"Society {index}" in summary, (
+                f"Society {index} missing — technician groups are truncated"
+            )
+
+    def test_sixth_technician_is_present(self):
+        """The narrowest expression of the bug: index 5 used to be dropped."""
+        technicians = [_technician(i) for i in range(1, 7)]
+        summary = _build_ai_technician_summary(_envelope([_group(1, technicians)]))
+
+        assert "Technician 6" in summary
+
+
+class TestDedupe:
+    def test_duplicate_rows_collapse_by_user_id(self):
+        duplicated = [_technician(1), _technician(1), _technician(2)]
+        assert len(_dedupe_technicians(duplicated)) == 2
+
+    def test_falls_back_to_name_and_mobile_without_id(self):
+        row = {"userId": None, "fullName": "Ramesh Patel", "mobileNumber": "9000000001"}
+        assert len(_dedupe_technicians([row, dict(row)])) == 1
+
+    def test_distinct_technicians_are_kept(self):
+        assert len(_dedupe_technicians([_technician(1), _technician(2)])) == 2
+
+    def test_order_is_preserved(self):
+        deduped = _dedupe_technicians([_technician(3), _technician(1), _technician(3)])
+        assert [t["userId"] for t in deduped] == ["AIT003", "AIT001"]
+
+    def test_duplicates_do_not_consume_visible_slots(self):
+        """Pre-fix, 6 duplicate rows of 3 technicians surfaced as 3 of 5 slots."""
+        rows = [_technician(i) for i in (1, 1, 2, 2, 3, 3)]
+        summary = _build_ai_technician_summary(_envelope([_group(1, rows)]))
+
+        for index in (1, 2, 3):
+            assert f"Technician {index}" in summary
+        assert summary.count("AIT001") == 1
+
+
+class TestUnchangedBehaviour:
+    def test_empty_group_still_reports_none_available(self):
+        summary = _build_ai_technician_summary(_envelope([_group(1, [])]))
+        assert "none available for this farmer group" in summary
+
+    def test_no_groups_reports_unavailable(self):
+        summary = _build_ai_technician_summary(_envelope([]))
+        assert "not available in the current signed-in context" in summary
+
+    def test_none_envelope_returns_empty_string(self):
+        assert _build_ai_technician_summary(None) == ""


### PR DESCRIPTION
Promotes `8cdb615` (PR #219) from `amul-dev` to `amul-prod`.

`amul-prod` was exactly 1 commit behind `amul-dev`, so this promotion carries the truncation fix and nothing else — no unrelated changes ride along.

## What it fixes

Voice silently capped the AI technician prompt context at 5 groups / 5 technicians per group (and farmer options at 5), so the agent could neither offer a technician past the cap nor match one the caller named. Chat has no such cap, which is why the same query worked there. Also adds dedupe by `userId`, mirroring chat, since the upstream endpoint can repeat rows.

Full analysis in #219.

## Verification

- Cherry-picked clean, no conflicts
- 11 regression tests pass on this branch; `[:5]` count in `app/services/voice.py` is 0
- Already deployed to dev (VM5 `amul_voice_app`, rebuilt from `8cdb615`) — container healthy, startup clean

## Deploy

`bash ~/amul-infra/scripts/run-voice-oan-api-build.sh` on the prod jump host after merge.