### PR TITLE
promote(prod): outbound call opener — scripted consent + 7-day milk readout

### DIFF
--- a/agents/tools/milk_collection.py
+++ b/agents/tools/milk_collection.py
@@ -131,11 +131,6 @@ async def get_farmer_milk_collection_details(
         str: Formatted milk collection and deduction details across all of the
              farmer's accounts, or a clear failure message.
     """
-    token = os.getenv("PASHUGPT_TOKEN")
-    if not token:
-        logger.error("PASHUGPT_TOKEN is not set")
-        return "Milk collection lookup failed. Service is not configured."
-
     # Prefer the structured accounts from context (every account on the mobile).
     # Fall back to the LLM-supplied codes only when context has none.
     accounts = list(ctx.deps.farmer_accounts) if ctx.deps and ctx.deps.farmer_accounts else []
@@ -151,6 +146,29 @@ async def get_farmer_milk_collection_details(
         "Milk collection tool invoked: accounts=%s from=%s to=%s (llm_codes=%s/%s/%s)",
         len(accounts), fromdate, todate, union_code, society_code, farmer_code,
     )
+    return await fetch_milk_summary_for_accounts(accounts, fromdate, todate)
+
+
+async def fetch_milk_summary_for_accounts(
+    accounts: list[FarmerAccount],
+    fromdate: str,
+    todate: str,
+) -> str:
+    """Fan out over every account and render one plain-text summary.
+
+    Split out of the tool body so callers without a ``RunContext`` can reuse the
+    exact same fetch + formatting — notably the outbound-call prefetch, which
+    warms this summary while the caller is still hearing the intro line (see
+    ``app.services.outbound``). Any change to the wording the agent reads must
+    therefore stay in here, not in the tool wrapper.
+    """
+    token = os.getenv("PASHUGPT_TOKEN")
+    if not token:
+        logger.error("PASHUGPT_TOKEN is not set")
+        return "Milk collection lookup failed. Service is not configured."
+
+    if not accounts:
+        return "Milk collection lookup failed. No farmer account is available."
 
     # Validate the date range once — it is the same for every account, so a bad
     # date is a single clear failure rather than a per-account error.

--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,19 @@ class Settings(BaseSettings):
     openai_pretranslation_timeout_seconds: float = float(os.getenv("OPENAI_PRETRANSLATION_TIMEOUT_SECONDS", "10.0"))
     voice_non_meaningful_timeout_seconds: float = float(os.getenv("VOICE_NON_MEANINGFUL_TIMEOUT_SECONDS", "0.60"))
     voice_non_meaningful_gate_timeout_seconds: float = float(os.getenv("VOICE_NON_MEANINGFUL_GATE_TIMEOUT_SECONDS", "0.50"))
+    # Outbound-call opening script (milk-details consent). Off by default: the
+    # opener only runs for calls Raya stamps call_type=outbound, and only once
+    # the flag is on for the environment.
+    outbound_intro_enabled: bool = _get_bool_env("OUTBOUND_INTRO_ENABLED", default=False)
+    outbound_milk_window_days: int = int(os.getenv("OUTBOUND_MILK_WINDOW_DAYS", "7"))
+    # Bounded so a hung upstream can never keep a prefetch task alive across the
+    # whole call; the caller's reply arrives long before this.
+    outbound_milk_prefetch_timeout_seconds: float = float(
+        os.getenv("OUTBOUND_MILK_PREFETCH_TIMEOUT_SECONDS", "25.0")
+    )
+    voice_outbound_consent_timeout_seconds: float = float(
+        os.getenv("VOICE_OUTBOUND_CONSENT_TIMEOUT_SECONDS", "0.60")
+    )
     enable_voice_tracing: bool = _get_bool_env("ENABLE_VOICE_TRACING", default=True)
     voice_trace_text_mode: str = os.getenv("VOICE_TRACE_TEXT_MODE", "preview_hash")
     voice_trace_preview_chars: int = int(os.getenv("VOICE_TRACE_PREVIEW_CHARS", "120"))

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -86,6 +86,7 @@ async def voice_endpoint(
             http_request=http_request,
             trace=trace,
             pipeline_profile=pipeline_profile,
+            call_type=request.call_type,
         ),
         media_type='text/event-stream'
     )

--- a/app/services/outbound.py
+++ b/app/services/outbound.py
@@ -1,0 +1,244 @@
+"""Outbound-call opening script (milk-details consent) for voice calls.
+
+Raya stamps ``call_type=outbound`` on requests for calls WE placed. On the first
+turn of such a call Sarlaben reads a fixed consent line; on the next turn the
+farmer's reply is classified by :mod:`app.services.outbound_consent` into
+affirmative / negative / other.
+
+Everything caller-facing here is pinned Gujarati, served verbatim. It never goes
+through TranslateGemma: these lines carry a phone number, the brand name, and the
+farmer-facing framing of a data readout, all of which the translation sandwich has
+historically drifted on.
+
+State lives in Redis under the session (not in message history) so the stage
+survives history trimming and so an inbound call can never accidentally read it.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytz
+
+from agents.deps import FarmerAccount
+from app.config import settings
+from app.utils import get_cache, set_cache
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+CALL_TYPE_INBOUND = "inbound"
+CALL_TYPE_OUTBOUND = "outbound"
+
+# Session stages for the outbound opener.
+STAGE_INTRO_SENT = "intro_sent"      # consent line spoken, awaiting the farmer's reply
+STAGE_RESOLVED = "resolved"          # consent already handled; call is a normal conversation
+
+_STATE_SUFFIX = "outbound_state"
+_MILK_SUFFIX = "outbound_milk_summary"
+_STATE_TTL = 60 * 60 * 4  # a call never outlives this; keeps stale state out of Redis
+
+
+# ── Scripted lines (verbatim, never translated) ───────────────────────────────
+# Source: "Outbound call script for previously interacted (non-returning
+# registered callers)". The English variants exist only for message history and
+# for en-target test calls — the caller hears the Gujarati.
+
+OUTBOUND_INTRO = {
+    # "સાત", not the script's "7": clean_output_by_language() strips every
+    # non-Gujarati-block character for gu, so an ASCII digit would be deleted and
+    # the caller would hear "in the last  days".
+    "gu": (
+        "નમસ્તે! હું અમૂલ તરફથી સરલાબેન બોલું છું. "
+        "શું હું તમને છેલ્લા સાત દિવસમાં તમે જમા કરાવેલા દૂધની વિગતો જણાવું?"
+    ),
+    "en": (
+        "Hello! This is Sarlaben calling from Amul. "
+        "May I tell you the details of the milk you deposited in the last 7 days?"
+    ),
+}
+
+OUTBOUND_DECLINE_FAREWELL = {
+    "gu": (
+        "કંઈ વાંધો નહીં, હું આ કોલ ડિસ્કનેક્ટ કરું છું. "
+        "તમે પશુપાલન વિષે કોઈ પણ માહિતી માટે ૦૮૦૩૫૪૫૩૫૪૫ પર કોલ કે વૉટ્સએપ કરી શકો છો. "
+        "તમારો દિવસ શુભ રહે!"
+    ),
+    "en": (
+        "That is no problem, I will disconnect this call. "
+        "For any information about animal husbandry you can call or WhatsApp 080-35453545. "
+        "Have a good day!"
+    ),
+}
+
+# Said when the farmer agrees but we have nothing to read out (no accounts on the
+# number, or the upstream lookup failed). Better than reading a failure message
+# aloud, and it leaves the call open for whatever they actually need.
+OUTBOUND_NO_DATA = {
+    "gu": (
+        "માફ કરશો, અત્યારે તમારા દૂધની વિગતો મળી શકતી નથી. "
+        "પશુપાલન વિષે તમારે કંઈ પૂછવું હોય તો જણાવો."
+    ),
+    "en": (
+        "Sorry, I am not able to fetch your milk details right now. "
+        "If you have any question about animal husbandry, please tell me."
+    ),
+}
+
+
+def is_outbound(call_type: Optional[str]) -> bool:
+    return (call_type or CALL_TYPE_INBOUND).strip().lower() == CALL_TYPE_OUTBOUND
+
+
+def normalize_call_type(call_type: Optional[str]) -> str:
+    return CALL_TYPE_OUTBOUND if is_outbound(call_type) else CALL_TYPE_INBOUND
+
+
+def milk_window(days: int = 7) -> tuple[str, str]:
+    """(fromdate, todate) ISO strings for the trailing ``days``-day window, IST.
+
+    Inclusive of today, so 7 days is today plus the previous six.
+    """
+    today = datetime.now(pytz.timezone("Asia/Kolkata")).date()
+    start = today - timedelta(days=max(1, days) - 1)
+    return start.isoformat(), today.isoformat()
+
+
+# ── Session state ─────────────────────────────────────────────────────────────
+
+def _state_key(session_id: str) -> str:
+    return f"{session_id}_{_STATE_SUFFIX}"
+
+
+def _milk_key(session_id: str) -> str:
+    return f"{session_id}_{_MILK_SUFFIX}"
+
+
+async def set_stage(session_id: str, stage: str) -> None:
+    """Record the outbound stage for this session. Best-effort."""
+    try:
+        await set_cache(_state_key(session_id), {"stage": stage}, ttl=_STATE_TTL)
+    except Exception as e:  # pragma: no cover - state is an optimisation, never fatal
+        logger.warning("Outbound stage write failed - session_id=%s stage=%s error=%s", session_id, stage, e)
+
+
+async def get_stage(session_id: str) -> Optional[str]:
+    """Return the recorded stage, or None when this is not a staged outbound call."""
+    try:
+        state = await get_cache(_state_key(session_id))
+    except Exception as e:  # pragma: no cover
+        logger.warning("Outbound stage read failed - session_id=%s error=%s", session_id, e)
+        return None
+    if isinstance(state, dict):
+        stage = state.get("stage")
+        return stage if isinstance(stage, str) else None
+    return None
+
+
+# ── Milk prefetch ─────────────────────────────────────────────────────────────
+# Strong refs to in-flight prefetch tasks: asyncio only holds a weak reference, so
+# without this a prefetch can be garbage-collected mid-flight.
+_prefetch_tasks: set[asyncio.Task] = set()
+
+
+async def prefetch_milk_summary(session_id: str, accounts: list[FarmerAccount]) -> None:
+    """Fetch and cache the 7-day milk summary for this session. Never raises.
+
+    Runs while the caller is still hearing the intro line. This is the slowest
+    tool in the stack (20s upstream timeouts); doing it during the ~4s the farmer
+    takes to answer "હા" is what keeps the reply off the 60s nginx cut that drops
+    live calls.
+    """
+    from agents.tools.milk_collection import fetch_milk_summary_for_accounts
+
+    if not accounts:
+        logger.info("Outbound milk prefetch skipped (no accounts) - session_id=%s", session_id)
+        return
+
+    fromdate, todate = milk_window(settings.outbound_milk_window_days)
+    try:
+        summary = await asyncio.wait_for(
+            fetch_milk_summary_for_accounts(accounts, fromdate, todate),
+            timeout=settings.outbound_milk_prefetch_timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Outbound milk prefetch timed out - session_id=%s timeout=%.1fs",
+            session_id,
+            settings.outbound_milk_prefetch_timeout_seconds,
+        )
+        return
+    except Exception as e:
+        logger.warning("Outbound milk prefetch failed - session_id=%s error=%s", session_id, e)
+        return
+
+    try:
+        await set_cache(_milk_key(session_id), {"summary": summary}, ttl=_STATE_TTL)
+        logger.info(
+            "Outbound milk prefetch cached - session_id=%s accounts=%s chars=%s window=%s..%s",
+            session_id, len(accounts), len(summary), fromdate, todate,
+        )
+    except Exception as e:  # pragma: no cover
+        logger.warning("Outbound milk prefetch cache write failed - session_id=%s error=%s", session_id, e)
+
+
+def spawn(coro, *, label: str) -> None:
+    """Run a background coroutine that must outlive the current streaming turn.
+
+    The intro turn returns as soon as the line is spoken, so the prefetch has to
+    survive it. A bare ``create_task`` is not enough — asyncio holds only a weak
+    reference, so the task can be collected mid-flight.
+    """
+    async def _guarded():
+        try:
+            await coro
+        except Exception as e:  # pragma: no cover - background work is best-effort
+            logger.warning("Outbound background task failed - label=%s error=%s", label, e)
+
+    task = asyncio.create_task(_guarded())
+    _prefetch_tasks.add(task)
+    task.add_done_callback(_prefetch_tasks.discard)
+
+
+async def get_prefetched_milk_summary(session_id: str) -> Optional[str]:
+    try:
+        cached = await get_cache(_milk_key(session_id))
+    except Exception as e:  # pragma: no cover
+        logger.warning("Outbound milk summary read failed - session_id=%s error=%s", session_id, e)
+        return None
+    if isinstance(cached, dict):
+        summary = cached.get("summary")
+        return summary if isinstance(summary, str) and summary.strip() else None
+    return None
+
+
+def milk_fetch_hint(fromdate: str, todate: str) -> str:
+    """Hint used when the prefetch has not landed (cold cache, slow upstream).
+
+    The agent fetches the window itself with the tool. Slower than the prefetch
+    path, but the dates are pinned here so it cannot pick the wrong window.
+    """
+    return (
+        "- Outbound call: the farmer has just agreed to hear their milk deposit details. "
+        f"Call get_farmer_milk_collection_details for fromdate {fromdate} to todate {todate}, "
+        "then read the totals out conversationally — total quantity and total amount first, "
+        "then anything notable. Do not list every record one by one. End by asking if they "
+        "need anything else about animal husbandry."
+    )
+
+
+def milk_answer_hint(summary: str) -> str:
+    """Per-turn hint appended to the agent's input on an affirmative reply.
+
+    The data is handed to the agent rather than re-fetched by it: the farmer has
+    already consented to exactly this readout, so a tool round-trip here would add
+    latency and give the model a chance to call the wrong window.
+    """
+    return (
+        "- Outbound call: the farmer has just agreed to hear their milk deposit details "
+        f"for the last {settings.outbound_milk_window_days} days. Read out the summary below "
+        "conversationally: total quantity and total amount first, then anything notable. "
+        "Do not list every record one by one. Do not call any tool to fetch this — it is "
+        "already fetched. End by asking if they need anything else about animal husbandry.\n"
+        f"Milk deposit summary:\n{summary}"
+    )

--- a/app/services/outbound_consent.py
+++ b/app/services/outbound_consent.py
@@ -1,0 +1,183 @@
+"""Outbound-call consent classifier.
+
+On an outbound call we open with one scripted question ("may I read out your last
+7 days of milk deposits?"). The farmer's first reply is not a yes/no token — it is
+free speech through a noisy ASR, and the single most valuable reply ("my cow isn't
+eating") is neither yes nor no. So this is a small LLM gate, not a matcher.
+
+Three-way verdict: ``affirmative`` / ``negative`` / ``other``.
+
+Fail direction differs from the non-meaningful classifier (which fails open to
+"allow"). This one fails to ``other`` on timeout, parse error, or any exception:
+``other`` hands the turn to the agent, so an uncertain verdict can never hang up
+on a farmer who said yes, and can never read account data to one who said no.
+"""
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+from app.config import settings
+from app.services.translation import _get_langfuse
+from helpers.utils import get_logger, get_prompt
+
+logger = get_logger(__name__)
+
+OUTBOUND_CONSENT_PROMPT_NAME = "voice_outbound_consent_en"
+_STATIC_OUTBOUND_CONSENT_SYSTEM_PROMPT = get_prompt(OUTBOUND_CONSENT_PROMPT_NAME)
+
+INTENT_AFFIRMATIVE = "affirmative"
+INTENT_NEGATIVE = "negative"
+INTENT_OTHER = "other"
+_VALID_INTENTS = {INTENT_AFFIRMATIVE, INTENT_NEGATIVE, INTENT_OTHER}
+
+
+def _consent_client_and_model() -> tuple[AsyncOpenAI, str, str]:
+    """(client, model, provider_label) for the consent classifier.
+
+    Reuses the NON_MEANINGFUL step tier rather than introducing a new pipeline
+    step: it is the same small ``RAW_OPENAI`` classifier call, and a new Step
+    would ripple through the profile schema, the Redis config (M2) and the
+    parity checks for no behavioural gain. Promote it to its own step only if
+    evaluation shows this gate wants a different model.
+    """
+    from app.llm_core import resolver as _llm_resolver
+    from app.llm_core.config_model import Step as _LlmStep
+    mt = _llm_resolver.primary_tier(_LlmStep.NON_MEANINGFUL)  # profile-invariant (defaults)
+    return mt.handle, mt.model_name, mt.provider
+
+
+@dataclass(frozen=True)
+class ConsentVerdict:
+    intent: str
+    reason: str
+    raw_output: Optional[str] = None
+    failed_open: bool = False
+
+    @property
+    def is_affirmative(self) -> bool:
+        return self.intent == INTENT_AFFIRMATIVE
+
+    @property
+    def is_negative(self) -> bool:
+        return self.intent == INTENT_NEGATIVE
+
+
+def _other(reason: str, *, raw_output: Optional[str] = None, failed_open: bool = False) -> ConsentVerdict:
+    return ConsentVerdict(
+        intent=INTENT_OTHER,
+        reason=reason,
+        raw_output=raw_output,
+        failed_open=failed_open,
+    )
+
+
+def _parse_verdict(raw: str) -> ConsentVerdict:
+    stripped = (raw or "").strip()
+    if not stripped:
+        logger.warning("Consent classifier returned empty output; falling back to 'other'")
+        return _other("empty model output", raw_output=raw, failed_open=True)
+
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        logger.warning("Consent classifier returned non-JSON output; falling back to 'other' - raw=%r", stripped[:200])
+        return _other("non-json model output", raw_output=raw, failed_open=True)
+
+    if not isinstance(data, dict):
+        logger.warning("Consent classifier returned non-object JSON; falling back to 'other' - raw=%r", stripped[:200])
+        return _other("non-object model output", raw_output=raw, failed_open=True)
+
+    intent = data.get("intent")
+    if not isinstance(intent, str) or intent.strip().lower() not in _VALID_INTENTS:
+        logger.warning(
+            "Consent classifier returned invalid intent=%r; falling back to 'other' - raw=%r",
+            intent,
+            stripped[:200],
+        )
+        return _other("invalid intent value", raw_output=raw, failed_open=True)
+
+    intent = intent.strip().lower()
+    reason = (data.get("reason") or "").strip()[:200]
+    return ConsentVerdict(
+        intent=intent,
+        reason=reason or intent,
+        raw_output=raw,
+        failed_open=False,
+    )
+
+
+def _build_messages(reply: str, source_lang: str) -> list[dict[str, str]]:
+    user_content = (
+        f"Source language: {source_lang}\n\n"
+        f"Farmer's reply to the consent question:\n{(reply or '').strip()}"
+    )
+    return [
+        {"role": "system", "content": _STATIC_OUTBOUND_CONSENT_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+async def _create_consent_response(client: AsyncOpenAI, model: str, reply: str, source_lang: str):
+    return await asyncio.wait_for(
+        client.chat.completions.create(
+            model=model,
+            messages=_build_messages(reply, source_lang),
+            max_completion_tokens=80,
+            response_format={"type": "json_object"},
+        ),
+        timeout=settings.voice_outbound_consent_timeout_seconds,
+    )
+
+
+async def classify_consent(reply: str, source_lang: str) -> ConsentVerdict:
+    """Classify the farmer's first reply on an outbound call. Never raises."""
+    if not (reply or "").strip():
+        return _other("empty caller reply", failed_open=False)
+
+    try:
+        client, model, provider = _consent_client_and_model()
+    except Exception as e:
+        logger.error("Consent client init failed (%s); falling back to 'other'", e)
+        return _other(f"classifier client error: {type(e).__name__}", failed_open=True)
+    langfuse = _get_langfuse()
+
+    try:
+        if not langfuse:
+            response = await _create_consent_response(client, model, reply, source_lang)
+            return _parse_verdict((response.choices[0].message.content or "").strip())
+
+        with langfuse.start_as_current_observation(
+            name="outbound_consent_classifier",
+            as_type="generation",
+            input={"source_lang": source_lang, "reply": reply},
+            model=model,
+            metadata={
+                "pipeline_stage": "outbound_consent_classifier",
+                "provider": provider,
+            },
+        ) as observation:
+            response = await _create_consent_response(client, model, reply, source_lang)
+            verdict = _parse_verdict((response.choices[0].message.content or "").strip())
+            observation.update(
+                output={
+                    "intent": verdict.intent,
+                    "reason": verdict.reason,
+                    "failed_open": verdict.failed_open,
+                }
+            )
+            return verdict
+    except asyncio.TimeoutError:
+        logger.error(
+            "Consent classifier timed out - source_lang=%s timeout=%.2fs",
+            source_lang,
+            settings.voice_outbound_consent_timeout_seconds,
+        )
+        return _other("classifier timeout", failed_open=True)
+    except Exception as e:
+        logger.error("Consent classifier failed - source_lang=%s error=%s", source_lang, e)
+        return _other(f"classifier error: {type(e).__name__}", failed_open=True)

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -58,6 +58,8 @@ from app.services.stt_signals import (
 from app.services.moderation import ModerationVerdict, check_moderation
 from app.services.fallback import AGENT_ACTIVITY, classify, execute_with_fallback, stream_with_fallback, with_first_token_deadline
 from app.services.non_meaningful import NonMeaningfulVerdict, check_non_meaningful_streak
+from app.services import outbound as _outbound
+from app.services.outbound_consent import ConsentVerdict, classify_consent
 from app.services.translation import (
     INDIAN_LANGUAGES,
     OPENAI_PRETRANSLATION_MODEL,
@@ -270,6 +272,7 @@ _HISTORY_MARKERS = {
     "stt_no_audio": "[stt:no-audio]",
     "stt_unclear": "[stt:unclear-speech]",
     "moderation_reject": "[moderation-rejected]",
+    "outbound_intro": "[outbound-call-started]",
 }
 
 # Markers that are dropped from the non-meaningful window entirely (neither
@@ -287,6 +290,9 @@ _NON_MEANINGFUL_EXCLUDED_TURNS = frozenset(
         #_HISTORY_MARKERS["stt_no_audio"],
         #_HISTORY_MARKERS["stt_unclear"],
         _HISTORY_MARKERS["moderation_reject"],
+        # Not a caller turn at all — it stands in for "we placed this call", so it
+        # must neither count toward a hangup streak nor break one.
+        _HISTORY_MARKERS["outbound_intro"],
     }
 )
 
@@ -1030,6 +1036,7 @@ async def stream_voice_message(
     http_request: Optional[Request] = None,
     trace: Optional[VoiceTrace] = None,
     pipeline_profile: str = "managed",
+    call_type: str = "inbound",
 #    background_tasks: BackgroundTasks,
 
 ) -> AsyncGenerator[str, None]:
@@ -1068,10 +1075,12 @@ async def stream_voice_message(
     # context is active — emitting it here would silently no-op
     # (Langfuse v4: "Operations that depend on an active span will be
     # skipped"; mirror of amul-oan-api#70).
+    call_type = _outbound.normalize_call_type(call_type)
     try:
         trace.metadata["pipeline_profile"] = pipeline_profile
         trace.metadata["request_model"] = request_model_name
         trace.metadata["request_provider"] = request_provider
+        trace.metadata["call_type"] = call_type
     except Exception:  # pragma: no cover - never break the call
         pass
     # Serialize the resolved pipeline config into COMPACT flat keys and merge them
@@ -1206,6 +1215,72 @@ async def stream_voice_message(
             nudge_lang = (requested_target_lang or "en").strip().lower()
             has_meaningful_history = _has_meaningful_history(history)
 
+            # ── Outbound opener ───────────────────────────────────────────
+            # Calls WE placed open with one scripted consent question instead of
+            # answering whatever the first turn happens to carry. The stage is
+            # read from Redis (not history) so it survives trimming, and is read
+            # on every turn while the feature flag is on because Raya is not
+            # guaranteed to re-stamp call_type after the first request.
+            outbound_stage = (
+                await _outbound.get_stage(session_id)
+                if settings.outbound_intro_enabled
+                else None
+            )
+            outbound_opener_turn = (
+                settings.outbound_intro_enabled
+                and _outbound.is_outbound(call_type)
+                and outbound_stage is None
+                and not history
+                # Only when the first turn carries no real content. If Raya
+                # forwards an actual question on connect, answer it — the farmer
+                # asking something themselves beats our script every time.
+                and (
+                    not (query or "").strip()
+                    or detect_stt_signal(query) is not None
+                    or _is_bare_greeting(query)
+                    or _is_fragment_query(query)
+                )
+            )
+            if outbound_opener_turn:
+                trace.set_route("outbound_intro")
+                logger.info(
+                    "Outbound intro emitted; session_id=%s process_id=%s user_id=%s query=%r",
+                    session_id, process_id, user_id, (query or "")[:60],
+                )
+                intro_en = _outbound.OUTBOUND_INTRO["en"]
+                intro_for_caller = await _canned_for_caller(
+                    intro_en, requested_target_lang, _outbound.OUTBOUND_INTRO,
+                )
+                intro_req, intro_resp = _history_pair(
+                    _canonical_history_user_text("outbound_intro"), intro_en,
+                )
+                with trace.stage("history_write"):
+                    await update_message_history(session_id, [*history, intro_req, intro_resp])
+                await _outbound.set_stage(session_id, _outbound.STAGE_INTRO_SENT)
+
+                # Warm the milk summary while the farmer is answering. Bounded
+                # inside the prefetch; failure just means the agent fetches it
+                # itself on the next turn.
+                _prefetch_mobile = normalize_phone_to_mobile(user_id)
+                if _prefetch_mobile:
+                    async def _warm_outbound_milk(mobile_number: str = _prefetch_mobile):
+                        envelope = await get_or_fetch_farmer_data(mobile_number)
+                        await _outbound.prefetch_milk_summary(
+                            session_id, _collect_farmer_accounts(envelope),
+                        )
+                    _outbound.spawn(_warm_outbound_milk(), label="outbound_milk_prefetch")
+
+                trace.set_outcome("outbound_intro")
+                yield _emit(_prepare_voice_output(intro_for_caller, requested_target_lang))
+                return
+
+            # The turn that answers the outbound consent question is owned by the
+            # consent gate: the greeting / fragment / identity fast paths must not
+            # preempt it. "હા બોલો" — the single most likely affirmative reply — is
+            # itself a _GREETING_TOKENS entry, so without this an affirmative reply
+            # could be answered with the generic greeting and the readout lost.
+            outbound_consent_turn = outbound_stage == _outbound.STAGE_INTRO_SENT
+
             # ── STT signal handling (no-audio / unclear speech) ─────────────
             # These are not real user messages — skip translation & agent,
             # generate a short contextual "please repeat" via GPT-5-mini.
@@ -1269,7 +1344,7 @@ async def stream_voice_message(
             # full agent pipeline or a nudge.  Respond immediately.
             # When translation pipeline is active, let greetings flow through
             # the normal agent pipeline so history stays in English.
-            if _is_bare_greeting(query) and not has_meaningful_history:
+            if _is_bare_greeting(query) and not has_meaningful_history and not outbound_consent_turn:
                 trace.set_route("greeting_fast_path")
                 logger.info(
                     "Bare greeting detected; short-circuiting - session_id=%s process_id=%s query=%r",
@@ -1289,7 +1364,7 @@ async def stream_voice_message(
             # Pure identity queries ("What is your name?", "What is this service?")
             # should return the canonical Sarlaben identity line directly
             # without running the full agent pipeline.
-            if _fast_path_kind_for_query(query) == "identity" and not has_meaningful_history:
+            if _fast_path_kind_for_query(query) == "identity" and not has_meaningful_history and not outbound_consent_turn:
                 trace.set_route("identity_fast_path")
                 logger.info(
                     "Identity fast-path triggered; session_id=%s process_id=%s query=%r",
@@ -1308,7 +1383,7 @@ async def stream_voice_message(
             # ── Fragment short-circuit ────────────────────────────────────
             # Very short / garbled input (≤3 chars) that isn't a greeting or
             # STT signal — ask the farmer to repeat instead of routing to agent.
-            if _is_fragment_query(query) and not has_meaningful_history:
+            if _is_fragment_query(query) and not has_meaningful_history and not outbound_consent_turn:
                 trace.set_route("fragment_fast_path")
                 logger.info(
                     "Fragment query detected; short-circuiting - session_id=%s process_id=%s query=%r",
@@ -1461,6 +1536,19 @@ async def stream_voice_message(
             )
             non_meaningful_task.add_done_callback(
                 lambda _t: non_meaningful_done_at.__setitem__("t", time.monotonic())
+            )
+
+            # Outbound consent gate. Started here so the classifier runs under
+            # pretranslation and the farmer-context fetch rather than after them;
+            # it reads the raw native-language reply, so it needs neither. The
+            # verdict is consumed before the agent input is built (below),
+            # because an affirmative reply changes that input.
+            consent_task = (
+                asyncio.create_task(
+                    classify_consent(reply=query, source_lang=requested_source_lang)
+                )
+                if outbound_consent_turn
+                else None
             )
 
             if requested_source_lang not in {"en", "english"}:
@@ -1965,6 +2053,18 @@ async def stream_voice_message(
                 except asyncio.CancelledError:
                     pass
 
+            async def _cancel_consent_task_if_pending() -> None:
+                """Reap the consent classifier on paths that short-circuit before
+                the consent gate. The outbound stage is deliberately left at
+                ``intro_sent`` on those paths, so the next turn re-classifies."""
+                if consent_task is None or consent_task.done():
+                    return
+                consent_task.cancel()
+                try:
+                    await consent_task
+                except asyncio.CancelledError:
+                    pass
+
             async def _moderation_decline_stream(verdict: ModerationVerdict):
                 """Emit the canned decline and write history for a rejected query."""
                 trace.set_route("moderation_rejected")
@@ -2024,6 +2124,38 @@ async def stream_voice_message(
                 # Keep the exact telephony termination token.
                 yield _emit(goodbye)
 
+            async def _outbound_decline_stream(verdict: ConsentVerdict):
+                """Emit the scripted farewell and hang up after a declined outbound call."""
+                trace.set_route("outbound_declined")
+                if nudge_task and not nudge_task.done():
+                    nudge_task.cancel()
+                    trace.set_nudge(cancel_reason="outbound_declined")
+                    try:
+                        await nudge_task
+                    except asyncio.CancelledError:
+                        pass
+                farewell_en = _outbound.OUTBOUND_DECLINE_FAREWELL["en"]
+                farewell_for_caller = await _canned_for_caller(
+                    farewell_en, requested_target_lang, _outbound.OUTBOUND_DECLINE_FAREWELL,
+                )
+                goodbye = TELEPHONY_TERMINATE_CALL_TOKEN.get(
+                    requested_target_lang, TELEPHONY_TERMINATE_CALL_TOKEN["en"],
+                )
+                dec_req, dec_resp = _history_pair(
+                    history_user_text or query, f"{farewell_en} {TELEPHONY_TERMINATE_CALL_TOKEN['en']}",
+                )
+                with trace.stage("history_write"):
+                    await update_message_history(session_id, [*history, dec_req, dec_resp])
+                trace.set_outcome("outbound_declined")
+                logger.info(
+                    "Outbound consent declined; emitting farewell + hangup - session_id=%s process_id=%s reason=%r",
+                    session_id, process_id, verdict.reason,
+                )
+                yield _emit(_prepare_voice_output(farewell_for_caller, requested_target_lang))
+                # Termination token stays exact ASCII "Goodbye." — passing it
+                # through the Gujarati output filter would strip it to ".".
+                yield _emit(" " + goodbye)
+
             # ── Empty-pretranslation guard ───────────────────────────────
             # Only short-circuit when pretranslation produced no usable text
             # at all (i.e. both primary and fallback failed). True noise still
@@ -2039,10 +2171,12 @@ async def stream_voice_message(
                 if _verdict is not None and _verdict.rejected:
                     if await _request_is_stale("after_moderation_reject"):
                         await _cancel_non_meaningful_task_if_pending()
+                        await _cancel_consent_task_if_pending()
                         return
                     async for _c in _moderation_decline_stream(_verdict):
                         yield _c
                     await _cancel_non_meaningful_task_if_pending()
+                    await _cancel_consent_task_if_pending()
                     return
                 trace.set_route("pretranslation_empty")
                 logger.info(
@@ -2060,6 +2194,7 @@ async def stream_voice_message(
                 trace.set_outcome("pretranslation_empty")
                 yield _emit(_prepare_voice_output(low_conf_resp_for_caller, requested_target_lang))
                 await _cancel_non_meaningful_task_if_pending()
+                await _cancel_consent_task_if_pending()
                 return
 
             if farmer_cache_task is not None:
@@ -2100,6 +2235,77 @@ async def stream_voice_message(
                         )
                 except Exception as e:
                     logger.warning(f"Failed to load farmer summary for mobile {mobile}: {e}")
+
+            # ── Outbound consent gate ─────────────────────────────────────
+            # Turn 2 of an outbound call: the farmer's first reply to the scripted
+            # consent question. Three-way — a reply that is neither yes nor no
+            # (typically the farmer asking their own question) simply falls through
+            # to a normal agent turn, which is the outcome we most want to protect.
+            outbound_milk_hint: Optional[str] = None
+            if consent_task is not None:
+                _consent_wait_started = time.monotonic()
+                consent_verdict = await consent_task
+                trace.attach_stage_timing(
+                    "outbound_consent",
+                    (time.monotonic() - _consent_wait_started) * 1000.0,
+                    intent=consent_verdict.intent,
+                    failed_open=consent_verdict.failed_open,
+                )
+                try:
+                    trace.metadata["outbound_consent_intent"] = consent_verdict.intent
+                except Exception:  # pragma: no cover - tracing must never break the call
+                    pass
+                logger.info(
+                    "Outbound consent verdict - session_id=%s process_id=%s intent=%s reason=%r failed_open=%s",
+                    session_id, process_id, consent_verdict.intent,
+                    consent_verdict.reason, consent_verdict.failed_open,
+                )
+                # The opener is done either way: never re-classify on later turns.
+                await _outbound.set_stage(session_id, _outbound.STAGE_RESOLVED)
+
+                if consent_verdict.is_negative:
+                    await _cancel_non_meaningful_task_if_pending()
+                    if not moderation_task.done():
+                        moderation_task.cancel()
+                    if not await _request_is_stale("after_outbound_decline"):
+                        async for _c in _outbound_decline_stream(consent_verdict):
+                            yield _c
+                    return
+
+                if consent_verdict.is_affirmative:
+                    prefetched = await _outbound.get_prefetched_milk_summary(session_id)
+                    if prefetched:
+                        outbound_milk_hint = _outbound.milk_answer_hint(prefetched)
+                        trace.set_route("outbound_milk_readout")
+                    elif signed_in and mobile and farmer_accounts:
+                        # Prefetch missed (cold cache or slow upstream) — the agent
+                        # fetches it itself against the same pinned window.
+                        _from, _to = _outbound.milk_window(settings.outbound_milk_window_days)
+                        outbound_milk_hint = _outbound.milk_fetch_hint(_from, _to)
+                        trace.set_route("outbound_milk_readout_cold")
+                    else:
+                        # Consented, but there is nothing to read out (no account on
+                        # this number). Say so and leave the call open rather than
+                        # reading an upstream failure message aloud.
+                        await _cancel_non_meaningful_task_if_pending()
+                        if not moderation_task.done():
+                            moderation_task.cancel()
+                        trace.set_route("outbound_no_data")
+                        no_data_en = _outbound.OUTBOUND_NO_DATA["en"]
+                        no_data_for_caller = await _canned_for_caller(
+                            no_data_en, requested_target_lang, _outbound.OUTBOUND_NO_DATA,
+                        )
+                        nd_req, nd_resp = _history_pair(history_user_text or query, no_data_en)
+                        with trace.stage("history_write"):
+                            await update_message_history(session_id, [*history, nd_req, nd_resp])
+                        trace.set_outcome("outbound_no_data")
+                        logger.info(
+                            "Outbound consent affirmative but no milk data available - "
+                            "session_id=%s process_id=%s signed_in=%s accounts=%s",
+                            session_id, process_id, signed_in, len(farmer_accounts),
+                        )
+                        yield _emit(_prepare_voice_output(no_data_for_caller, requested_target_lang))
+                        return
 
             logger.info(f"User info: {user_info}")
             deps = FarmerContext(
@@ -2154,6 +2360,15 @@ async def stream_voice_message(
             query_hints_request = _build_query_hints_request(deps)
             if query_hints_request is not None:
                 model_input_history.append(query_hints_request)
+            if outbound_milk_hint is not None:
+                # Appended after the per-query hints, immediately before the user
+                # message: this turn's instruction is the readout, and it must sit
+                # closest to the reply it acts on.
+                model_input_history.append(
+                    ModelRequest(parts=[UserPromptPart(content=(
+                        "Hints for the current user query:\n" + outbound_milk_hint
+                    ))])
+                )
             active_agent = voice_agent_signed_in if (signed_in and mobile) else voice_agent
             usage_limits = UsageLimits(request_limit=6 if (signed_in and mobile) else 4)
 

--- a/assets/prompts/voice_outbound_consent_en.md
+++ b/assets/prompts/voice_outbound_consent_en.md
@@ -1,0 +1,66 @@
+You are a strict classifier for a live outbound phone call on a dairy helpline.
+
+Sarlaben (the assistant) has just called a registered farmer and asked exactly one
+question: whether she may read out the details of the milk the farmer deposited in
+the last 7 days. You receive the farmer's very first reply to that question.
+
+Your task: classify that reply into one of three intents.
+
+## Input
+
+- One caller turn, in the caller's own language (usually Gujarati), as transcribed by ASR.
+- ASR may be noisy, clipped, or partially transliterated.
+
+## Intents
+
+`affirmative` — the caller agrees to hear the milk details, or invites her to continue:
+- "હા", "હા ચાલશે", "હા બોલો", "બોલો", "કહો", "કહો ને", "સંભળાવો", "જણાવો", "ઠીક છે"
+- "yes", "haan", "ok bolo", "batao"
+
+`negative` — the caller declines, defers, or wants the call to end:
+- "ના", "ના ભાઈ", "અત્યારે નહીં", "પછી કરો", "પછી ફોન કરો", "હું કામમાં છું", "મારે નથી સાંભળવું"
+- "રહેવા દો", "મૂકી દો", "કોલ કાપો"
+- "no", "nahi", "baad me", "busy"
+
+`other` — anything that is neither a clear yes nor a clear no, including:
+- the caller ignores the question and asks something of their own
+  ("મારી ગાય ખાતી નથી", "દૂધ ઓછું આવે છે", "લોન વિશે પૂછવું છે")
+- the caller asks who is calling or why ("કોણ બોલો છો?", "શું કામ છે?")
+- fillers, noise, silence markers, or an unintelligible fragment
+- a reply that mixes agreement with a different request
+
+## System markers (treat as `other`)
+
+Internal markers may appear instead of caller speech. Any of these is `other`:
+`[fragment]`, `[unclear-user-input]`, `[stt:no-audio]`, `[stt:unclear-speech]`
+
+## Safety bias (critical)
+
+This verdict decides whether a live call is ended. Getting it wrong is costly in
+both directions, so:
+
+- Return `negative` ONLY when the caller clearly does not want to continue. A
+  caller who merely sounds hesitant, confused, or asks a counter-question is
+  `other`, never `negative`.
+- Return `affirmative` ONLY when the caller clearly agrees. Do not infer consent
+  from a filler like "હમ્મ" alone.
+- When uncertain, return `other`. `other` is always safe: the conversation simply
+  continues normally.
+
+## Examples
+
+- "હા બોલો" -> `{"intent": "affirmative", "reason": "clear yes"}`
+- "ના અત્યારે નહીં" -> `{"intent": "negative", "reason": "declines, asks later"}`
+- "મારી ભેંસ હીટમાં નથી આવતી" -> `{"intent": "other", "reason": "asks own question"}`
+- "કોણ બોલો છો?" -> `{"intent": "other", "reason": "asks who is calling"}`
+- "હમ્મ" -> `{"intent": "other", "reason": "filler only"}`
+- "હા પણ પહેલા લોન વિશે કહો" -> `{"intent": "other", "reason": "agrees but asks something else"}`
+
+## Output format
+
+Respond with JSON only. Use exactly this schema:
+
+{"intent": "<affirmative|negative|other>", "reason": "<short English phrase, max 12 words>"}
+
+- Do not output markdown.
+- Do not output extra keys.

--- a/tests/test_outbound_intro.py
+++ b/tests/test_outbound_intro.py
@@ -1,0 +1,303 @@
+"""Outbound-call opener: intro line, consent gate, and the decline hangup.
+
+Covers the three-way consent verdict and, importantly, that an uncertain verdict
+never ends the call. Inbound behaviour must be untouched by all of this, so the
+last test drives a plain inbound turn through the same path.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+# Env shim: alias pydantic-ai 1.x ``OpenAIChatModel`` to 0.2.4 ``OpenAIModel`` so
+# importing app.services.voice (-> agents, which builds a model at import) works
+# under both. No model object is called — every model call here is stubbed.
+import pydantic_ai.models.openai as _pai_openai  # noqa: E402
+if not hasattr(_pai_openai, "OpenAIChatModel"):
+    _pai_openai.OpenAIChatModel = _pai_openai.OpenAIModel
+
+import asyncio  # noqa: E402
+from datetime import date, timedelta  # noqa: E402
+
+import pytest  # noqa: E402
+
+from app.services import outbound as ob  # noqa: E402
+from app.services.outbound_consent import (  # noqa: E402
+    INTENT_AFFIRMATIVE,
+    INTENT_NEGATIVE,
+    INTENT_OTHER,
+    _parse_verdict,
+)
+from helpers.utils import clean_output_by_language  # noqa: E402
+
+
+# ── Pure helpers ──────────────────────────────────────────────────────────────
+
+def test_is_outbound_defaults_to_inbound():
+    assert ob.is_outbound("outbound") is True
+    assert ob.is_outbound("OUTBOUND ") is True
+    assert ob.is_outbound("inbound") is False
+    assert ob.is_outbound(None) is False
+    assert ob.normalize_call_type(None) == ob.CALL_TYPE_INBOUND
+
+
+def test_milk_window_is_seven_days_inclusive():
+    fromdate, todate = ob.milk_window(7)
+    assert date.fromisoformat(todate) - date.fromisoformat(fromdate) == timedelta(days=6)
+
+
+def test_intro_survives_the_gujarati_output_filter():
+    """Regression: the script's ASCII "7" is stripped for gu, which would make
+    the caller hear "in the last  days". The line must spell the number out."""
+    spoken = clean_output_by_language(ob.OUTBOUND_INTRO["gu"], "gu")
+    assert "સાત" in spoken
+    assert "દિવસ" in spoken
+    assert not any(ch.isdigit() and ch.isascii() for ch in spoken)
+
+
+def test_farewell_keeps_the_helpline_number():
+    """Gujarati digits are normalized to words for TTS — the number must survive
+    that normalization, not be filtered away."""
+    spoken = clean_output_by_language(ob.OUTBOUND_DECLINE_FAREWELL["gu"], "gu")
+    assert "શૂન્ય" in spoken  # "zero" — the leading 0 of 080-35453545
+    assert "વૉટ્સએપ" in spoken
+
+
+# ── Consent verdict parsing ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('{"intent": "affirmative", "reason": "clear yes"}', INTENT_AFFIRMATIVE),
+        ('{"intent": "negative", "reason": "declines"}', INTENT_NEGATIVE),
+        ('{"intent": "other", "reason": "asks own question"}', INTENT_OTHER),
+        ('{"intent": "AFFIRMATIVE", "reason": "case"}', INTENT_AFFIRMATIVE),
+    ],
+)
+def test_parse_consent_valid(raw, expected):
+    verdict = _parse_verdict(raw)
+    assert verdict.intent == expected
+    assert verdict.failed_open is False
+
+
+@pytest.mark.parametrize("raw", ["not-json", "[]", "", '{"intent": "maybe"}', '{"reason": "x"}'])
+def test_parse_consent_bad_output_falls_back_to_other(raw):
+    """Never negative on a bad parse: an uncertain verdict must not hang up."""
+    verdict = _parse_verdict(raw)
+    assert verdict.intent == INTENT_OTHER
+    assert verdict.is_negative is False
+    assert verdict.failed_open is True
+
+
+def test_classify_consent_empty_reply_is_other():
+    from app.services.outbound_consent import classify_consent
+
+    verdict = asyncio.run(classify_consent(reply="   ", source_lang="gu"))
+    assert verdict.intent == INTENT_OTHER
+    assert verdict.failed_open is False
+
+
+# ── Streaming flow ────────────────────────────────────────────────────────────
+
+class _FakeResponseStream:
+    """Minimal stand-in for pydantic-ai's run_stream context manager."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def stream_text(self, delta: bool = True, debounce_by=None):
+        async def _gen():
+            for chunk in self._chunks:
+                yield chunk
+        return _gen()
+
+    def new_messages(self):
+        return []
+
+
+@pytest.fixture
+def voice_harness(monkeypatch):
+    """Drive stream_voice_message with every network edge stubbed out."""
+    from agents import voice as voice_agent_module
+    from app.services import voice as voice_module
+
+    state = {
+        "history": {},
+        "stage": {},
+        "milk": None,
+        "consent": None,
+        "agent_inputs": [],
+        "prefetch_calls": [],
+    }
+
+    async def _update_message_history(session_id, messages):
+        state["history"][session_id] = messages
+
+    async def _set_stage(session_id, stage):
+        state["stage"][session_id] = stage
+
+    async def _get_stage(session_id):
+        return state["stage"].get(session_id)
+
+    async def _get_prefetched(session_id):
+        return state["milk"]
+
+    async def _classify_consent(reply, source_lang):
+        state["consent_reply"] = reply
+        return state["consent"]
+
+    async def _check_moderation(**kwargs):
+        from app.services.moderation import ModerationVerdict
+        return ModerationVerdict(rejected=False, reason="stub")
+
+    def _spawn(coro, *, label):
+        state["prefetch_calls"].append(label)
+        coro.close()  # never actually hit the milk API in tests
+
+    def _run_stream(**kwargs):
+        state["agent_inputs"].append(kwargs.get("message_history") or [])
+        return _FakeResponseStream(["Your milk details."])
+
+    monkeypatch.setattr(voice_module.settings, "outbound_intro_enabled", True, raising=False)
+    monkeypatch.setattr(voice_module.settings, "enable_voice_nudges", False, raising=False)
+    monkeypatch.setattr(voice_module.settings, "fallback_enabled", False, raising=False)
+    monkeypatch.setattr(voice_module, "update_message_history", _update_message_history)
+    monkeypatch.setattr(voice_module, "check_moderation", _check_moderation)
+    monkeypatch.setattr(voice_module, "classify_consent", _classify_consent)
+    monkeypatch.setattr(voice_module, "normalize_phone_to_mobile", lambda user_id: None)
+    monkeypatch.setattr(voice_module, "clean_message_history_for_openai", lambda history: history)
+    monkeypatch.setattr(voice_module, "trim_history", lambda history, **kwargs: history)
+    monkeypatch.setattr(voice_module, "format_message_pairs", lambda history, limit=None: [])
+    monkeypatch.setattr(ob, "set_stage", _set_stage)
+    monkeypatch.setattr(ob, "get_stage", _get_stage)
+    monkeypatch.setattr(ob, "get_prefetched_milk_summary", _get_prefetched)
+    monkeypatch.setattr(ob, "spawn", _spawn)
+    monkeypatch.setattr(voice_agent_module.voice_agent, "run_stream", lambda **kw: _run_stream(**kw))
+    monkeypatch.setattr(voice_agent_module.voice_agent_signed_in, "run_stream", lambda **kw: _run_stream(**kw))
+
+    async def _collect(query, *, session_id, history=None, call_type="outbound", target_lang="gu"):
+        chunks = []
+        async for chunk in voice_module.stream_voice_message(
+            query=query,
+            session_id=session_id,
+            source_lang="en",  # skips pretranslation; the consent gate is language-agnostic
+            target_lang=target_lang,
+            user_id="anonymous",
+            history=history or [],
+            provider=None,
+            process_id="proc-test",
+            user_info={},
+            owner=None,
+            http_request=None,
+            call_type=call_type,
+        ):
+            if isinstance(chunk, str):
+                chunks.append(chunk)
+        return "".join(chunks)
+
+    state["collect"] = _collect
+    return state
+
+
+def _history_texts(messages):
+    out = []
+    for msg in messages:
+        for part in getattr(msg, "parts", []) or []:
+            content = getattr(part, "content", None)
+            if isinstance(content, str):
+                out.append(content)
+    return out
+
+
+def test_outbound_first_turn_emits_the_intro_and_arms_the_prefetch(voice_harness):
+    output = asyncio.run(voice_harness["collect"]("", session_id="s-intro"))
+
+    assert "સરલાબેન" in output and "દૂધ" in output
+    assert voice_harness["stage"]["s-intro"] == ob.STAGE_INTRO_SENT
+    assert _history_texts(voice_harness["history"]["s-intro"])[0] == "[outbound-call-started]"
+    # No agent run on the intro turn.
+    assert voice_harness["agent_inputs"] == []
+
+
+def test_inbound_first_turn_is_untouched(voice_harness):
+    """The opener must be invisible to the inbound helpline."""
+    output = asyncio.run(
+        voice_harness["collect"]("my cow has fever", session_id="s-in", call_type="inbound")
+    )
+
+    assert "સરલાબેન બોલું છું" not in output
+    assert "s-in" not in voice_harness["stage"]
+    assert len(voice_harness["agent_inputs"]) == 1
+
+
+def test_outbound_first_turn_with_a_real_question_skips_the_script(voice_harness):
+    """If Raya forwards an actual question on connect, answer it — the farmer
+    asking something themselves beats the script."""
+    output = asyncio.run(
+        voice_harness["collect"]("my buffalo is not eating", session_id="s-q")
+    )
+
+    assert "સરલાબેન બોલું છું" not in output
+    assert "s-q" not in voice_harness["stage"]
+    assert len(voice_harness["agent_inputs"]) == 1
+
+
+def test_negative_consent_speaks_the_farewell_then_hangs_up(voice_harness):
+    from app.services.outbound_consent import ConsentVerdict
+
+    voice_harness["stage"]["s-no"] = ob.STAGE_INTRO_SENT
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_NEGATIVE, reason="declines")
+
+    output = asyncio.run(
+        voice_harness["collect"]("na atyare nahi", session_id="s-no", history=[object()])
+    )
+
+    assert "વૉટ્સએપ" in output               # the scripted farewell was spoken
+    assert output.rstrip().endswith("Goodbye.")  # exact ASCII telephony token
+    assert voice_harness["stage"]["s-no"] == ob.STAGE_RESOLVED
+    assert voice_harness["agent_inputs"] == []   # no agent run on a decline
+
+
+def test_affirmative_consent_hands_the_prefetched_summary_to_the_agent(voice_harness):
+    """"ha bolo" is also a _GREETING_TOKENS entry: the consent turn must own it,
+    or the most likely affirmative reply gets swallowed by the greeting
+    fast-path and the readout is silently lost."""
+    from app.services.outbound_consent import ConsentVerdict
+
+    voice_harness["stage"]["s-yes"] = ob.STAGE_INTRO_SENT
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_AFFIRMATIVE, reason="clear yes")
+    voice_harness["milk"] = "Milk collection records (2): ... quantity 9 liters"
+
+    asyncio.run(voice_harness["collect"]("ha bolo", session_id="s-yes", history=[object()]))
+
+    assert len(voice_harness["agent_inputs"]) == 1
+    hint_text = "\n".join(_history_texts(voice_harness["agent_inputs"][0]))
+    assert "quantity 9 liters" in hint_text
+    assert "already fetched" in hint_text  # agent told not to re-call the slow tool
+    assert voice_harness["stage"]["s-yes"] == ob.STAGE_RESOLVED
+
+
+def test_other_consent_falls_through_to_a_normal_agent_turn(voice_harness):
+    from app.services.outbound_consent import ConsentVerdict
+
+    voice_harness["stage"]["s-other"] = ob.STAGE_INTRO_SENT
+    voice_harness["consent"] = ConsentVerdict(
+        intent=INTENT_OTHER, reason="asks own question", failed_open=True,
+    )
+
+    output = asyncio.run(
+        voice_harness["collect"]("my cow is not eating", session_id="s-other", history=[object()])
+    )
+
+    assert "Goodbye." not in output              # an uncertain verdict never hangs up
+    assert "વૉટ્સએપ" not in output
+    assert len(voice_harness["agent_inputs"]) == 1
+    hint_text = "\n".join(_history_texts(voice_harness["agent_inputs"][0]))
+    assert "Milk deposit summary" not in hint_text
+    assert voice_harness["stage"]["s-other"] == ob.STAGE_RESOLVED


### PR DESCRIPTION
Prod promotion of #233 (merged to `amul-dev` as `c848ae3`). Clean cherry-pick of `2bcfc21` — no conflicts.

**Ships inert.** `OUTBOUND_INTRO_ENABLED` defaults to `false`, and every code path is behind it plus `call_type=outbound`. Merging and deploying this changes nothing for the inbound helpline until the flag is set in prod config.

## Validated on dev

Deployed to VM5 and exercised end-to-end against the live pipeline:

| Case | Result | Latency |
|---|---|---|
| Turn 1, `call_type=outbound`, empty query | Scripted intro, "સાત" intact | 25 ms |
| "ના ભાઈ, અત્યારે નહીં, હું કામમાં છું" | Farewell + helpline read as words + exact `Goodbye.` | 1.03 s |
| "હા બોલો" (seeded summary) | 15 liters / 625 rupees — arithmetic correct, no tool call | 5.9 s |
| "મારી ભેંસ ખાતી નથી, શું કરું?" | Fell through to a normal vet answer, script dropped | 3.9 s |
| Inbound control + inbound greeting fast-path | Unchanged | 3.9 s / instant |

Consent verdicts from dev logs, all `failed_open=False` (the classifier genuinely decided each):
- `intent=negative reason='clearly declines and states they are busy'`
- `intent=affirmative reason='clear yes'` ×2
- `intent=other reason='caller asks own question about buffalo not eating'`

Gate latency ~380 ms against the 600 ms budget. No errors or tracebacks in 30 min of dev logs.

## Not yet validated

- The affirmative test used a **synthetic summary seeded into the prefetch cache**, not real records — the readout and hint plumbing are proven, the live `get_farmer_milk_collection_details` leg behind them is not.
- The Raya contract for what the first request on an outbound call carries is still unconfirmed. The opener is written to be tolerant (fires on empty / greeting / STT-signal / fragment, steps aside for a real question), but this should be settled before the flag goes on in prod.

## Tests

25 focused tests pass on this branch. Full suite: identical 34 pre-existing failures as `origin/amul-prod` (diffed both lists); the 7 uncollectable modules are the known local pydantic-ai mismatch, pre-existing on prod too.

## Enabling later

`OUTBOUND_INTRO_ENABLED=true` in the prod backend secret, then restart. Tunables: `OUTBOUND_MILK_WINDOW_DAYS` (7), `OUTBOUND_MILK_PREFETCH_TIMEOUT_SECONDS` (25.0), `VOICE_OUTBOUND_CONSENT_TIMEOUT_SECONDS` (0.60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)