### PR TITLE
fix(gu): pin RAMESHBHAI to રમેશભાઈ (TranslateGemma long-vowel artifact)

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -212,6 +212,17 @@ _PROTECTED_OUTPUT = [
         ),
         "ખેડા ડિસ્ટ્રિક્ટ સેન્ટ્રલ કો-ઓપરેટિવ બેંક લિમિટેડ - નડિયાદ",
     ),
+    (
+        # TranslateGemma transliterates this name letter-by-letter off the Latin
+        # spelling and lengthens the first vowel — રામેશભાઈ ("Raamesh"), verified
+        # against the live 27b-base on every phrasing tried. Standard Gujarati is
+        # રમેશભાઈ. The regex also matches the already-correct form so the pin is a
+        # harmless self-replace when a different tier (gemma-4 / managed overflow)
+        # served the text, and the output is identical whichever tier answered.
+        "RAMESHBHAI",
+        re.compile(r"રા?મેશભાઈ"),
+        "રમેશભાઈ",
+    ),
 ]
 # Chars to hold back in streaming so a forming match completes before flushing
 # (> the longest model rendering of any protected term).
@@ -219,10 +230,15 @@ _PROTECTED_STREAM_HOLDBACK = 80
 
 
 def _protected_output_triggers(source_text: str, target_lang: str):
-    """Regex/pinned pairs whose English trigger appears in the source (gu target only)."""
+    """Regex/pinned pairs whose English trigger appears in the source (gu target only).
+
+    The trigger match is case-insensitive: a personal name reaches the translator in
+    whatever case the upstream record or the agent's sentence used (RAMESHBHAI /
+    Rameshbhai), and a case-sensitive gate would silently skip the pin for most of them."""
     if not source_text or target_lang.lower() not in ("gujarati", "gu"):
         return []
-    return [(rx, pinned) for en, rx, pinned in _PROTECTED_OUTPUT if en in source_text]
+    lowered = source_text.lower()
+    return [(rx, pinned) for en, rx, pinned in _PROTECTED_OUTPUT if en.lower() in lowered]
 
 
 def _apply_protected_output(text: str, triggers) -> str:

--- a/tests/test_protected_proper_nouns.py
+++ b/tests/test_protected_proper_nouns.py
@@ -1,0 +1,76 @@
+"""Pinned Gujarati renderings for protected proper nouns.
+
+Covers the RAMESHBHAI pin. TranslateGemma transliterates the name off the Latin
+spelling and lengthens the first vowel (રામેશભાઈ, "Raamesh"); the pin rewrites it
+to the standard રમેશભાઈ. The raw strings below are verbatim live output from the
+27b-base LB, so these tests fail if the pin's regex stops matching what the model
+actually emits.
+"""
+
+import os
+
+# Import-time guard used across this tests/ tree: translation.py builds clients at
+# module import, which needs a key present even though these tests never call out.
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+
+from app.services.translation import (
+    _apply_protected_output,
+    _buffered_protected_stream,
+    _protected_output_triggers,
+)
+
+# Verbatim TranslateGemma output for an English sentence naming the farmer.
+TG_RAW = "નમસ્તે રામેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
+TG_PINNED = "નમસ્તે રમેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
+
+EN_SRC = "Hello RAMESHBHAI KANUBHAI PARMAR2, your milk for the last 7 days is 17.83 litres."
+
+
+def test_long_vowel_rendering_is_pinned():
+    out = _apply_protected_output(TG_RAW, _protected_output_triggers(EN_SRC, "gu"))
+    assert out == TG_PINNED
+    assert "રામેશભાઈ" not in out
+
+
+def test_already_correct_rendering_is_left_alone():
+    """A tier that already spells it correctly (gemma-4 / managed overflow) must
+    round-trip unchanged — the pin is a self-replace, not a double-edit."""
+    good = "રમેશભાઈ પાસે ૩ ભેંસ છે."
+    assert _apply_protected_output(good, _protected_output_triggers(EN_SRC, "gu")) == good
+
+
+@pytest.mark.parametrize("src", [
+    "Hello RAMESHBHAI, your milk is ready.",
+    "Hello Rameshbhai, your milk is ready.",
+    "hello rameshbhai, your milk is ready.",
+])
+def test_trigger_gate_is_case_insensitive(src):
+    """The name arrives in whatever case the record or the agent's sentence used."""
+    assert _protected_output_triggers(src, "gu")
+
+
+def test_no_trigger_when_name_absent():
+    """Ordinary traffic must not be rewritten (or, on the streaming path, buffered)."""
+    assert _protected_output_triggers("Your milk fat is 8.91 percent.", "gu") == []
+
+
+def test_no_trigger_for_non_gujarati_target():
+    assert _protected_output_triggers(EN_SRC, "hi") == []
+
+
+@pytest.mark.asyncio
+async def test_pin_survives_a_chunk_boundary_mid_name():
+    """Streaming splits tokens arbitrarily; the holdback buffer must let a name
+    broken across two chunks still match before it is flushed."""
+    chunks = ["નમસ્તે રા", "મેશભાઈ કાનુભાઈ પરમાર, તમારું દૂધ તૈયાર છે."]
+
+    async def gen():
+        for c in chunks:
+            yield c
+
+    triggers = _protected_output_triggers(EN_SRC, "gu")
+    out = "".join([c async for c in _buffered_protected_stream(gen(), triggers)])
+    assert "રમેશભાઈ" in out
+    assert "રામેશભાઈ" not in out


