### PR TITLE
fix(telemetry): record cancelled voice turns, flush spans on shutdown

### DIFF
--- a/app/observability.py
+++ b/app/observability.py
@@ -53,14 +53,33 @@ if langfuse_public_key and langfuse_secret_key:
 
         langfuse_client = get_client()
 
-        # Verify connection before enabling pydantic-ai OTEL instrumentation.
-        if langfuse_client.auth_check():
-            print("Langfuse initialized successfully - authentication verified", flush=True)
-            has_otel_exporter = True
-        else:
-            print("Langfuse authentication failed - traces will not be sent", flush=True)
+        # Boot-time connectivity probe. This is advisory ONLY: a single Langfuse
+        # blip during a deploy used to hard-gate `has_otel_exporter` for the whole
+        # lifetime of the process, silently disabling pydantic-ai instrumentation
+        # until the next restart. The OTEL exporter retries on its own background
+        # thread and drops spans on queue overflow, so enabling it optimistically
+        # can never add latency to or fail a farmer-facing request.
+        try:
+            if langfuse_client.auth_check():
+                print("Langfuse initialized successfully - authentication verified", flush=True)
+            else:
+                print(
+                    "Langfuse auth_check failed at boot - enabling tracing anyway "
+                    "(the exporter retries; a transient blip must not disable tracing "
+                    "for the life of the process)",
+                    flush=True,
+                )
+        except Exception as auth_exc:  # pragma: no cover - never fail boot on telemetry
+            print(
+                f"Langfuse auth_check errored at boot ({auth_exc}) - enabling tracing anyway",
+                flush=True,
+            )
+        has_otel_exporter = True
     except ImportError as e:
         print(f"Langfuse package not available - tracing disabled ({e})", flush=True)
