### PR TITLE
feat(api): accept optional call_type (inbound|outbound) from Raya

### DIFF
--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -11,4 +11,8 @@ class ChatRequest(BaseModel):
     target_lang: str = Field('gu', description="Target language code")
     user_id: str = Field('anonymous', description="User identifier (expected to be phone number for farmer context)")
     provider: Optional[Literal['RAYA']] = Field(None, description="Provider for the voice service - can be RAYA or None")
-    process_id: Optional[str] = Field(None, description="Process ID for tracking and hold messages") 
+    process_id: Optional[str] = Field(None, description="Process ID for tracking and hold messages")
+    call_type: Literal['inbound', 'outbound'] = Field(
+        'inbound',
+        description="Direction of the call as reported by the provider (inbound=farmer called us, outbound=we called the farmer). Optional; defaults to inbound.",
+    )

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -41,7 +41,7 @@ async def voice_endpoint(
         f"Voice request received - session_id: {session_id}, user_id: {request.user_id}, "
         f"source_lang: {request.source_lang}, "
         f"target_lang: {request.target_lang}, provider: {request.provider}, process_id: {request.process_id}, "
-        f"query: {request.query}"
+        f"call_type: {request.call_type}, query: {request.query}"
     )
     # These two steps happen before StreamingResponse starts iterating the
     # generator, so the router attaches their timings to the request trace.

--- a/tests/test_request_contract_call_type.py
+++ b/tests/test_request_contract_call_type.py
@@ -1,0 +1,35 @@
+"""Contract tests for the optional `call_type` query param Raya may send.
+
+`call_type` is accepted but deliberately unused for now — these tests pin the
+contract so a later consumer can rely on the default and the allowed values.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.requests import ChatRequest
+
+
+def test_call_type_defaults_to_inbound_when_absent():
+    request = ChatRequest(query="test")
+    assert request.call_type == "inbound"
+
+
+@pytest.mark.parametrize("value", ["inbound", "outbound"])
+def test_call_type_accepts_valid_values(value):
+    request = ChatRequest(query="test", call_type=value)
+    assert request.call_type == value
+
+
+def test_call_type_rejects_unknown_value():
+    with pytest.raises(ValidationError):
+        ChatRequest(query="test", call_type="transfer")
+
+
+def test_existing_fields_unchanged_by_call_type_addition():
+    request = ChatRequest(query="test")
+    assert request.source_lang == "gu"
+    assert request.target_lang == "gu"
+    assert request.user_id == "anonymous"
+    assert request.provider is None
+    assert request.process_id is None


### PR DESCRIPTION
## What

Adds an optional `call_type` query param to the voice request contract (`GET /voice`).

- Valid values: `inbound`, `outbound`
- Optional — defaults to `inbound` when Raya doesn't send it

## Why

Raya is going to start sending the call direction. We want the field accepted on dev and prod *before* they start sending it, so their rollout doesn't 422 against our validation.

## Deliberately does nothing with it (yet)

Nothing downstream consumes `call_type`. It is not threaded into the trace, the agent, or the pipeline. The only use is the existing request `logger.info` line, so we can confirm from logs that Raya is actually populating the field. Behaviour change for existing callers: none.

## Test

`tests/test_request_contract_call_type.py` pins the contract — default is `inbound`, both values accepted, unknown values rejected, and the other request fields keep their current defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)