### PR TITLE
promote(prod): pin the vowel રામેશ→રમેશ (streaming-path fix)

### DIFF
--- a/app/services/translation.py
+++ b/app/services/translation.py
@@ -214,14 +214,22 @@ _PROTECTED_OUTPUT = [
     ),
     (
         # TranslateGemma transliterates this name letter-by-letter off the Latin
-        # spelling and lengthens the first vowel — રામેશભાઈ ("Raamesh"), verified
-        # against the live 27b-base on every phrasing tried. Standard Gujarati is
-        # રમેશભાઈ. The regex also matches the already-correct form so the pin is a
-        # harmless self-replace when a different tier (gemma-4 / managed overflow)
-        # served the text, and the output is identical whichever tier answered.
-        "RAMESHBHAI",
-        re.compile(r"રા?મેશભાઈ"),
-        "રમેશભાઈ",
+        # spelling and lengthens the first vowel: રામેશ ("Raamesh") for રમેશ.
+        #
+        # Pin the VOWEL, not the whole name. An earlier ભાઈ-anchored pattern
+        # (રા?મેશભાઈ) worked on the unary path but was a no-op on the streaming
+        # path — verified in a prod pod, the streaming tier renders the same
+        # English as "રામેશ કાનુભાઈ પરમાર", dropping ભાઈ off the first name, so
+        # the anchor never matched on the path voice actually delivers on.
+        #
+        # Rewriting રામેશ -> રમેશ is safe in a way the anchored form was not: it
+        # can only fire on the INCORRECT long-vowel spelling. Already-correct text
+        # (રમેશભાઈ, and the technician રમેશ પટેલ in the booking matcher) does not
+        # contain રામેશ and is left untouched, so this is still a self-replace
+        # no-op whenever gemma-4 or the managed overflow tier served the text.
+        "RAMESH",
+        re.compile(r"રામેશ"),
+        "રમેશ",
     ),
 ]
 # Chars to hold back in streaming so a forming match completes before flushing

--- a/tests/test_protected_proper_nouns.py
+++ b/tests/test_protected_proper_nouns.py
@@ -1,10 +1,12 @@
 """Pinned Gujarati renderings for protected proper nouns.
 
-Covers the RAMESHBHAI pin. TranslateGemma transliterates the name off the Latin
-spelling and lengthens the first vowel (રામેશભાઈ, "Raamesh"); the pin rewrites it
-to the standard રમેશભાઈ. The raw strings below are verbatim live output from the
-27b-base LB, so these tests fail if the pin's regex stops matching what the model
-actually emits.
+Covers the Ramesh pin. TranslateGemma lengthens the first vowel — રામેશ
+("Raamesh") for રમેશ — and the two translation paths disagree on the rest of the
+name: the unary path keeps રામેશભાઈ while the streaming path drops ભાઈ and emits
+a bare રામેશ. The pin therefore normalises the VOWEL rather than the whole name.
+All raw strings below are verbatim live output from the 27b-base LB (the streaming
+ones captured inside a prod pod), so these tests fail if the pin's regex stops
+matching what the model actually emits on either path.
 """
 
 import os
@@ -24,6 +26,12 @@ from app.services.translation import (
 # Verbatim TranslateGemma output for an English sentence naming the farmer.
 TG_RAW = "નમસ્તે રામેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
 TG_PINNED = "નમસ્તે રમેશભાઈ કાનુભાઈ પરમાર, છેલ્લાં 7 દિવસમાં તમારું દૂધ 17.83 લિટર છે."
+
+# Verbatim STREAMING-path output from a prod pod: ભાઈ dropped off the first name.
+# A ભાઈ-anchored pattern silently missed this, which is the whole point of the pin
+# being on the vowel.
+TG_STREAM_RAW = "નમસ્તે રામેશ કાનુભાઈ પરમાર છેલ્લાં સાત દિવસમાં આપનું દૂધ રહ્યું છે."
+TG_STREAM_PINNED = "નમસ્તે રમેશ કાનુભાઈ પરમાર છેલ્લાં સાત દિવસમાં આપનું દૂધ રહ્યું છે."
 
 EN_SRC = "Hello RAMESHBHAI KANUBHAI PARMAR2, your milk for the last 7 days is 17.83 litres."
 
@@ -74,3 +82,18 @@ async def test_pin_survives_a_chunk_boundary_mid_name():
     out = "".join([c async for c in _buffered_protected_stream(gen(), triggers)])
     assert "રમેશભાઈ" in out
     assert "રામેશભાઈ" not in out
+
+
+def test_streaming_rendering_without_bhai_is_pinned():
+    """The streaming tier drops ભાઈ off the first name; the pin must still fire.
+    This is the regression that a ભાઈ-anchored pattern let through to prod."""
+    out = _apply_protected_output(TG_STREAM_RAW, _protected_output_triggers(EN_SRC, "gu"))
+    assert out == TG_STREAM_PINNED
+    assert "રામેશ" not in out
+
+
+def test_technician_short_form_is_untouched():
+    """The booking matcher's technician fixture is already correctly spelled, so the
+    pin must not perturb it — it fires only on the long-vowel misspelling."""
+    tech = "રમેશ પટેલ સાથે બુક કરો"
+    assert _apply_protected_output(tech, _protected_output_triggers(EN_SRC, "gu")) == tech


### PR DESCRIPTION
Prod promotion of the streaming-path fix. Cherry-pick `-x`, clean.

The pin shipped earlier today (`રા?મેશભાઈ` → `રમેશભાઈ`) was a **no-op on the streaming path**, which is the path voice delivers on. Verified inside a prod voice pod: the streaming tier renders the name as `રામેશ કાનુભાઈ પરમાર`, dropping `ભાઈ` off the first name, so the `ભાઈ` anchor never matched. The unary path keeps `રામેશભાઈ`, which is why the original looked correct.

Fix pins the vowel instead — `રામેશ` → `રમેશ` — which can only fire on the incorrect long-vowel spelling, leaves already-correct text (including the technician fixture `રમેશ પટેલ`) untouched, and covers both paths.

10 tests passing against this prod base. Zero new failures in the regression diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)