+    except Exception as e:  # pragma: no cover - telemetry must never break startup
+        print(f"Langfuse initialization failed - tracing disabled ({e})", flush=True)
+        langfuse_client = None
 else:
     print(
         "Langfuse not configured - LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY not set",
@@ -78,6 +97,46 @@ if has_otel_exporter:
 def get_langfuse_client():
     """Return the configured Langfuse client, or None when tracing is disabled."""
     return langfuse_client
+
+
+async def flush_tracing(timeout: float = 5.0) -> bool:
+    """Best-effort flush of buffered Langfuse/OTEL spans, e.g. on SIGTERM.
+
+    Without this, spans still sitting in the batch queue are lost every time the
+    container is stopped or rolled — which is exactly when you most want the
+    trailing traces. Runs the (blocking) SDK flush on a worker thread and gives
+    up after ``timeout`` seconds so shutdown can never hang. Returns True when
+    the flush completed within the budget.
+
+    Only ever called from the shutdown path, never from a request.
+    """
+    if langfuse_client is None:
+        return False
+
+    flush = getattr(langfuse_client, "flush", None)
+    if not callable(flush):
+        return False
+
+    import asyncio
+
+    def _flush() -> None:
+        try:
+            flush()
+        except Exception as exc:  # pragma: no cover - telemetry must never raise
+            logger.warning("Langfuse flush failed: %s", exc)
+
+    try:
+        await asyncio.wait_for(asyncio.to_thread(_flush), timeout=timeout)
+        logger.info("Langfuse spans flushed on shutdown")
+        return True
+    except asyncio.TimeoutError:
+        # The worker thread is left running; it is a daemon-side best effort and
+        # must not delay process exit any further.
+        logger.warning("Langfuse flush timed out after %.1fs on shutdown", timeout)
+        return False
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Langfuse flush errored on shutdown: %s", exc)
+        return False
 
 
 @contextmanager

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -2935,6 +2935,23 @@ async def stream_voice_message(
                 await update_message_history(session_id, messages)
             if trace.outcome is None:
                 trace.set_outcome("success")
+    except (asyncio.CancelledError, GeneratorExit) as exc:
+        # CancelledError and GeneratorExit derive from BaseException, not Exception,
+        # so the `except Exception` below never sees them. Without this branch a
+        # cancelled turn fell straight through to the `finally`, which recorded
+        # `trace.outcome or "success"` — that is why the 60s nginx cut on a hung
+        # tool call shows up in telemetry as a successful turn. Record it as
+        # "cancelled" and re-raise unchanged: swallowing it would break asyncio
+        # task-cancellation / async-generator close semantics.
+        try:
+            if trace.outcome is not None:
+                trace.metadata["outcome_before_cancel"] = trace.outcome
+            # finish() is idempotent (guarded by trace.finished), so the `finally`
+            # below cannot overwrite this outcome.
+            trace.finish("cancelled", error=exc)
+        except Exception as _cancel_trace_exc:  # pragma: no cover - never mask a cancel
+            logger.debug("Voice trace cancel finish failed: %s", _cancel_trace_exc)
+        raise
     except Exception as exc:
         trace.finish(trace.outcome or "error", error=exc)
         raise

--- a/main.py
+++ b/main.py
@@ -47,6 +47,14 @@ async def lifespan(app: FastAPI):
     # Shutdown
     await stop_health_poller()
     await stop_farmer_refresh_worker()
+    # Flush buffered Langfuse/OTEL spans before the process exits — otherwise every
+    # container stop/roll silently drops the trailing traces. Bounded and best-effort:
+    # it can never hang shutdown and never raises.
+    try:
+        from app.observability import flush_tracing
+        await flush_tracing(timeout=5.0)
+    except Exception as _flush_exc:  # pragma: no cover - shutdown must not fail
+        print(f"⚠️  tracing flush skipped: {_flush_exc}")
     print(f"🛑 {settings.app_name} shutting down...")
 
 # Create FastAPI app with settings


### PR DESCRIPTION
Telemetry coverage fixes for voice, under `OpenAgriNet/amul-oan-api#179`. Chat's half of #179 shipped in the 2026-08-05 prod promotion; this is the voice half.

Three defects, all verified against current `amul-dev` before changing anything.

## 1. Cancelled turns were recorded as `success`

`app/services/voice.py`, in `stream_voice_message`:

```python
except Exception as exc:
    trace.finish(trace.outcome or "error", error=exc)
    raise
finally:
    trace.finish(trace.outcome or "success")
```

`asyncio.CancelledError` inherits from `BaseException`, not `Exception`, so a cancelled turn skips the `except` and falls into the `finally`, which stamps it **`success`**.

There *is* cooperative disconnect detection (`_request_is_stale` → `set_outcome("client_disconnected")`), but it only fires at explicit checkpoints. A turn stuck inside a hung tool call never reaches one — so the nginx 60s cut arrives as a cancellation and is logged as a successful turn. **This is why the known 60s tool-hang call drops are invisible in their own telemetry.**

Fixed by catching cancellation before `except Exception`, recording `"cancelled"`, and re-raising unchanged.

Note this catches **both** `CancelledError` and `GeneratorExit`. The turn is an async generator handed to `StreamingResponse`, so a client disconnect arrives as either — `aclose()` throws `GeneratorExit` at the yield point, task cancellation throws `CancelledError`. Catching only `CancelledError` would have left roughly half the drops still logging as success.

`VoiceTrace.finish()` is already idempotent (`if self.finished: return`), so the `finally` cannot overwrite the outcome — that was already the mechanism protecting the error path. The trace call is wrapped in its own `except Exception` so a telemetry failure cannot mask a cancellation.

### Mutation evidence

Verified by reproducing the exact `try/except/finally` shape in a standalone harness with a stub trace, run old vs new:

```
old  aclose  -> ('success', None)         new  aclose  -> ('cancelled', 'GeneratorExit')
old  cancel  -> ('success', None)         new  cancel  -> ('cancelled', 'CancelledError')
old  error   -> ('error', 'ValueError')   new  error   -> ('error', 'ValueError')
```

The old shape genuinely produces the bug, the new shape fixes it, the ordinary-exception path is unchanged, and the cancellation still propagates to the caller.

## 2. No flush on shutdown

No `flush`, `shutdown`, or signal handler existed anywhere; lifespan shutdown did only `stop_health_poller()` / `stop_farmer_refresh_worker()`. Buffered spans were dropped on every container stop or restart.

Added `flush_tracing()` in `app/observability.py`, called from lifespan shutdown: blocking SDK flush on a worker thread under a 5s `asyncio.wait_for`, never raises, shutdown path only.

## 3. `auth_check()` hard-gate — ⚠️ needs a decision in review

`app/observability.py` gated instrumentation on a boot-time `auth_check()` with no re-check, so one Langfuse blip during a deploy disabled pydantic-ai spans for that process's entire lifetime. The gate only affected `Agent.instrument_all()`; `langfuse_client` stayed set, so manual `VoiceTrace` spans survived.

Not in the ticket: the enclosing `try` caught **only `ImportError`**, so a network-level failure inside `auth_check()` would propagate out of module import and **crash boot** — `app.observability` is imported at `main.py:14`, before the app object exists.

This commit makes the probe advisory (log the result, enable instrumentation regardless) and broadens the `except` so a raising `auth_check` cannot kill boot.

**This is a behaviour change and is the one hunk to argue about.** Enabling instrumentation when auth genuinely fails means bad credentials produce silently dropped spans rather than no instrumentation. The reasoning for it: the OTEL exporter retries on its own background thread with a bounded drop-on-overflow queue, so the worst case never reaches the request path. If reviewers prefer the strict gate, **revert just this hunk** — the cancel fix and the flush are independent of it.

## Invariant respected

Telemetry must never add latency to, block, or fail a farmer-facing request. The flush is shutdown-path only; the cancel handler does bounded work and re-raises; the auth probe no longer blocks or crashes boot.

## What is NOT verified — please weigh in review

- **Nothing was executed against the real code.** Local pytest is broken on this machine (`ImportError: cannot import name 'OpenAIChatModel' from pydantic_ai`, pre-existing on `amul-dev`), and this repo has **no CI**, so there is no downstream safety net.
- **The flush path has never run.** Its correctness rests on reading only. `langfuse` isn't installed locally, so the SDK could not be introspected — `flush_tracing` uses `getattr(client, "flush", None)` and no-ops if absent. `flush()` exists in Langfuse v3/v4 but was not confirmed against the pinned version.
- **No tests added, deliberately.** A regression test would need to import `app.services.voice`, which pulls the broken `pydantic_ai` — unrunnable locally and unrunnable in CI, since there is none. The mutation evidence above is offered instead of a test nobody has watched fail. It covers defect 1 only.
- `python3 -m py_compile` passes on all three files. That is a syntax check, not a behaviour check.

## Before merge

Verify on dev VM5 (`amul_voice_app`, port 8003):

1. Confirm SIGTERM actually reaches uvicorn. The Dockerfile CMD is `sh -c "uvicorn ..."`; dash normally execs a single simple command so uvicorn becomes PID 1, but **this was not confirmed on a running container**. If SIGTERM isn't reaching uvicorn, the flush hook never fires and defect 2 is unfixed in practice.
2. Drop a call mid-tool-call and confirm the turn records `cancelled`, not `success`.
