### PR TITLE
promote(prod): Raya owns the outbound intro — classify turn 1, never re-ask

### DIFF
--- a/app/services/outbound.py
+++ b/app/services/outbound.py
@@ -1,9 +1,11 @@
-"""Outbound-call opening script (milk-details consent) for voice calls.
+"""Outbound-call consent handling (milk-details readout) for voice calls.
 
-Raya stamps ``call_type=outbound`` on requests for calls WE placed. On the first
-turn of such a call Sarlaben reads a fixed consent line; on the next turn the
-farmer's reply is classified by :mod:`app.services.outbound_consent` into
-affirmative / negative / other.
+Raya stamps ``call_type=outbound`` on requests for calls WE placed, and Raya —
+not this service — speaks the opening line ("may I read out your last 7 days of
+milk?"). Our work starts at the farmer's ANSWER: the first outbound turn already
+carries it, and it is classified by :mod:`app.services.outbound_consent` into
+affirmative / negative / other. This module never emits an intro; doing so would
+give the farmer two.
 
 Everything caller-facing here is pinned Gujarati, served verbatim. It never goes
 through TranslateGemma: these lines carry a phone number, the brand name, and the
@@ -31,7 +33,10 @@ CALL_TYPE_INBOUND = "inbound"
 CALL_TYPE_OUTBOUND = "outbound"
 
 # Session stages for the outbound opener.
-STAGE_INTRO_SENT = "intro_sent"      # consent line spoken, awaiting the farmer's reply
+# Legacy: written only by the removed in-app intro. Sessions carrying it were
+# mid-call across that deploy; kept so their next turn still routes to the
+# consent gate. Nothing sets it any more.
+STAGE_INTRO_SENT = "intro_sent"
 STAGE_RESOLVED = "resolved"          # consent already handled; call is a normal conversation
 
 _STATE_SUFFIX = "outbound_state"
@@ -43,20 +48,13 @@ _STATE_TTL = 60 * 60 * 4  # a call never outlives this; keeps stale state out of
 # Source: "Outbound call script for previously interacted (non-returning
 # registered callers)". The English variants exist only for message history and
 # for en-target test calls — the caller hears the Gujarati.
-
-OUTBOUND_INTRO = {
-    # "સાત", not the script's "7": clean_output_by_language() strips every
-    # non-Gujarati-block character for gu, so an ASCII digit would be deleted and
-    # the caller would hear "in the last  days".
-    "gu": (
-        "નમસ્તે! હું અમૂલ તરફથી સરલાબેન બોલું છું. "
-        "શું હું તમને છેલ્લા સાત દિવસમાં તમે જમા કરાવેલા દૂધની વિગતો જણાવું?"
-    ),
-    "en": (
-        "Hello! This is Sarlaben calling from Amul. "
-        "May I tell you the details of the milk you deposited in the last 7 days?"
-    ),
-}
+#
+# NOTE: the script's opening line lives in RAYA, not here. Everything below is
+# said only AFTER the farmer has replied to it.
+#
+# Digits are spelled as Gujarati words on purpose: clean_output_by_language()
+# strips every non-Gujarati-block character for gu, so an ASCII digit would be
+# deleted and the caller would hear a gap where the number should be.
 
 OUTBOUND_DECLINE_FAREWELL = {
     "gu": (

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -290,8 +290,9 @@ _NON_MEANINGFUL_EXCLUDED_TURNS = frozenset(
         #_HISTORY_MARKERS["stt_no_audio"],
         #_HISTORY_MARKERS["stt_unclear"],
         _HISTORY_MARKERS["moderation_reject"],
-        # Not a caller turn at all — it stands in for "we placed this call", so it
-        # must neither count toward a hangup streak nor break one.
+        # Legacy marker from the removed in-app intro (Raya owns the opener now).
+        # Not a caller turn at all, so it must neither count toward a hangup
+        # streak nor break one, for as long as such histories survive trimming.
         _HISTORY_MARKERS["outbound_intro"],
     }
 )
@@ -1215,52 +1216,46 @@ async def stream_voice_message(
             nudge_lang = (requested_target_lang or "en").strip().lower()
             has_meaningful_history = _has_meaningful_history(history)
 
-            # ── Outbound opener ───────────────────────────────────────────
-            # Calls WE placed open with one scripted consent question instead of
-            # answering whatever the first turn happens to carry. The stage is
-            # read from Redis (not history) so it survives trimming, and is read
-            # on every turn while the feature flag is on because Raya is not
-            # guaranteed to re-stamp call_type after the first request.
+            # ── Outbound consent gate ─────────────────────────────────────
+            # RAYA speaks the opening line on a call we placed, not us. By the
+            # time the first request reaches this service the farmer has already
+            # heard the intro and answered it — so the FIRST outbound turn
+            # carries the consent reply. We classify that reply; we never send an
+            # intro of our own, or the farmer hears two.
+            #
+            # The stage is read from Redis (not history) so it survives trimming,
+            # and is read on every turn while the feature flag is on because Raya
+            # is not guaranteed to re-stamp call_type after the first request.
             outbound_stage = (
                 await _outbound.get_stage(session_id)
                 if settings.outbound_intro_enabled
                 else None
             )
-            outbound_opener_turn = (
-                settings.outbound_intro_enabled
-                and _outbound.is_outbound(call_type)
-                and outbound_stage is None
-                and not history
-                # Only when the first turn carries no real content. If Raya
-                # forwards an actual question on connect, answer it — the farmer
-                # asking something themselves beats our script every time.
-                and (
-                    not (query or "").strip()
-                    or detect_stt_signal(query) is not None
-                    or _is_bare_greeting(query)
-                    or _is_fragment_query(query)
+            # The turn answering Raya's opening question is owned by the consent
+            # gate: the greeting / fragment / identity fast paths must not preempt
+            # it. "હા બોલો" — the single most likely affirmative reply — is itself a
+            # _GREETING_TOKENS entry, so without this an affirmative reply could be
+            # answered with the generic greeting and the readout lost.
+            outbound_consent_turn = settings.outbound_intro_enabled and (
+                (
+                    _outbound.is_outbound(call_type)
+                    and outbound_stage is None
+                    and not history
                 )
+                # Sessions opened by our own (now removed) intro that are still
+                # mid-call across the deploy — they are already past the intro, so
+                # their next turn is still the consent reply.
+                or outbound_stage == _outbound.STAGE_INTRO_SENT
             )
-            if outbound_opener_turn:
-                trace.set_route("outbound_intro")
+            if outbound_consent_turn:
                 logger.info(
-                    "Outbound intro emitted; session_id=%s process_id=%s user_id=%s query=%r",
+                    "Outbound consent turn; session_id=%s process_id=%s user_id=%s query=%r",
                     session_id, process_id, user_id, (query or "")[:60],
                 )
-                intro_en = _outbound.OUTBOUND_INTRO["en"]
-                intro_for_caller = await _canned_for_caller(
-                    intro_en, requested_target_lang, _outbound.OUTBOUND_INTRO,
-                )
-                intro_req, intro_resp = _history_pair(
-                    _canonical_history_user_text("outbound_intro"), intro_en,
-                )
-                with trace.stage("history_write"):
-                    await update_message_history(session_id, [*history, intro_req, intro_resp])
-                await _outbound.set_stage(session_id, _outbound.STAGE_INTRO_SENT)
-
-                # Warm the milk summary while the farmer is answering. Bounded
-                # inside the prefetch; failure just means the agent fetches it
-                # itself on the next turn.
+                # Warm the milk summary alongside the consent classifier so an
+                # affirmative reply does not pay the upstream lookup serially.
+                # There is no longer a turn of our own to hide it behind. Failure
+                # just means the agent fetches it itself.
                 _prefetch_mobile = normalize_phone_to_mobile(user_id)
                 if _prefetch_mobile:
                     async def _warm_outbound_milk(mobile_number: str = _prefetch_mobile):
@@ -1269,17 +1264,6 @@ async def stream_voice_message(
                             session_id, _collect_farmer_accounts(envelope),
                         )
                     _outbound.spawn(_warm_outbound_milk(), label="outbound_milk_prefetch")
-
-                trace.set_outcome("outbound_intro")
-                yield _emit(_prepare_voice_output(intro_for_caller, requested_target_lang))
-                return
-
-            # The turn that answers the outbound consent question is owned by the
-            # consent gate: the greeting / fragment / identity fast paths must not
-            # preempt it. "હા બોલો" — the single most likely affirmative reply — is
-            # itself a _GREETING_TOKENS entry, so without this an affirmative reply
-            # could be answered with the generic greeting and the readout lost.
-            outbound_consent_turn = outbound_stage == _outbound.STAGE_INTRO_SENT
 
             # ── STT signal handling (no-audio / unclear speech) ─────────────
             # These are not real user messages — skip translation & agent,

--- a/tests/test_outbound_intro.py
+++ b/tests/test_outbound_intro.py
@@ -1,8 +1,12 @@
-"""Outbound-call opener: intro line, consent gate, and the decline hangup.
+"""Outbound-call consent gate and the decline hangup.
+
+Raya speaks the opening line, so the FIRST outbound turn already carries the
+farmer's answer to it. These tests pin that we classify that first turn and never
+speak an intro ourselves (which would give the farmer two).
 
 Covers the three-way consent verdict and, importantly, that an uncertain verdict
-never ends the call. Inbound behaviour must be untouched by all of this, so the
-last test drives a plain inbound turn through the same path.
+never ends the call. Inbound behaviour must be untouched by all of this, so one
+test drives a plain inbound turn through the same path.
 """
 import os
 
@@ -46,13 +50,10 @@ def test_milk_window_is_seven_days_inclusive():
     assert date.fromisoformat(todate) - date.fromisoformat(fromdate) == timedelta(days=6)
 
 
-def test_intro_survives_the_gujarati_output_filter():
-    """Regression: the script's ASCII "7" is stripped for gu, which would make
-    the caller hear "in the last  days". The line must spell the number out."""
-    spoken = clean_output_by_language(ob.OUTBOUND_INTRO["gu"], "gu")
-    assert "સાત" in spoken
-    assert "દિવસ" in spoken
-    assert not any(ch.isdigit() and ch.isascii() for ch in spoken)
+def test_no_intro_line_is_shipped_in_this_service():
+    """Raya owns the call's opening line. If an intro constant reappears here,
+    the farmer hears the question twice — once from Raya, once from us."""
+    assert not hasattr(ob, "OUTBOUND_INTRO")
 
 
 def test_farewell_keeps_the_helpline_number():
@@ -215,48 +216,68 @@ def _history_texts(messages):
     return out
 
 
-def test_outbound_first_turn_emits_the_intro_and_arms_the_prefetch(voice_harness):
-    output = asyncio.run(voice_harness["collect"]("", session_id="s-intro"))
+def test_outbound_first_turn_classifies_instead_of_speaking_an_intro(voice_harness):
+    """The core of this change: Raya already asked, so turn 1 is the ANSWER.
+    We must classify it and never re-ask."""
+    from app.services.outbound_consent import ConsentVerdict
 
-    assert "સરલાબેન" in output and "દૂધ" in output
-    assert voice_harness["stage"]["s-intro"] == ob.STAGE_INTRO_SENT
-    assert _history_texts(voice_harness["history"]["s-intro"])[0] == "[outbound-call-started]"
-    # No agent run on the intro turn.
-    assert voice_harness["agent_inputs"] == []
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_NEGATIVE, reason="declines")
+
+    output = asyncio.run(voice_harness["collect"]("nahi", session_id="s-first"))
+
+    # The reply reached the classifier on the very first turn.
+    assert voice_harness["consent_reply"] == "nahi"
+    # ...and was acted on, rather than answered with an intro.
+    assert "સરલાબેન બોલું છું" not in output
+    assert "વૉટ્સએપ" in output
+    assert voice_harness["stage"]["s-first"] == ob.STAGE_RESOLVED
+
+
+def test_outbound_first_turn_never_arms_the_intro_stage(voice_harness):
+    """Nothing may write STAGE_INTRO_SENT any more — that stage existed only to
+    mean "we spoke our own intro, awaiting the reply"."""
+    from app.services.outbound_consent import ConsentVerdict
+
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_OTHER, reason="unclear")
+
+    asyncio.run(voice_harness["collect"]("", session_id="s-empty"))
+
+    assert ob.STAGE_INTRO_SENT not in voice_harness["stage"].values()
+
+
+def test_outbound_first_turn_arms_the_milk_prefetch(voice_harness, monkeypatch):
+    """The prefetch used to hide behind our intro turn. With that turn gone it
+    must start alongside the consent classifier, or an affirmative reply pays the
+    full upstream lookup serially."""
+    from app.services import voice as voice_module
+    from app.services.outbound_consent import ConsentVerdict
+
+    monkeypatch.setattr(voice_module, "normalize_phone_to_mobile", lambda user_id: "9999999999")
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_OTHER, reason="unclear")
+
+    asyncio.run(voice_harness["collect"]("hmm", session_id="s-prefetch"))
+
+    assert "outbound_milk_prefetch" in voice_harness["prefetch_calls"]
 
 
 def test_inbound_first_turn_is_untouched(voice_harness):
-    """The opener must be invisible to the inbound helpline."""
+    """The consent gate must be invisible to the inbound helpline."""
     output = asyncio.run(
         voice_harness["collect"]("my cow has fever", session_id="s-in", call_type="inbound")
     )
 
-    assert "સરલાબેન બોલું છું" not in output
+    assert "વૉટ્સએપ" not in output
+    assert voice_harness.get("consent_reply") is None   # classifier never ran
     assert "s-in" not in voice_harness["stage"]
-    assert len(voice_harness["agent_inputs"]) == 1
-
-
-def test_outbound_first_turn_with_a_real_question_skips_the_script(voice_harness):
-    """If Raya forwards an actual question on connect, answer it — the farmer
-    asking something themselves beats the script."""
-    output = asyncio.run(
-        voice_harness["collect"]("my buffalo is not eating", session_id="s-q")
-    )
-
-    assert "સરલાબેન બોલું છું" not in output
-    assert "s-q" not in voice_harness["stage"]
     assert len(voice_harness["agent_inputs"]) == 1
 
 
 def test_negative_consent_speaks_the_farewell_then_hangs_up(voice_harness):
     from app.services.outbound_consent import ConsentVerdict
 
-    voice_harness["stage"]["s-no"] = ob.STAGE_INTRO_SENT
     voice_harness["consent"] = ConsentVerdict(intent=INTENT_NEGATIVE, reason="declines")
 
-    output = asyncio.run(
-        voice_harness["collect"]("na atyare nahi", session_id="s-no", history=[object()])
-    )
+    output = asyncio.run(voice_harness["collect"]("na atyare nahi", session_id="s-no"))
 
     assert "વૉટ્સએપ" in output               # the scripted farewell was spoken
     assert output.rstrip().endswith("Goodbye.")  # exact ASCII telephony token
@@ -270,11 +291,10 @@ def test_affirmative_consent_hands_the_prefetched_summary_to_the_agent(voice_har
     fast-path and the readout is silently lost."""
     from app.services.outbound_consent import ConsentVerdict
 
-    voice_harness["stage"]["s-yes"] = ob.STAGE_INTRO_SENT
     voice_harness["consent"] = ConsentVerdict(intent=INTENT_AFFIRMATIVE, reason="clear yes")
     voice_harness["milk"] = "Milk collection records (2): ... quantity 9 liters"
 
-    asyncio.run(voice_harness["collect"]("ha bolo", session_id="s-yes", history=[object()]))
+    asyncio.run(voice_harness["collect"]("ha bolo", session_id="s-yes"))
 
     assert len(voice_harness["agent_inputs"]) == 1
     hint_text = "\n".join(_history_texts(voice_harness["agent_inputs"][0]))
@@ -284,15 +304,15 @@ def test_affirmative_consent_hands_the_prefetched_summary_to_the_agent(voice_har
 
 
 def test_other_consent_falls_through_to_a_normal_agent_turn(voice_harness):
+    """A farmer who answers the opener with their own question gets it answered."""
     from app.services.outbound_consent import ConsentVerdict
 
-    voice_harness["stage"]["s-other"] = ob.STAGE_INTRO_SENT
     voice_harness["consent"] = ConsentVerdict(
         intent=INTENT_OTHER, reason="asks own question", failed_open=True,
     )
 
     output = asyncio.run(
-        voice_harness["collect"]("my cow is not eating", session_id="s-other", history=[object()])
+        voice_harness["collect"]("my cow is not eating", session_id="s-other")
     )
 
     assert "Goodbye." not in output              # an uncertain verdict never hangs up
@@ -301,3 +321,19 @@ def test_other_consent_falls_through_to_a_normal_agent_turn(voice_harness):
     hint_text = "\n".join(_history_texts(voice_harness["agent_inputs"][0]))
     assert "Milk deposit summary" not in hint_text
     assert voice_harness["stage"]["s-other"] == ob.STAGE_RESOLVED
+
+
+def test_legacy_intro_sent_sessions_still_route_to_the_consent_gate(voice_harness):
+    """Sessions mid-call across the deploy already heard our old intro; their
+    next turn is still the consent reply and must not be re-classified as turn 1."""
+    from app.services.outbound_consent import ConsentVerdict
+
+    voice_harness["stage"]["s-legacy"] = ob.STAGE_INTRO_SENT
+    voice_harness["consent"] = ConsentVerdict(intent=INTENT_NEGATIVE, reason="declines")
+
+    output = asyncio.run(
+        voice_harness["collect"]("nahi", session_id="s-legacy", history=[object()])
+    )
+
+    assert "વૉટ્સએપ" in output
+    assert voice_harness["stage"]["s-legacy"] == ob.STAGE_RESOLVED


### PR DESCRIPTION
Promotion of #241 to `amul-prod`. Clean cherry-pick of `ae2b8f4`, no conflicts, no prod-only adjustments.

On an outbound call Raya speaks the opening line, not us. We were speaking it too, so the farmer heard the milk-consent question twice and the gate waited an extra turn for an answer already given. The first outbound turn now goes straight to the consent classifier — so **"nahi" on turn 1 reaches the decline farewell + hangup**.

`tests/test_outbound_intro.py` re-run on the prod branch after the cherry-pick: 22 passed.

Note: `OUTBOUND_INTRO_ENABLED` is currently **true** in the prod ConfigMap, so this ships live on merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)