### PR TITLE
promote(voice): failed-technician-lookup caching fix to prod

### DIFF
--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -71,6 +71,16 @@ def _record_needs_animals(record: FarmerRecord) -> bool:
     return bool(_record_tags(record)) and not record.animals
 
 
+def _has_failed_technician_lookup(envelope: FarmerDataEnvelope) -> bool:
+    """True when any cached technician group came from a FAILED lookup rather
+    than a society that genuinely has no technicians.
+
+    Envelopes written before the lookupFailed flag existed omit the key; those
+    are treated as successful so old cache entries are not refreshed forever.
+    """
+    return any(group.get("lookupFailed") for group in (envelope.aiTechnicians or []))
+
+
 def _refresh_lock_key(phone: str) -> str:
     return build_cache_key(_cache_key(phone), namespace=FARMER_REFRESH_LOCK_NAMESPACE)
 
@@ -127,6 +137,15 @@ async def get_cached_farmer_data(phone: str) -> Optional[FarmerDataEnvelope]:
             if envelope.farmers and "aiTechnicians" not in raw:
                 envelope.stale = True
                 envelope.staleReason = "missing_ai_technicians"
+                envelope.refreshAfter = datetime.now(timezone.utc).isoformat()
+            elif _has_failed_technician_lookup(envelope):
+                # A failed lookup was cached as an empty technician list. The
+                # key IS present, so the check above cannot catch it and the
+                # envelope is not stale by age — without this the blip would
+                # persist for the full TTL and voice would keep telling callers
+                # no technicians are available.
+                envelope.stale = True
+                envelope.staleReason = "ai_technician_lookup_failed"
                 envelope.refreshAfter = datetime.now(timezone.utc).isoformat()
             elif any(_record_needs_animals(f) for f in envelope.farmers):
                 # Backfill per-animal records (incl. AI history) for envelopes
@@ -460,6 +479,12 @@ async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:
             )
             technicians = None
 
+        # get_ai_technicians_by_society_api returns None when the lookup FAILED
+        # and [] when the society genuinely has no technicians. Both used to be
+        # flattened to [], so a transient upstream blip was cached as a
+        # confident "no technicians" for the life of the envelope. Record the
+        # difference so get_cached_farmer_data can mark the envelope stale and
+        # let the background worker retry.
         return {
             "farmerName": data.get("farmerName"),
             "farmerCode": data.get("farmerCode"),
@@ -467,6 +492,7 @@ async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:
             "societyCode": str(society_code),
             "unionCode": str(union_code),
             "technicians": [technician.model_dump() for technician in (technicians or [])],
+            "lookupFailed": technicians is None,
         }
 
     groups = await asyncio.gather(*[_fetch_for_farmer(record) for record in records])

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -934,7 +934,16 @@ def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
             )
             technicians = _dedupe_technicians(group.get("technicians") or [])
             if not technicians:
-                lines.append("- AI technician option: none available for this farmer group.")
+                if group.get("lookupFailed"):
+                    # Distinct from "none exist": the lookup errored, so the
+                    # agent must not assert the society has no technicians.
+                    lines.append(
+                        "- AI technician option: could not be retrieved for this farmer group "
+                        "right now; say technician details are temporarily unavailable and ask "
+                        "the caller to try again later. Do not say the society has no technicians."
+                    )
+                else:
+                    lines.append("- AI technician option: none available for this farmer group.")
                 continue
             for technician in technicians:
                 name = technician.get("fullName")