### PR DESCRIPTION
Urgent fix: pin the Gujarati rendering of **RAMESHBHAI** to **રમેશભાઈ**.

## Why

TranslateGemma transliterates the name letter-by-letter off the Latin spelling and lengthens the first vowel. Verified against the live 27b-base LB (`10.185.25.198:8030`) using this repo's own production prompt (`_build_translation_instruction` + `_wrap_translategemma_prompt`), `temperature: 0`:

| English in | TranslateGemma out |
|---|---|
| `Hello RAMESHBHAI KANUBHAI PARMAR2, your milk collection…` | નમસ્તે **રામેશભાઈ** કાનુભાઈ પરમાર, … |
| `Rameshbhai, your buffalo milk fat is 8.91 percent.` | **રામેશભાઈ**, તમારા ભેંસના દૂધમાં … |
| `Good morning Rameshbhai Kanubhai Parmar, …` | સુપ્રભાત, **રામેશભાઈ** કાનુભાઈ પરમાર, … |

`રામેશ` reads "Raamesh". Standard Gujarati is `રમેશ`. gemma-4-31b-it gets it right (`રમેશભાઈ`) — this is a TranslateGemma-specific artifact, same family as the ૫↔પ confusion already patched around in this file.

## Approach: pin, not prompt

Uses the existing `_PROTECTED_OUTPUT` mechanism — deterministic post-replacement, gated on the English source containing the term, applied on both the unary and streaming paths. A prompt/glossary rule was the alternative, but a base translation model is free to ignore it, and it would add tokens to every request to fix one name.

Two deliberate properties:

- **The regex matches the already-correct form too**, so the pin is a harmless self-replace when gemma-4 or the managed overflow tier served the text. Output is identical whichever tier answered — no tier-dependent spelling.
- **It requires the `ભાઈ` suffix**, so a bare "Ramesh" is untouched. Checked: the technician booking matcher fixture uses `રમેશ પટેલ` and is unaffected.

This normalises the spelling for *any* Rameshbhai, not just this farmer record — `રમેશભાઈ` is the correct rendering in every case.

## Also: the trigger gate was case-sensitive

`_protected_output_triggers` used `if en in source_text`. A personal name reaches the translator in whatever case the record or the agent's sentence used (`RAMESHBHAI` from the record, `Rameshbhai` in prose), so the pin would have silently no-op'd for most real traffic. Now lowercased on both sides — strictly widening, no effect on the existing bank-name entry.

## Tests

New `tests/test_protected_proper_nouns.py`, 8 tests: the live-verified long-vowel rendering is pinned; the correct form round-trips unchanged; the gate fires across three casings; no trigger when the name is absent; no trigger for non-`gu` targets; and the pin survives a chunk boundary splitting the name mid-word on the streaming path.

**8 passed.** Local checkouts can't run the suite (pre-existing: 11 collection errors on the untouched base tree from a `pydantic_ai` version mismatch), so these were run in a clean venv built from `requirements.txt`.

Regression-checked by diffing failing-test names with and without the patch on the translation-adjacent selection: **zero new failures**; 5 of the new tests flip from failing to passing; the 5 remaining failures are present identically on the base tree and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)