### PR TITLE
bench: voice A/B harness from the guided-decoding experiment

### DIFF
--- a/scripts/BENCH_README.md
+++ b/scripts/BENCH_README.md
@@ -1,0 +1,21 @@
+# Voice model bench harness
+
+Voice half of the harness used for the 2026-08-01 guided-decoding experiment
+(amul-oan-api#181, #203). Chat-side runners and the pairwise judge live in
+`amul-oan-api/scripts/`.
+
+| file | what it does |
+|---|---|
+| `run_bench_voice.py` | Runs questions through `voice_agent` directly — no FastAPI, Redis or JWT. Optional vLLM guided decoding. |
+| `run_bench_voice_parity.py` | Above + `--inject-rules` (the 33 `GU_PREFERRED_TRANSLATION_RULES` into the agent prompt, verified present in the sent messages) and `--apply-map` (deterministic forbidden-term replacement). |
+| `guided_patch.py` | Port of `bharat-oan-api#142`. Byte-identical to the chat copy. |
+| `rubric_score.py` / `report.py` | Mechanical scoring and side-by-side tables. |
+| `gender_check.py` | Coverage of `GU_FEMININE_SELF_REFERENCE_REPLACEMENTS` against real output. |
+| `posthoc_map.py` | Applies the forbidden map to existing results. |
+
+Run with **cwd = repo root** — assets load via relative paths. Requires
+`BARE_GU_NATIVE=1` and the gu-native voice prompt to exercise the no-sandwich path.
+
+See `amul-oan-api/scripts/BENCH_README.md` for the full list of traps (silently-ignored
+`guided_regex` on vLLM 0.15.1, judge position bias, per-row script scoring,
+silent degradation under an over-tight constraint).

--- a/scripts/gender_check.py
+++ b/scripts/gender_check.py
@@ -1,0 +1,22 @@
+import csv,re,sys
+csv.field_size_limit(sys.maxsize)
+FEM=[(re.compile(r"(^|[,।.!?]\s+)\s*હું(?P<body>[^.!?\n]{0,80}?)શકું\s+ન(?:થી|હીં|હિ)(?=\s|[,।.!?]|$)"),r"\1હું\g<body>શકતી નથી"),
+     (re.compile(r"(^|[,।.!?]\s+)\s*હું(?P<body>[^.!?\n]{0,80}?)શકું\s+છું(?=\s|[,।.!?]|$)"),r"\1હું\g<body>શકતી છું"),
+     (re.compile(r"(^|[,।.!?]\s+)\s*હું(?P<body>[^.!?\n]{0,80}?)કરું(?=\s|[,।.!?]|$)"),r"\1હું\g<body>કરૂં"),
+     (re.compile(r"(^|[,।.!?]\s+)\s*હું(?P<body>[^.!?\n]{0,80}?)આવું\s+છું(?=\s|[,।.!?]|$)"),r"\1હું\g<body>આવી છું")]
+MASC=re.compile(r"હું[^.।!?]{0,40}(શકું|કરું|આવું|શકતો|કરતો|જાણતો)")
+def femfix(t):
+    for p,r in FEM: t=p.sub(r,t)
+    return t
+for path in sys.argv[1:]:
+    rows=[r for r in csv.DictReader(open(path,encoding="utf-8")) if (r.get("answer") or "").strip()]
+    masc=[r for r in rows if MASC.search(r["answer"])]
+    fixed=[r for r in masc if not MASC.search(femfix(r["answer"]))]
+    resid=[r for r in masc if MASC.search(femfix(r["answer"]))]
+    print(f"{path.split('/')[-1]:24} masc={len(masc):3d}  fixed_by_prod_regex={len(fixed):3d}  RESIDUAL={len(resid):3d}  coverage={100*len(fixed)/max(len(masc),1):.0f}%")
+    pats={}
+    for r in resid:
+        m=MASC.search(femfix(r["answer"]))
+        if m: pats[m.group(0)[:44]]=pats.get(m.group(0)[:44],0)+1
+    for k,v in sorted(pats.items(),key=lambda x:-x[1])[:5]:
+        print(f"     uncovered x{v}: {k}")

--- a/scripts/guided_patch.py
+++ b/scripts/guided_patch.py
@@ -1,0 +1,59 @@
+"""Guided-decoding helper for the bare-gemma4 bench.
+
+Ports OpenAgriNet/bharat-oan-api#142 (Gautam-Rajeev) to the amul stack, with the
+shared character set EXTENDED — #142's set omits the degree sign, so a
+constrained answer cannot write "25°C" and every weather answer is silently
+mangled. Additions over #142 are marked below.
+
+Verified on this box against vLLM 0.15.1:
+  - extra_body {"structured_outputs": {"regex": ...}}  -> HONORED
+  - extra_body {"guided_regex": ...}                   -> SILENTLY IGNORED
+  - tool_calls are byte-identical with and without the constraint
+"""
+from pydantic_ai.models.openai import OpenAIChatModelSettings
+
+# Unicode block per language, exactly as in #142.
+_SCRIPT_RANGES = {
+    "kn": "ಀ-೿",  # Kannada
+    "ta": "஀-௿",  # Tamil
+    "ml": "ഀ-ൿ",  # Malayalam
+    "te": "ఀ-౿",  # Telugu
+    "bn": "ঀ-৿",  # Bengali
+    "as": "ঀ-৿",  # Assamese (shares the Bengali block)
+    "gu": "઀-૿",  # Gujarati
+    "hi": "ऀ-ॿ",  # Devanagari (NOT in #142; added for our Hindi traffic)
+}
+
+# #142's shared set: escaped tab/newline/CR (raw control bytes crash xgrammar's
+# EBNF parser) + printable ASCII + danda + dashes/quotes/bullet/rupee.
+_SHARED_142 = "\\t\\n\\r -~" "।॥" "–—‘’“”•₹"
+
+# EXTENSIONS over #142 — each one is a character our answers actually emit.
+#   ° degree      -> "25°C", every weather answer
+#   … ellipsis    -> truncation in voice
+#   × multiply    -> dosage "2 × 5 ml"
+#   ≥ ≤      -> thresholds in advisory text
+#   → ←      -> arrows in chat formatting
+#   ± plus-minus  -> tolerance ranges
+#     NBSP        -> emitted by the model around units
+#   ½¼¾ -> vulgar fractions, common in feed quantities
+_SHARED_EXTRA = "°…×≥≤→←± ½¼¾"
+
+SHARED_CHARS = _SHARED_142 + _SHARED_EXTRA
+
+
+def guided_settings(lang_code, extended=True):
+    """Return OpenAIChatModelSettings constraining output to the target script.
+
+    extended=False reproduces #142 verbatim (no degree sign) so the bench can
+    measure what the missing characters actually cost.
+    Returns None for an unmapped language -> unconstrained, same as #142.
+    """
+    script_range = _SCRIPT_RANGES.get((lang_code or "").lower())
+    if not script_range:
+        return None
+    shared = SHARED_CHARS if extended else _SHARED_142
+    pattern = f"^[{script_range}{shared}]*$"
+    return OpenAIChatModelSettings(
+        extra_body={"structured_outputs": {"regex": pattern}}
+    )

--- a/scripts/posthoc_map.py
+++ b/scripts/posthoc_map.py
@@ -1,0 +1,27 @@
+"""Apply the deterministic forbidden map to bare output post-hoc.
+
+Tests whether R1 is actually a blocker, or just an unported layer. The map is
+Gujarati->Gujarati, so unlike proper-noun pinning and glossary injection it does
+NOT gate on an English source -- meaning it ports to bare mode unchanged.
+"""
+import csv,json,re,sys
+csv.field_size_limit(sys.maxsize)
+pol=json.load(open(sys.argv[1],encoding="utf-8"))
+forb={k.strip():v.strip() for k,v in pol.get("forbidden",{}).items() if k.strip() and v.strip()}
+pairs=sorted(forb.items(),key=lambda kv:len(kv[0]),reverse=True)  # longest first
+def apply_map(t):
+    for bad,good in pairs:
+        t=t.replace(bad,good)
+    return t
+for path in sys.argv[2:]:
+    rows=list(csv.DictReader(open(path,encoding="utf-8")))
+    before=after=0; fixed=0
+    for r in rows:
+        a=r.get("answer","")
+        if not a.strip(): continue
+        b=any(k in a for k in forb)
+        a2=apply_map(a)
+        aft=any(k in a2 for k in forb)
+        before+=b; after+=aft
+        if b and not aft: fixed+=1
+    print(f"{path.split('/')[-1]:26} violating_before={before:4d}  after_map={after:4d}  fixed={fixed:4d}  ({100*fixed/max(before,1):.1f}% of violations)")

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Side-by-side rubric report for a control/guided arm pair."""
+import json
+import subprocess
+import sys
+
+KEYS = [
+    ("rows", "rows"), ("errors", "errors"), ("empty", "empty answers"),
+    ("drift_pct", "R-drift  cross-script %"),
+    ("drift_rows", "R-drift  rows"),
+    ("drift_scored_rows", "R-drift  rows scored (gu+hi)"),
+    ("forbidden_rows", "R1 forbidden-term rows"),
+    ("forbidden_hits_total", "R1 forbidden hits"),
+    ("masc_self_ref_rows", "R2 masc self-ref rows"),
+    ("fem_self_ref_rows", "R2 fem self-ref rows"),
+    ("insemination_wording_rows", "R3 insemination wording"),
+    ("ai_helpline_wording_rows", "R3 AI-helpline wording"),
+    ("placeholder_rows", "R7 placeholder qty rows"),
+    ("markdown_rows", "R7 markdown rows"),
+    ("degree_rows", "gap: rows using °"),
+    ("gap_char_rows", "gap: rows using °…×≥→±"),
+    ("latency_mean", "latency mean s"),
+    ("latency_p90", "latency p90 s"),
+    ("tools_per_turn", "tools/turn"),
+    ("zero_tool_rows", "zero-tool rows"),
+    ("answer_chars_mean", "answer chars mean"),
+]
+
+
+def main():
+    policy, langmap, files = sys.argv[1], sys.argv[2], sys.argv[3:]
+    raw = subprocess.run(
+        [sys.executable, "rubric_score.py", *files, "--policy", policy,
+         "--langmap", langmap],
+        capture_output=True, text=True, cwd=".")
+    if raw.returncode != 0:
+        print(raw.stderr[-2000:]); sys.exit(1)
+    d = json.loads(raw.stdout[raw.stdout.find("["):])
+    labels = [f.split("/")[-1].replace(".csv", "") for f in files]
+
+    w = max(len(x) for x in labels) + 2
+    print(f"{'metric':30}" + "".join(f"{x:>{w}}" for x in labels))
+    print("-" * (30 + w * len(labels)))
+    for k, label in KEYS:
+        print(f"{label:30}" + "".join(f"{str(x.get(k, '')):>{w}}" for x in d))
+    print()
+    for lab, x in zip(labels, d):
+        print(f"drift scripts [{lab}]: {x.get('drift_scripts')}")
+    print()
+    for lab, x in zip(labels, d):
+        print(f"tool mix [{lab}]: {x.get('tool_mix')}")
+    print()
+    for lab, x in zip(labels, d):
+        top = x.get("forbidden_top") or {}
+        if top:
+            print(f"top forbidden [{lab}]: {top}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rubric_score.py
+++ b/scripts/rubric_score.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Mechanical scoring for the bare-gemma4 bench.
+
+Covers the rubrics that are checkable without a judge. Rubrics needing human or
+LLM judgement (persona gender nuance, proper-noun pinning, glossary fidelity)
+are scored separately.
+
+Usage: python3 rubric_score.py <results.csv> [--policy path/to/gu_term_policy.json]
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter
+
+csv.field_size_limit(sys.maxsize)
+
+GU_LO, GU_HI = "઀", "૿"
+
+
+def script_of(ch):
+    if GU_LO <= ch <= GU_HI:
+        return "gujarati"
+    if "a" <= ch.lower() <= "z":
+        return "latin"
+    if "ऀ" <= ch <= "ॿ":
+        return "devanagari"
+    try:
+        return unicodedata.name(ch).split()[0].lower()
+    except ValueError:
+        return "unknown"
+
+
+def skip(ch):
+    return (ch.isspace() or ch.isdigit()
+            or unicodedata.category(ch)[0] in ("P", "S"))
+
+
+# R1: terminology. Loaded from gu_term_policy.json forbidden map.
+def load_forbidden(path):
+    try:
+        pol = json.load(open(path, encoding="utf-8"))
+    except Exception:
+        return {}
+    f = pol.get("forbidden", {})
+    return f if isinstance(f, dict) else {}
+
+
+# R2: persona gender — masculine self-reference forms Sarlaben must never use.
+# Scoped to first-person clauses; a bare token match would fire on quoted farmer
+# speech, so require the Gujarati first-person pronoun nearby.
+MASC_SELF = [r"શકું", r"કરું", r"આવું", r"શકતો", r"કરતો", r"જાણતો"]
+FEM_SELF = [r"શકતી", r"કરૂં", r"કરતી", r"જાણતી"]
+
+# R3: the AI-sense rule — helpline "AI" must never render as insemination.
+INSEMINATION = [r"કૃત્રિમ\s*બીજદાન", r"બીજદાન"]
+AI_HELPLINE = [r"અમૂલ\s*એ\.?આઈ", r"એ\.?આઈ\.?\s*હેલ્પલાઇન"]
+
+# R7: placeholder quantities and markdown scaffolding.
+PLACEHOLDER = re.compile(r"(?<![\d\w])[-–—]{1,3}(?![\d\w])")
+MARKDOWN = re.compile(r"(\*\*|^\s*[\*\-•]\s|^#{1,6}\s|\[.+?\]\(.+?\))", re.M)
+
+# Char-set gap probe: characters #142 omits that our answers legitimately need.
+GAP_CHARS = "°…×≥≤→←±½¼¾"
+
+
+NATIVE = {"gu": {"gujarati"}, "hi": {"devanagari"}, "en": set()}
+
+
+def load_langmap(path):
+    if not path:
+        return {}
+    m = {}
+    for r in csv.DictReader(open(path, encoding="utf-8")):
+        if r.get("id"):
+            m[r["id"]] = (r.get("lang") or "gu").strip().lower()
+    return m
+
+
+def score(path, forbidden, langmap=None):
+    langmap = langmap or {}
+    rows = list(csv.DictReader(open(path, encoding="utf-8")))
+    n = len(rows)
+    ans = [(r, (r.get("answer") or r.get("answer_gu") or "")) for r in rows]
+    nonempty = [(r, a) for r, a in ans if a.strip()]
+
+    out = {"file": path, "rows": n, "nonempty": len(nonempty),
+           "empty": n - len(nonempty),
+           "errors": sum(1 for r, _ in ans if (r.get("error") or "").strip())}
+
+    drift_rows, drift_detail, drift_scored = 0, Counter(), 0
+    latin_only = 0
+    for r, a in nonempty:
+        # Score against the row's OWN expected script. A Hindi row is supposed to
+        # be Devanagari; counting that as drift would be a scorer artifact.
+        lang = langmap.get(r.get("qid", ""), "gu")
+        # Only gu/hi rows can test script fidelity. BARE_GU_NATIVE forces the
+        # Gujarati prompt for EVERY row, so an English-input row is answered in
+        # Gujarati by design -- scoring it against Latin would be meaningless.
+        if lang not in ("gu", "hi"):
+            continue
+        drift_scored += 1
+        native = NATIVE[lang] | {"latin"}
+        sc = Counter(script_of(c) for c in a if not skip(c))
+        foreign = {k: v for k, v in sc.items() if k not in native}
+        if foreign:
+            drift_rows += 1
+            drift_detail.update(foreign.keys())
+        if sc.get("latin", 0) > 0 and sc.get("gujarati", 0) > 0:
+            latin_only += 1
+    out["drift_rows"] = drift_rows
+    out["drift_scored_rows"] = drift_scored
+    out["drift_pct"] = round(100 * drift_rows / max(drift_scored, 1), 2)
+    out["drift_scripts"] = dict(drift_detail.most_common())
+    out["rows_with_latin"] = latin_only
+
+    viol = Counter()
+    for r, a in nonempty:
+        for bad in forbidden:
+            if bad and bad in a:
+                viol[bad] += 1
+    out["forbidden_hits_total"] = sum(viol.values())
+    out["forbidden_rows"] = sum(1 for r, a in nonempty
+                                if any(b in a for b in forbidden if b))
+    out["forbidden_top"] = dict(viol.most_common(10))
+
+    masc = sum(1 for _, a in nonempty
+               if re.search(r"હું[^.।]{0,40}(" + "|".join(MASC_SELF) + ")", a))
+    fem = sum(1 for _, a in nonempty
+              if re.search(r"હું[^.।]{0,40}(" + "|".join(FEM_SELF) + ")", a))
+    out["masc_self_ref_rows"] = masc
+    out["fem_self_ref_rows"] = fem
+
+    ins = sum(1 for _, a in nonempty if any(re.search(p, a) for p in INSEMINATION))
+    hl = sum(1 for _, a in nonempty if any(re.search(p, a) for p in AI_HELPLINE))
+    out["insemination_wording_rows"] = ins
+    out["ai_helpline_wording_rows"] = hl
+
+    out["placeholder_rows"] = sum(1 for _, a in nonempty if PLACEHOLDER.search(a))
+    out["markdown_rows"] = sum(1 for _, a in nonempty if MARKDOWN.search(a))
+
+    out["gap_char_rows"] = sum(1 for _, a in nonempty
+                               if any(c in a for c in GAP_CHARS))
+    out["degree_rows"] = sum(1 for _, a in nonempty if "°" in a)
+
+    lat = [float(r["latency_s"]) for r, _ in ans if r.get("latency_s")]
+    tc = [int(r["num_tool_calls"] or 0) for r, _ in ans]
+    out["latency_mean"] = round(sum(lat) / max(len(lat), 1), 2)
+    out["latency_p90"] = round(sorted(lat)[int(0.9 * len(lat))], 2) if lat else 0
+    out["tools_per_turn"] = round(sum(tc) / max(len(tc), 1), 3)
+    out["zero_tool_rows"] = sum(1 for x in tc if x == 0)
+    out["answer_chars_mean"] = round(
+        sum(len(a) for _, a in ans) / max(n, 1))
+
+    names = Counter()
+    for r, _ in ans:
+        for t in (r.get("tool_names") or "").split("|"):
+            if t:
+                names[t] += 1
+    out["tool_mix"] = dict(names.most_common())
+    return out
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("files", nargs="+")
+    p.add_argument("--policy", default="")
+    p.add_argument("--langmap", default="", help="question-set CSV with id,lang")
+    a = p.parse_args()
+    forb = load_forbidden(a.policy) if a.policy else {}
+    lm = load_langmap(a.langmap)
+    print(f"[policy] {len(forb)} forbidden terms | [langmap] {len(lm)} rows",
+          file=sys.stderr)
+    print(json.dumps([score(f, forb, lm) for f in a.files],
+                     ensure_ascii=False, indent=2))

--- a/scripts/run_bench_voice.py
+++ b/scripts/run_bench_voice.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Bare-gemma4 VOICE bench runner with optional vLLM guided decoding.
+
+Voice port of amul-oan-api/scripts/run_bench.py. Same CLI, same output schema,
+so the two repos' arms are directly comparable and score.py works on both.
+
+Voice-specific differences vs the chat runner:
+  - agent import is `from agents.voice import voice_agent`
+  - FarmerContext also takes target_lang (voice answers in the target language)
+  - .env.experiment sets BARE_GU_NATIVE=1, so the agent uses the gu-native
+    system prompt: no pre-translation, no moderation, no post-translation.
+
+Must run with cwd = repo root; assets load via relative paths.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+csv.field_size_limit(sys.maxsize)
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_PATH = REPO_ROOT / ".env.experiment"
+if ENV_PATH.exists():
+    load_dotenv(dotenv_path=ENV_PATH, override=True)
+else:
+    print(f"[warn] .env.experiment not found at {ENV_PATH}")
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_TOKEN", "")
+
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from guided_patch import guided_settings  # noqa: E402
+
+FIELDS = [
+    "row_num", "qid", "arm", "guided", "question", "answer",
+    "latency_s", "error", "num_tool_calls", "tool_names", "tool_log",
+]
+
+
+def _import_agent():
+    from agents.voice import voice_agent
+    from agents.deps import FarmerContext
+    return voice_agent, FarmerContext
+
+
+async def run_one(agent, FarmerContext, row_num, qid, question, lang, settings, arm, sem):
+    async with sem:
+        t0 = time.perf_counter()
+        row = {
+            "row_num": row_num, "qid": qid, "arm": arm,
+            "guided": bool(settings), "question": question, "answer": "",
+            "latency_s": 0.0, "error": "", "num_tool_calls": 0,
+            "tool_names": "", "tool_log": "",
+        }
+        try:
+            deps = FarmerContext(
+                query=question, lang_code=lang, target_lang=lang,
+                session_id=f"bench-{arm}-{row_num}",
+            )
+            kwargs = {"user_prompt": deps.get_user_message(), "deps": deps}
+            if settings is not None:
+                kwargs["model_settings"] = settings
+            result = await agent.run(**kwargs)
+            row["answer"] = (result.output if hasattr(result, "output") else str(result)) or ""
+
+            names, log, n = [], [], 0
+            try:
+                for m in (result.all_messages() if hasattr(result, "all_messages") else []):
+                    for p in getattr(m, "parts", []) or []:
+                        ks = str(getattr(p, "part_kind", "") or type(p).__name__).lower()
+                        if "tool-call" in ks:
+                            n += 1
+                            tn = getattr(p, "tool_name", "?")
+                            names.append(tn)
+                            log.append({"t": "call", "tool": tn,
+                                        "args": str(getattr(p, "args", ""))[:600]})
+                        elif "tool-return" in ks:
+                            log.append({"t": "ret", "tool": getattr(p, "tool_name", "?"),
+                                        "content": str(getattr(p, "content", ""))[:2000]})
+            except Exception:
+                pass
+            row["num_tool_calls"] = n
+            row["tool_names"] = "|".join(names)
+            row["tool_log"] = json.dumps(log, ensure_ascii=False)
+        except Exception as e:
+            row["error"] = f"{type(e).__name__}: {e}"
+        row["latency_s"] = round(time.perf_counter() - t0, 3)
+        return row
+
+
+def load_questions(path, limit):
+    rows = []
+    with open(path, newline="", encoding="utf-8") as f:
+        for i, r in enumerate(csv.DictReader(f)):
+            q = next((r[c] for c in ("question", "question_gu", "query", "input")
+                      if r.get(c)), "")
+            if not q:
+                continue
+            rows.append((i, r.get("id", str(i)), q, (r.get("lang") or "").strip().lower()))
+            if limit and len(rows) >= limit:
+                break
+    return rows
+
+
+async def main_async(a):
+    agent, FarmerContext = _import_agent()
+    print(f"[ok] agent={getattr(agent, 'name', '?')}")
+    if a.dry_run:
+        s = guided_settings(a.lang, extended=not a.strict_142)
+        print(f"[dry-run] guided={'ON' if (a.guided and s) else 'OFF'}")
+        if a.guided and s:
+            print(f"[dry-run] pattern={s.get('extra_body')['structured_outputs']['regex'][:120]}")
+        return 0
+
+    rows = load_questions(a.questions, a.limit)
+
+    # Per-row language: constrain only languages that have a script range,
+    # exactly as #142 does -- English stays unconstrained in BOTH arms.
+    def _settings_for(lang):
+        if not a.guided:
+            return None
+        return guided_settings(lang or a.lang, extended=not a.strict_142)
+
+    n_con = sum(1 for _, _, _, lg in rows if _settings_for(lg) is not None)
+    print(f"[info] {len(rows)} rows | arm={a.arm} | guided_flag={a.guided} "
+          f"| rows_constrained={n_con} | strict142={a.strict_142} "
+          f"| concurrency={a.concurrency}")
+
+    sem = asyncio.Semaphore(a.concurrency)
+    tasks = [run_one(agent, FarmerContext, rn, qid, q, (lg or a.lang), _settings_for(lg), a.arm, sem)
+             for rn, qid, q, lg in rows]
+
+    out, done = [], 0
+    for coro in asyncio.as_completed(tasks):
+        out.append(await coro)
+        done += 1
+        if done % 25 == 0 or done == len(tasks):
+            errs = sum(1 for x in out if x["error"])
+            print(f"[progress] {done}/{len(tasks)} errors={errs}", flush=True)
+
+    out.sort(key=lambda r: r["row_num"])
+    with open(a.out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        w.writerows(out)
+    errs = sum(1 for x in out if x["error"])
+    print(f"[done] {len(out)} rows -> {a.out} ({errs} errors)")
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--questions", required=False, default="")
+    p.add_argument("--out", default="bench_out_voice.csv")
+    p.add_argument("--arm", default="bare_voice")
+    p.add_argument("--lang", default="gu")
+    p.add_argument("--guided", action="store_true")
+    p.add_argument("--strict-142", action="store_true",
+                   help="use #142's char set verbatim (omits the degree sign)")
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--concurrency", type=int, default=8)
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args()
+    if not a.dry_run and not a.questions:
+        p.error("--questions required unless --dry-run")
+    sys.exit(asyncio.run(main_async(a)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bench_voice_parity.py
+++ b/scripts/run_bench_voice_parity.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""VOICE parity bench runner: bare gemma4 + the two prod terminology gates.
+
+Identical to scripts/run_bench_voice.py except for two added flags that port
+production's Gujarati terminology enforcement -- which lives ENTIRELY in the
+translation layer and is therefore bypassed by BARE_GU_NATIVE=1 -- onto the
+bare agent:
+
+  --inject-rules : appends the 33 GU_PREFERRED_TRANSLATION_RULES (imported
+                   verbatim from app/services/translation.py) to the voice
+                   agent's instructions AT RUNTIME, rephrased from
+                   translator-instructions to agent-instructions. Every
+                   Gujarati term is reproduced character-for-character.
+                   assets/prompts/voice_system_gu_native.md is NOT touched.
+
+  --apply-map    : applies assets/gu_term_policy.json "forbidden" pairs to the
+                   answer post-hoc, longest-key-first (phrase beats word),
+                   exactly like translation._build_gu_policy_replacements.
+
+Output schema is the base runner's schema plus a trailing `answer_raw` column
+holding the pre-map answer.
+
+Must run with cwd = repo root; assets load via relative paths.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+csv.field_size_limit(sys.maxsize)
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_PATH = REPO_ROOT / ".env.experiment"
+if ENV_PATH.exists():
+    load_dotenv(dotenv_path=ENV_PATH, override=True)
+else:
+    print(f"[warn] .env.experiment not found at {ENV_PATH}")
+
+os.environ.setdefault("LOGFIRE_SEND_TO_LOGFIRE", "false")
+os.environ.setdefault("LOGFIRE_IGNORE_NO_CONFIG", "1")
+os.environ.setdefault("LOGFIRE_TOKEN", "")
+
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from guided_patch import guided_settings  # noqa: E402
+
+FIELDS = [
+    "row_num", "qid", "arm", "guided", "question", "answer",
+    "latency_s", "error", "num_tool_calls", "tool_names", "tool_log",
+    "answer_raw",
+]
+
+# --------------------------------------------------------------------------
+# Gate 1: the 33 rules, rephrased translator -> agent voice.
+# Only the rules that literally speak about "translating" / "the English
+# source" are reworded; the other 30 are used verbatim. Gujarati is untouched
+# everywhere. Keys must match translation.py exactly -- we assert that below,
+# so a drift in translation.py fails loudly instead of silently dropping a rule.
+# --------------------------------------------------------------------------
+REPHRASE = {
+    "Do not translate English address markers such as sister, brother, bhai, ben, madam, or sir into caller labels like બહેન, ભાઈ, મેડમ, or સાહેબ. Use respectful gender-neutral 'આપ' wording instead.":
+        "Do not address the caller with labels like બહેન, ભાઈ, મેડમ, or સાહેબ, even if the caller uses sister, brother, bhai, ben, madam, or sir. Use respectful gender-neutral 'આપ' wording instead.",
+    "If the English source mentions 'sister' because the caller addressed Sarlaben, do not call the caller બહેન. Omit the address marker or render it as a neutral reference to સરલાબેન only when necessary.":
+        "If the caller addresses Sarlaben as 'sister' or બહેન, do not call the caller બહેન. Omit the address marker or use a neutral reference to સરલાબેન only when necessary.",
+    "'Amul AI', 'Amul A I', 'AMUL AI', 'AI helpline', 'amul helpline', 'AI helpline advisor', and 'AI-powered helpline' refer to the Amul Artificial Intelligence digital advisory helpline, not artificial insemination. Render as 'અમૂલ એ.આઈ.' / 'એ.આઈ. હેલ્પલાઇન'; never as 'કૃત્રિમ બીજદાન' or other insemination wording in helpline or assistant identity context.":
+        "'Amul AI', 'Amul A I', 'AMUL AI', 'AI helpline', 'amul helpline', 'AI helpline advisor', and 'AI-powered helpline' refer to the Amul Artificial Intelligence digital advisory helpline, not artificial insemination. Say 'અમૂલ એ.આઈ.' / 'એ.આઈ. હેલ્પલાઇન'; never 'કૃત્રિમ બીજદાન' or other insemination wording in helpline or assistant identity context.",
+}
+
+RULES_HEADER = (
+    "\n\n## GUJARATI TERMINOLOGY AND PERSONA RULES (MANDATORY)\n"
+    "Every rule below applies to the Gujarati text you produce. Gujarati terms "
+    "quoted here are exact: reproduce them character-for-character and never "
+    "substitute a synonym.\n"
+)
+
+
+def build_rules_block() -> str:
+    from app.services.translation import GU_PREFERRED_TRANSLATION_RULES as RULES
+    missing = [k for k in REPHRASE if k not in RULES]
+    if missing:
+        raise SystemExit(
+            "[fatal] REPHRASE key(s) not found verbatim in "
+            f"GU_PREFERRED_TRANSLATION_RULES -- translation.py drifted:\n  "
+            + "\n  ".join(r[:80] for r in missing)
+        )
+    lines = [REPHRASE.get(r, r) for r in RULES]
+    print(f"[rules] imported {len(RULES)} rules, rephrased {len(REPHRASE)}")
+    return RULES_HEADER + "\n".join(f"- {ln}" for ln in lines) + "\n"
+
+
+# --------------------------------------------------------------------------
+# Gate 2: deterministic forbidden-pair post-replacement.
+# --------------------------------------------------------------------------
+def build_map(policy_path: Path):
+    with policy_path.open(encoding="utf-8") as f:
+        pol = json.load(f)
+    forb = pol.get("forbidden", {}) or {}
+    pairs = sorted(
+        [(str(k).strip(), str(v).strip()) for k, v in forb.items()
+         if str(k).strip() and str(v).strip()],
+        key=lambda kv: len(kv[0]), reverse=True,   # phrase-level beats word-level
+    )
+    print(f"[map] {len(pairs)} forbidden pairs, longest-key-first "
+          f"(longest={len(pairs[0][0])} chars: {pairs[0][0]!r})")
+    return pairs
+
+
+def apply_map(text: str, pairs) -> str:
+    for bad, good in pairs:
+        if bad in text:
+            text = text.replace(bad, good)
+    return text
+
+
+def _import_agent():
+    from agents.voice import voice_agent
+    from agents.deps import FarmerContext
+    return voice_agent, FarmerContext
+
+
+async def run_one(agent, FarmerContext, row_num, qid, question, lang, settings,
+                  arm, sem, pairs):
+    async with sem:
+        t0 = time.perf_counter()
+        row = {
+            "row_num": row_num, "qid": qid, "arm": arm,
+            "guided": bool(settings), "question": question, "answer": "",
+            "latency_s": 0.0, "error": "", "num_tool_calls": 0,
+            "tool_names": "", "tool_log": "", "answer_raw": "",
+        }
+        try:
+            deps = FarmerContext(
+                query=question, lang_code=lang, target_lang=lang,
+                session_id=f"bench-{arm}-{row_num}",
+            )
+            kwargs = {"user_prompt": deps.get_user_message(), "deps": deps}
+            if settings is not None:
+                kwargs["model_settings"] = settings
+            result = await agent.run(**kwargs)
+            raw = (result.output if hasattr(result, "output") else str(result)) or ""
+            row["answer_raw"] = raw
+            row["answer"] = apply_map(raw, pairs) if pairs else raw
+
+            names, log, n = [], [], 0
+            try:
+                for m in (result.all_messages() if hasattr(result, "all_messages") else []):
+                    for p in getattr(m, "parts", []) or []:
+                        ks = str(getattr(p, "part_kind", "") or type(p).__name__).lower()
+                        if "tool-call" in ks:
+                            n += 1
+                            tn = getattr(p, "tool_name", "?")
+                            names.append(tn)
+                            log.append({"t": "call", "tool": tn,
+                                        "args": str(getattr(p, "args", ""))[:600]})
+                        elif "tool-return" in ks:
+                            log.append({"t": "ret", "tool": getattr(p, "tool_name", "?"),
+                                        "content": str(getattr(p, "content", ""))[:2000]})
+            except Exception:
+                pass
+            row["num_tool_calls"] = n
+            row["tool_names"] = "|".join(names)
+            row["tool_log"] = json.dumps(log, ensure_ascii=False)
+        except Exception as e:
+            row["error"] = f"{type(e).__name__}: {e}"
+        row["latency_s"] = round(time.perf_counter() - t0, 3)
+        return row
+
+
+def load_questions(path, limit):
+    rows = []
+    with open(path, newline="", encoding="utf-8") as f:
+        for i, r in enumerate(csv.DictReader(f)):
+            q = next((r[c] for c in ("question", "question_gu", "query", "input")
+                      if r.get(c)), "")
+            if not q:
+                continue
+            rows.append((i, r.get("id", str(i)), q, (r.get("lang") or "").strip().lower()))
+            if limit and len(rows) >= limit:
+                break
+    return rows
+
+
+async def prove_injection(agent, FarmerContext, block, lang):
+    """One real request; dump the instructions actually attached to the
+    ModelRequest that went to gemma4. A silent no-op must not survive this."""
+    probe = "તમે કોણ છો?"
+    deps = FarmerContext(query=probe, lang_code=lang, target_lang=lang,
+                         session_id="bench-proof")
+    result = await agent.run(user_prompt=deps.get_user_message(), deps=deps)
+    sent = ""
+    for m in result.all_messages():
+        sent = getattr(m, "instructions", None) or sent
+        if sent:
+            break
+    if not sent:
+        raise SystemExit("[fatal] could not read instructions off the ModelRequest")
+    tail = sent[-1400:]
+    print("=" * 72)
+    print("[proof] instructions attached to the outgoing ModelRequest "
+          f"({len(sent)} chars total). Last 1400 chars:")
+    print(tail)
+    print("=" * 72)
+    needles = [
+        "GUJARATI TERMINOLOGY AND PERSONA RULES",
+        "શકતી છું",
+        "NEVER use 'સ્તન' for animal udder",
+        "Use 'બુલ' for bull",
+        "Use 'ફેટ' for fat/milk-fat",
+    ]
+    for nd in needles:
+        ok = nd in sent
+        print(f"[proof] {'FOUND  ' if ok else 'MISSING'} {nd!r}")
+        if not ok:
+            raise SystemExit("[fatal] rules did NOT reach the model -- aborting")
+    if block.strip() not in sent:
+        raise SystemExit("[fatal] injected block not present verbatim -- aborting")
+    print("[proof] full 33-rule block present verbatim in the sent instructions.")
+    print(f"[proof] probe answer: {result.output[:300]}")
+
+
+async def main_async(a):
+    agent, FarmerContext = _import_agent()
+    print(f"[ok] agent={getattr(agent, 'name', '?')}")
+
+    block = ""
+    if a.inject_rules:
+        block = build_rules_block()
+        # Runtime-only injection: register an extra instructions source on the
+        # already-built Agent. The on-disk prompt file is never modified.
+        def _injected_terminology_rules() -> str:
+            return block
+        agent.instructions(_injected_terminology_rules)
+        print(f"[rules] injected {len(block)} chars at runtime "
+              f"(on-disk prompt untouched)")
+
+    pairs = []
+    if a.apply_map:
+        pairs = build_map(Path(a.policy))
+
+    if a.dry_run:
+        s = guided_settings(a.lang, extended=not a.strict_142)
+        print(f"[dry-run] guided={'ON' if (a.guided and s) else 'OFF'}")
+        if a.guided and s:
+            print(f"[dry-run] pattern={s.get('extra_body')['structured_outputs']['regex'][:120]}")
+        if a.inject_rules:
+            await prove_injection(agent, FarmerContext, block, a.lang)
+        return 0
+
+    if a.inject_rules:
+        await prove_injection(agent, FarmerContext, block, a.lang)
+
+    rows = load_questions(a.questions, a.limit)
+
+    def _settings_for(lang):
+        if not a.guided:
+            return None
+        return guided_settings(lang or a.lang, extended=not a.strict_142)
+
+    n_con = sum(1 for _, _, _, lg in rows if _settings_for(lg) is not None)
+    print(f"[info] {len(rows)} rows | arm={a.arm} | guided_flag={a.guided} "
+          f"| rows_constrained={n_con} | strict142={a.strict_142} "
+          f"| concurrency={a.concurrency} | inject_rules={a.inject_rules} "
+          f"| apply_map={a.apply_map}", flush=True)
+
+    sem = asyncio.Semaphore(a.concurrency)
+    tasks = [run_one(agent, FarmerContext, rn, qid, q, (lg or a.lang),
+                     _settings_for(lg), a.arm, sem, pairs)
+             for rn, qid, q, lg in rows]
+
+    out, done = [], 0
+    for coro in asyncio.as_completed(tasks):
+        out.append(await coro)
+        done += 1
+        if done % 25 == 0 or done == len(tasks):
+            errs = sum(1 for x in out if x["error"])
+            print(f"[progress] {done}/{len(tasks)} errors={errs}", flush=True)
+
+    out.sort(key=lambda r: r["row_num"])
+    with open(a.out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        w.writerows(out)
+    errs = sum(1 for x in out if x["error"])
+    changed = sum(1 for x in out if x["answer"] != x["answer_raw"])
+    print(f"[map] rows changed by forbidden map: {changed}/{len(out)}")
+    print(f"[done] {len(out)} rows -> {a.out} ({errs} errors)")
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--questions", required=False, default="")
+    p.add_argument("--out", default="bench_out_voice_parity.csv")
+    p.add_argument("--arm", default="voice_parity")
+    p.add_argument("--lang", default="gu")
+    p.add_argument("--guided", action="store_true")
+    p.add_argument("--strict-142", action="store_true",
+                   help="use #142's char set verbatim (omits the degree sign)")
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--concurrency", type=int, default=8)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--inject-rules", action="store_true",
+                   help="append the 33 GU_PREFERRED_TRANSLATION_RULES to the "
+                        "agent's instructions at runtime")
+    p.add_argument("--apply-map", action="store_true",
+                   help="apply gu_term_policy.json forbidden pairs post-hoc")
+    p.add_argument("--policy", default="assets/gu_term_policy.json")
+    a = p.parse_args()
+    if not a.dry_run and not a.questions:
+        p.error("--questions required unless --dry-run")
+    sys.exit(asyncio.run(main_async(a)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Voice half of the harness behind `amul-oan-api#181` / `#203`. Adds to `scripts/`, next to the existing measurement tooling (`measure_voice_ttft.py`, `check_pipeline_parity.py`). Code only — no result data.

Lives here rather than with the chat runners because it imports voice agent modules. Chat side is `amul-oan-api#204`.

## What's here

- `run_bench_voice.py` — runs questions straight through `voice_agent`, no FastAPI/Redis/JWT, optional vLLM guided decoding
- `run_bench_voice_parity.py` — above, plus `--inject-rules` (the 33 `GU_PREFERRED_TRANSLATION_RULES` into the agent prompt) and `--apply-map` (deterministic forbidden-term replacement). The injection is verified against `result.all_messages()` and the run aborts if any rule is missing, so it cannot silently no-op.
- `guided_patch.py` — port of `bharat-oan-api#142`, byte-identical to the chat copy
- `rubric_score.py` / `report.py` / `gender_check.py` / `posthoc_map.py`

## Worth knowing

`gender_check.py` measures `GU_FEMININE_SELF_REFERENCE_REPLACEMENTS` against real output. On production data it covers only **22–35%** of masculine self-reference. The gap is bare interrogative `શકું?` — as in `હું તમારી શું મદદ કરી શકું?` — which none of its four patterns match, since they all require `શકું છું`, `શકું નથી`, `કરું` or `આવું છું`.

That is a live gap independent of the experiment, and the script makes it measurable. Closing it looks cheap, but the block is deliberately narrow and the `સર`-strip history (#127, regressed in #154) shows what over-broad patterns cost here — so it deserves its own change, not a drive-by.

## Not included

Result CSVs and logs — raw data, kept alongside the writeup rather than in the repo.

Additive and inert: nothing here is imported by application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)