--- a/tests/test_technician_lookup_failure_not_cached.py
+++ b/tests/test_technician_lookup_failure_not_cached.py
@@ -1,0 +1,126 @@
+"""A failed AI-technician lookup must not be cached as "no technicians".
+
+get_ai_technicians_by_society_api returns None on failure and [] when the
+society genuinely has none. Both were flattened to [] in the cached envelope,
+so a transient upstream blip was indistinguishable from an empty society and
+persisted for the life of the envelope: the "aiTechnicians" key was present
+(so the missing_ai_technicians check could not fire) and the envelope was not
+stale by age.
+"""
+
+import pytest
+
+from agents.models.farmer import FarmerDataEnvelope
+from agents.services.farmer_cache import _has_failed_technician_lookup
+from app.services.voice import _build_ai_technician_summary
+
+
+def _group(*, technicians: list[dict], lookup_failed: bool | None) -> dict:
+    group = {
+        "farmerName": "Farmer 1",
+        "farmerCode": "FC001",
+        "societyName": "Society 1",
+        "societyCode": "SC001",
+        "unionCode": "BANAS",
+        "technicians": technicians,
+    }
+    if lookup_failed is not None:
+        group["lookupFailed"] = lookup_failed
+    return group
+
+
+def _envelope(groups: list[dict]) -> FarmerDataEnvelope:
+    envelope = FarmerDataEnvelope()
+    envelope.aiTechnicians = groups
+    return envelope
+
+
+class TestFailedLookupDetection:
+    def test_failed_lookup_is_detected(self):
+        envelope = _envelope([_group(technicians=[], lookup_failed=True)])
+        assert _has_failed_technician_lookup(envelope) is True
+
+    def test_genuinely_empty_society_is_not_a_failure(self):
+        envelope = _envelope([_group(technicians=[], lookup_failed=False)])
+        assert _has_failed_technician_lookup(envelope) is False
+
+    def test_successful_lookup_is_not_a_failure(self):
+        group = _group(
+            technicians=[{"userId": "AIT001", "fullName": "A", "mobileNumber": "9"}],
+            lookup_failed=False,
+        )
+        assert _has_failed_technician_lookup(_envelope([group])) is False
+
+    def test_legacy_envelope_without_the_flag_is_not_a_failure(self):
+        """Pre-flag cache entries omit the key; treating them as failed would
+        refresh them forever."""
+        envelope = _envelope([_group(technicians=[], lookup_failed=None)])
+        assert _has_failed_technician_lookup(envelope) is False
+
+    def test_one_failed_group_among_several_is_detected(self):
+        groups = [
+            _group(technicians=[{"userId": "AIT001"}], lookup_failed=False),
+            _group(technicians=[], lookup_failed=True),
+        ]
+        assert _has_failed_technician_lookup(_envelope(groups)) is True
+
+    def test_no_groups_is_not_a_failure(self):
+        assert _has_failed_technician_lookup(_envelope([])) is False
+
+
+class TestPromptWording:
+    def test_failed_lookup_does_not_claim_none_exist(self):
+        summary = _build_ai_technician_summary(
+            _envelope([_group(technicians=[], lookup_failed=True)])
+        )
+        assert "temporarily unavailable" in summary
+        assert "none available for this farmer group" not in summary
+
+    def test_genuinely_empty_society_still_says_none_available(self):
+        summary = _build_ai_technician_summary(
+            _envelope([_group(technicians=[], lookup_failed=False)])
+        )
+        assert "none available for this farmer group" in summary
+        assert "temporarily unavailable" not in summary
+
+    def test_legacy_envelope_keeps_the_none_available_wording(self):
+        summary = _build_ai_technician_summary(
+            _envelope([_group(technicians=[], lookup_failed=None)])
+        )
+        assert "none available for this farmer group" in summary
+
+
+class TestFetchMarksFailure:
+    @pytest.mark.asyncio
+    async def test_api_none_marks_lookup_failed(self, monkeypatch):
+        import agents.services.farmer_cache as fc
+
+        monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
+
+        async def _api_returns_none(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(fc, "get_ai_technicians_by_society_api", _api_returns_none)
+
+        record = fc.FarmerRecord(unionCode="BANAS", societyCode="SC001")
+        groups = await fc._fetch_ai_technicians([record])
+
+        assert groups[0]["lookupFailed"] is True
+        assert groups[0]["technicians"] == []
+
+    @pytest.mark.asyncio
+    async def test_api_empty_list_does_not_mark_failure(self, monkeypatch):
+        import agents.services.farmer_cache as fc
+
+        monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
+
+        async def _api_returns_empty(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(fc, "get_ai_technicians_by_society_api", _api_returns_empty)
+
+        record = fc.FarmerRecord(unionCode="BANAS", societyCode="SC001")
+        groups = await fc._fetch_ai_technicians([record])
+
+        assert groups[0]["lookupFailed"] is False
+        assert groups[0]["technicians"] == []


### PR DESCRIPTION
Promotes `c56725a` (PR #221) from `amul-dev` to `amul-prod`.

Delta vs `amul-prod` is exactly the 3 files of that fix — the truncation fix (#219) is already on prod as `4c0b242`, so nothing else rides along.

A failed AI-technician lookup was cached as a confident "no technicians" and could not be recovered within the envelope's life (the staleness check tests key presence, not emptiness; the envelope stays fresh by age). One upstream blip silenced technician details for that caller for up to 24h. Full analysis in #221.

Verified on this branch: 22 tests pass (11 new + the 11 truncation regressions from #219). Already deployed to dev — VM5 `amul_voice_app` rebuilt from `c56725a`, healthy.