### PR TITLE
promote(prod): pin RAMESHBHAI to રમેશભાઈ

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -212,6 +212,17 @@ _PROTECTED_OUTPUT = [
         ),
         "ખેડા ડિસ્ટ્રિક્ટ સેન્ટ્રલ કો-ઓપરેટિવ બેંક લિમિટેડ - નડિયાદ",
     ),
+    (
+        # TranslateGemma transliterates this name letter-by-letter off the Latin
+        # spelling and lengthens the first vowel — રામેશભાઈ ("Raamesh"), verified
+        # against the live 27b-base on every phrasing tried. Standard Gujarati is
+        # રમેશભાઈ. The regex also matches the already-correct form so the pin is a
+        # harmless self-replace when a different tier (gemma-4 / managed overflow)
+        # served the text, and the output is identical whichever tier answered.
+        "RAMESHBHAI",
+        re.compile(r"રા?મેશભાઈ"),
+        "રમેશભાઈ",
+    ),
 ]
 # Chars to hold back in streaming so a forming match completes before flushing
 # (> the longest model rendering of any protected term).
@@ -219,10 +230,15 @@ _PROTECTED_STREAM_HOLDBACK = 80
 
 
 def _protected_output_triggers(source_text: str, target_lang: str):
-    """Regex/pinned pairs whose English trigger appears in the source (gu target only)."""
+    """Regex/pinned pairs whose English trigger appears in the source (gu target only).
+
+    The trigger match is case-insensitive: a personal name reaches the translator in
+    whatever case the upstream record or the agent's sentence used (RAMESHBHAI /
+    Rameshbhai), and a case-sensitive gate would silently skip the pin for most of them."""
     if not source_text or target_lang.lower() not in ("gujarati", "gu"):
         return []
-    return [(rx, pinned) for en, rx, pinned in _PROTECTED_OUTPUT if en in source_text]
+    lowered = source_text.lower()
+    return [(rx, pinned) for en, rx, pinned in _PROTECTED_OUTPUT if en.lower() in lowered]
 
 
 def _apply_protected_output(text: str, triggers) -> str:

--- a/tests/test_protected_proper_nouns.py
+++ b/tests/test_protected_proper_nouns.py
@@ -1,0 +1,76 @@
+"""Pinned Gujarati renderings for protected proper nouns.
+
+Covers the RAMESHBHAI pin. TranslateGemma transliterates the name off the Latin
+spelling and lengthens the first vowel (રામેશભાઈ, "Raamesh"); the pin rewrites it
+to the standard રમેશભાઈ. The raw strings below are verbatim live output from the
+27b-base LB, so these tests fail if the pin's regex stops matching what the model
+actually emits.
+"""
+
+import os
+
+# Import-time guard used across this tests/ tree: translation.py builds clients at
+# module import, which needs a key present even though these tests never call out.
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+
+from app.services.translation import (
+    _apply_protected_output,
+    _buffered_protected_stream,
+    _protected_output_triggers,
+)
+
+# Verbatim TranslateGemma output for an English sentence naming the farmer.
+TG_RAW = "નમસ્તે રામેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
+TG_PINNED = "નમસ્તે રમેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
+
+EN_SRC = "Hello RAMESHBHAI KANUBHAI PARMAR2, your milk for the last 7 days is 17.83 litres."
+
+
+def test_long_vowel_rendering_is_pinned():
+    out = _apply_protected_output(TG_RAW, _protected_output_triggers(EN_SRC, "gu"))
+    assert out == TG_PINNED
+    assert "રામેશભાઈ" not in out
+
+
+def test_already_correct_rendering_is_left_alone():
+    """A tier that already spells it correctly (gemma-4 / managed overflow) must
+    round-trip unchanged — the pin is a self-replace, not a double-edit."""
+    good = "રમેશભાઈ પાસે ૩ ભેંસ છે."
+    assert _apply_protected_output(good, _protected_output_triggers(EN_SRC, "gu")) == good
+
+
+@pytest.mark.parametrize("src", [
+    "Hello RAMESHBHAI, your milk is ready.",
+    "Hello Rameshbhai, your milk is ready.",
+    "hello rameshbhai, your milk is ready.",
+])
+def test_trigger_gate_is_case_insensitive(src):
+    """The name arrives in whatever case the record or the agent's sentence used."""
+    assert _protected_output_triggers(src, "gu")
+
+
+def test_no_trigger_when_name_absent():
+    """Ordinary traffic must not be rewritten (or, on the streaming path, buffered)."""
+    assert _protected_output_triggers("Your milk fat is 8.91 percent.", "gu") == []
+
+
+def test_no_trigger_for_non_gujarati_target():
+    assert _protected_output_triggers(EN_SRC, "hi") == []
+
+
+@pytest.mark.asyncio
+async def test_pin_survives_a_chunk_boundary_mid_name():
+    """Streaming splits tokens arbitrarily; the holdback buffer must let a name
+    broken across two chunks still match before it is flushed."""
+    chunks = ["નમસ્તે રા", "મેશભાઈ કાનુભાઈ પરમાર, તમારું દૂધ તૈયાર છે."]
+
+    async def gen():
+        for c in chunks:
+            yield c
+
+    triggers = _protected_output_triggers(EN_SRC, "gu")
+    out = "".join([c async for c in _buffered_protected_stream(gen(), triggers)])
+    assert "રમેશભાઈ" in out
+    assert "રામેશભાઈ" not in out


### PR DESCRIPTION
Prod promotion of the urgent Gujarati name fix. Cherry-pick `-x` of the dev commit, clean, no conflicts.

Pins **RAMESHBHAI** → **રમેશભાઈ**. TranslateGemma renders it **રામેશભાઈ** ("Raamesh") — verified against the live 27b-base LB with this repo's production prompt at `temperature: 0`, on every phrasing tried. Standard Gujarati is `રમેશ`. gemma-4 already gets it right, so this is a TranslateGemma-specific artifact, same family as the ૫↔પ confusion already patched around in this file.

Uses the existing `_PROTECTED_OUTPUT` mechanism (deterministic post-replacement, gated on the English source containing the term, applied on both the unary and streaming paths) rather than a prompt rule a base translation model is free to ignore.

Also fixes the trigger gate, which was case-sensitive (`if en in source_text`). The name arrives as `RAMESHBHAI` from the record but `Rameshbhai` in prose, so the pin would have silently no-op'd on most real traffic.

**Safety:**
- The regex matches the already-correct spelling too → self-replace no-op when gemma-4 or the managed overflow tier answers. Same output whichever tier serves.
- Requires the `ભાઈ` suffix → bare "Ramesh" untouched (checked against the technician booking matcher fixture `રમેશ પટેલ`).
- Normalises the spelling for any Rameshbhai, not just this record.

**Tests:** 8, all passing **against this prod base** (not just dev) in a clean venv — local checkouts can't run the suite due to a pre-existing `pydantic_ai` version mismatch. Covers the pinned rendering, the correct-form round trip, three casings of the gate, absent-name and non-`gu` no-ops, and a chunk boundary splitting the name mid-word on the streaming path.

Deploys via `run-{amul-oan-api,voice-oan-api}-build.sh` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)