### PR TITLE
promote(prod): ban Kutch union from booking AI calls

### DIFF
--- a/agents/services/farmer_cache.py
+++ b/agents/services/farmer_cache.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 from app.core.cache import cache, redis_client, build_cache_key
 from app.config import settings
+from app.models.union import is_ai_call_banned_union
 from app.observability import start_observation
 from agents.models.farmer import AnimalRecord, FarmerDataEnvelope, FarmerRecord
 from agents.tools.farmer_animal_backends import (
@@ -456,6 +457,14 @@ async def _fetch_ai_technicians(records: list[FarmerRecord]) -> list[dict]:
 
     async def _fetch_for_farmer(record: FarmerRecord) -> Optional[dict]:
         data = record.model_dump()
+        union_name = data.get("unionName") or data.get("union_name")
+        if is_ai_call_banned_union(union_name if isinstance(union_name, str) else None):
+            logger.info(
+                "Skipping AI technician lookup; union is banned from AI-call booking union=%s farmer=%s",
+                union_name,
+                data.get("farmerName"),
+            )
+            return None
         union_code = data.get("unionCode") or data.get("union_code")
         society_code = data.get("societyCode") or data.get("society_code")
         if not union_code or not society_code:

--- a/agents/tools/ai_call.py
+++ b/agents/tools/ai_call.py
@@ -11,6 +11,7 @@ from agents.deps import FarmerContext
 from agents.models.ai_call import AICallRequestModel, AISpecies
 from agents.tools.farmer_animal_backends import create_ai_call_api
 from app.core.cache import cache, try_reserve, release_reservation
+from app.models.union import UNION_BANNED_MESSAGE, any_union_banned_from_ai_calls
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -35,6 +36,9 @@ async def create_ai_call(
     Ask the farmer whether the booking is for a cow (ગાય) or buffalo (ભેંસ) before calling this tool.
     Never ask the farmer to speak an internal technician ID. Use the selected technician option
     already present in farmer context.
+    If Farmer Profile says AI call booking is not allowed for this union, tell the farmer
+    exactly: Kindly contact your Milk Society to book the service. Do not ask which
+    technician and do not book.
 
     Args:
         ctx: The run context (automatically provided).
@@ -59,6 +63,18 @@ async def create_ai_call(
     if not await ctx.deps.ensure_in_scope():
         logger.info("AI call blocked: query failed moderation; session=%s", session_id)
         return "This helpline only handles dairy farming and animal husbandry questions."
+
+    # Union ban is a policy gate, not a booking write: refuse before Redis
+    # reservation and before PashuGPT. farmer_unions may be missing on test
+    # stubs and on unsigned-in turns — those are not banned.
+    farmer_unions = getattr(ctx.deps, "farmer_unions", []) if ctx and ctx.deps else []
+    if any_union_banned_from_ai_calls(farmer_unions):
+        logger.info(
+            "AI call blocked: union banned from AI-call booking unions=%s session=%s",
+            farmer_unions,
+            session_id,
+        )
+        return UNION_BANNED_MESSAGE
 
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:

--- a/app/models/union.py
+++ b/app/models/union.py
@@ -53,6 +53,51 @@ def canonical_union_name(name: str | None) -> str:
     return UNION_NAME_ALIASES.get(key, key)
 
 
+# Canonical union names that must not book artificial-insemination calls.
+# Compare against ``canonical_union_name`` output so brand/spelling aliases
+# (e.g. "sarhad" for Kutch) hit the same entry.
+AI_CALL_BANNED_UNIONS: frozenset[str] = frozenset({UnionName.KUTCH.value})
+# Farmer-facing refusal, keyed by language code. English is what the agent is
+# told to say (and what create_ai_call returns); Gujarati/Hindi are pinned so
+# post-translation cannot drift off the agreed copy.
+UNION_BANNED_MESSAGES: dict[str, str] = {
+    "en": "Kindly contact your Milk Society to book the service.",
+    "gu": "કૃપા કરીને આપની દૂધ મંડળીનો સંપર્ક કરશો.",
+    "hi": "कृपया सेवा बुक करने के लिए अपनी दूध मंडली से संपर्क करें।",
+}
+_UNION_BANNED_LANG_ALIASES: dict[str, str] = {
+    "english": "en",
+    "gujarati": "gu",
+    "hindi": "hi",
+}
+# Shared by technician-context copy and create_ai_call so banned unions hear the
+# same refusal whether the model follows the prompt or the tool is reached.
+UNION_BANNED_MESSAGE = UNION_BANNED_MESSAGES["en"]
+
+
+def union_banned_message_for_lang(lang: str | None) -> str:
+    """Pinned union-ban copy for ``lang`` (``en`` / ``gu`` / ``hi`` or aliases)."""
+    key = (lang or "en").strip().lower()
+    code = _UNION_BANNED_LANG_ALIASES.get(key, key)
+    return UNION_BANNED_MESSAGES.get(code, UNION_BANNED_MESSAGES["en"])
+
+
+def is_ai_call_banned_union(name: str | None) -> bool:
+    """True when ``name`` canonicalizes to a union banned from AI-call booking."""
+    canonical = canonical_union_name(name)
+    return bool(canonical) and canonical in AI_CALL_BANNED_UNIONS
+
+
+def any_union_banned_from_ai_calls(names: list[str] | None) -> bool:
+    """True when any entry in ``names`` is banned from AI-call booking.
+
+    Farmer context stores unions as ``strip().lower()`` without alias mapping,
+    so this canonicalizes each name before checking :data:`AI_CALL_BANNED_UNIONS`.
+    An empty/missing list is not banned.
+    """
+    return any(is_ai_call_banned_union(name) for name in (names or []))
+
+
 def resolve_supported_unions(union_names: list[str] | None, supported_unions: set[str]) -> list[str]:
     """Canonicalize raw union names and keep only supported values.
 

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -22,7 +22,13 @@ from agents.services.farmer_cache import (
     should_refresh_farmer_data,
     exceeds_max_serve_stale,
 )
-from app.models.union import UnionName, resolve_supported_unions
+from app.models.union import (
+    UNION_BANNED_MESSAGE,
+    UnionName,
+    is_ai_call_banned_union,
+    resolve_supported_unions,
+    union_banned_message_for_lang,
+)
 from app.services.scheme_ingestion import (
     SchemeCacheError,
     SchemeDependencyError,
@@ -543,11 +549,22 @@ def _should_gate_non_meaningful_llm(turns: list[str]) -> bool:
     return len(turns) >= 5
 
 
+def _canned_union_ban_translation(text_en: str, target_lang: str) -> str | None:
+    """Pinned Gujarati/Hindi union-ban copy when the English batch is that line."""
+    if (text_en or "").strip() != UNION_BANNED_MESSAGE:
+        return None
+    return union_banned_message_for_lang(target_lang)
+
+
 async def _render_text_for_caller(text_en: str, target_lang: str) -> str:
     """Render English loop text for the caller's language outside the agent loop."""
     normalized_target = (target_lang or "en").strip().lower()
     if normalized_target in {"en", "english"}:
         return _prepare_voice_output(text_en, "en")
+
+    canned_ban = _canned_union_ban_translation(text_en, normalized_target)
+    if canned_ban is not None:
+        return _prepare_voice_output(canned_ban, normalized_target)
 
     try:
         translated = await translate_text(
@@ -913,12 +930,96 @@ def _dedupe_technicians(technicians: list[dict]) -> list[dict]:
     return list(unique.values())
 
 
+def _farmer_record_union_name(record: FarmerRecord) -> str | None:
+    data = record.model_dump()
+    union_name = data.get("unionName") or data.get("union_name")
+    return union_name if isinstance(union_name, str) else None
+
+
+def _farmer_record_identity(data: dict) -> tuple[str, str, str]:
+    return (
+        str(data.get("farmerCode") or data.get("farmer_code") or ""),
+        str(data.get("societyCode") or data.get("society_code") or ""),
+        str(data.get("unionCode") or data.get("union_code") or ""),
+    )
+
+
+def _technician_group_is_banned(
+    group: dict,
+    banned_identities: set[tuple[str, str, str]],
+    banned_union_codes: set[str],
+) -> bool:
+    """True when this cached group belongs to a union banned from AI-call booking.
+
+    Identity (farmerCode, societyCode, unionCode) is the primary match so a mixed
+    mobile keeps Kaira technicians. Farmer+society and union-code fallbacks hide
+    leftover Kutch groups when some codes on the group are incomplete.
+    """
+    identity = (
+        str(group.get("farmerCode") or group.get("farmer_code") or ""),
+        str(group.get("societyCode") or group.get("society_code") or ""),
+        str(group.get("unionCode") or group.get("union_code") or ""),
+    )
+    if identity != ("", "", "") and identity in banned_identities:
+        return True
+    farmer_society = (identity[0], identity[1])
+    if farmer_society != ("", "") and any(
+        (farmer_code, society_code) == farmer_society
+        for farmer_code, society_code, _union_code in banned_identities
+    ):
+        return True
+    union_code = identity[2]
+    return bool(union_code) and union_code in banned_union_codes
+
+
+def _append_ai_call_union_ban_lines(lines: list[str], farmer: FarmerRecord) -> None:
+    data = farmer.model_dump()
+    farmer_name = data.get("farmerName") or data.get("farmer_name") or "Unknown farmer"
+    society_name = data.get("societyName") or data.get("society_name") or "Unknown society"
+    _, society_code, union_code = _farmer_record_identity(data)
+    lines.append(
+        f"- Technician group: farmer_name={farmer_name}, society_name={society_name}, "
+        f"union_code={union_code or None}, society_code={society_code or None}"
+    )
+    lines.append("- AI call booking is not allowed for this union.")
+    lines.append(f"- Tell the farmer: `{UNION_BANNED_MESSAGE}`")
+    lines.append("- Do not ask which technician they want. Do not call `create_ai_call`.")
+
+
 def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
     if envelope is None:
         return ""
 
-    technician_groups = envelope.aiTechnicians or []
+    banned_farmers: list[FarmerRecord] = []
+    banned_identities: set[tuple[str, str, str]] = set()
+    banned_union_codes: set[str] = set()
+    for farmer in envelope.farmers or []:
+        if not is_ai_call_banned_union(_farmer_record_union_name(farmer)):
+            continue
+        banned_farmers.append(farmer)
+        data = farmer.model_dump()
+        identity = _farmer_record_identity(data)
+        if identity != ("", "", ""):
+            banned_identities.add(identity)
+        if identity[2]:
+            banned_union_codes.add(identity[2])
+
+    if banned_farmers:
+        logger.info(
+            "Skipping AI technician context; union is banned from AI-call booking unions=%s",
+            [_farmer_record_union_name(farmer) for farmer in banned_farmers],
+        )
+
+    all_farmers_banned = bool(envelope.farmers) and len(banned_farmers) == len(envelope.farmers)
+    technician_groups = [] if all_farmers_banned else [
+        group
+        for group in (envelope.aiTechnicians or [])
+        if not _technician_group_is_banned(group, banned_identities, banned_union_codes)
+    ]
     lines: list[str] = []
+    for farmer in banned_farmers:
+        _append_ai_call_union_ban_lines(lines, farmer)
+
     if technician_groups:
         lines.append("- AI technician options for booking are internal context, not user-provided information.")
         lines.append("- The caller does not know which AI technicians are available unless you tell them by technician name.")
@@ -964,7 +1065,7 @@ def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
                 if mobile:
                     option += f", mobile_number={mobile}"
                 lines.append(option)
-    else:
+    elif not banned_farmers:
         lines.append("- AI technician options for booking are not available in the current signed-in context.")
     return "\n".join(lines)
 
@@ -2396,6 +2497,12 @@ async def stream_voice_message(
                     if not text_to_translate:
                         return
                     text_to_translate = _guard_identity_drift(text_to_translate)
+                    canned_ban = _canned_union_ban_translation(
+                        text_to_translate, requested_target_lang,
+                    )
+                    if canned_ban is not None:
+                        yield _prepare_voice_output(canned_ban, requested_target_lang)
+                        return
                     try:
                         with trace.stage(
                             "output_translation",

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -218,6 +218,8 @@ Never read out animal tag numbers, farmer codes, society codes, or union codes u
 
 When a farmer requests artificial insemination booking (beech daan, beej daan, AI booking):
 
+**Union ban (takes precedence):** If the runtime Farmer Context or internal AI technician context says AI call booking is not allowed for this union, tell the farmer exactly: `Kindly contact your Milk Society to book the service.` Do **not** ask which technician they want. Do **not** call `create_ai_call`. Do **not** treat missing technicians as unavailable / try again later.
+
 1. Check farmer context first. `union_code`, `society_code`, and `farmer_code` must be present in the selected farmer record. If missing, say their details are not available right now.
 2. If the runtime Farmer Context shows more than one farmer record for the mobile number, ask which farmer name should be used for booking before doing anything else.
 3. Keep that farmer-selection prompt short, similar to: "Which farmer name should I use for the booking? I found Rameshbhai and Sureshbhai."
@@ -228,7 +230,7 @@ When a farmer requests artificial insemination booking (beech daan, beej daan, A
 8. Keep that technician prompt concise, similar to: "Which technician should I book with? I can book with Ramesh Patel or Suresh Patel."
 9. Never ask the farmer to choose a technician by position, number, option index, or ordinal words. Do not say first technician, second technician, third technician, option one, option two, પહેલા, બીજા, ત્રીજા, or similar translated equivalents. **Always use technician name to identify him**.
 10. If exactly one technician option is available for the selected farmer, use that technician directly. Do not ask the farmer to choose unless confirmation is genuinely necessary.
-11. If no technician options are available for the selected farmer, say technician details are not available right now and ask them to try again later.
+11. If no technician options are available for the selected farmer **and** the context does not say AI calls are banned for this union, say technician details are not available right now and ask them to try again later.
 12. Ask species if still missing. Keep it short, for example: "Is this for a cow or buffalo?"
 13. After the farmer chooses a technician, or when only one technician is available, map that technician to the matching `id` from the selected farmer's technician group and call `create_ai_call` with `union_code`, `society_code`, `farmer_code`, `user_id`, and `species`.
 14. If more than one technician still matches the farmer's reply, ask one brief disambiguation question using name and mobile number only.

--- a/assets/prompts/voice_system_translation_pipeline_gemma4_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_gemma4_en.md
@@ -108,7 +108,7 @@ Classify intent: clinical, nutrition, breeding, crop, scheme, market, weather, s
 - clinical, nutrition, breeding, crop, market, weather → call `search_documents` with concise English keywords. Always retrieve for these.
 - scheme → if runtime Farmer Context shows the signed-in farmer's union schemes, prefer `get_union_scheme_data(scheme_name=...)`. Use `search_documents` only when union cache is unavailable.
 - milk collection, fat, S N F, milk payment, deduction, milk account, collection history → call `get_farmer_milk_collection_details`. Never use `search_documents` for these.
-- services (artificial insemination, beech daan, beej daan, A I booking) → run the A I booking flow; finish with `create_ai_call`.
+- services (artificial insemination, beech daan, beej daan, A I booking) → run the A I booking flow; finish with `create_ai_call` unless context says AI calls are not allowed for this union.
 - services (veterinary visit, emergency health booking) → run the health-call flow; finish with `create_health_call`.
 - profile → use `get_farmer_profile`, `get_herd_summary`, `list_animal_tags`.
 - language_switch → ignore silently. Do not retrieve. Do not mention language.
@@ -138,6 +138,8 @@ After retrieval: give the smallest useful answer — one main recommendation, op
 
 ## create_ai_call — artificial insemination booking
 
+**Union ban (takes precedence):** If runtime Farmer Context or internal A I technician context says AI call booking is not allowed for this union, tell the farmer exactly: `Kindly contact your Milk Society to book the service.` Do **not** ask which technician they want. Do **not** call `create_ai_call`. Do **not** treat missing technicians as unavailable / try again later.
+
 Run when the caller asks for beech daan, beej daan, or A I booking. Steps:
 
 1. Require `union_code`, `society_code`, `farmer_code` on the chosen farmer record. If missing, say their details are not available right now and stop.
@@ -146,7 +148,7 @@ Run when the caller asks for beech daan, beej daan, or A I booking. Steps:
 4. Never ask the caller for a technician ID or internal user ID.
 5. Exactly one technician available → use it. Multiple → ask the caller, naming each technician by full name. Use phone number only to disambiguate similar names. Example: "Which technician should I book with? I can book with Ramesh Patel or Suresh Patel."
 6. Never ask the caller to choose by ordinal or option index ("first technician", "second", "પહેલા", "બીજા"). Use names.
-7. Zero technicians → say technician details are not available right now and ask them to try again later.
+7. Zero technicians **and** the context does not say AI calls are banned for this union → say technician details are not available right now and ask them to try again later.
 8. Ask species if missing: "Is this for a cow or buffalo?"
 9. Map chosen technician to its `id` and call `create_ai_call(union_code, society_code, farmer_code, user_id, species)`.
 10. Success → share the ticket number and the assigned technician's name or phone. Failure → say the booking could not be completed right now.

--- a/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
@@ -113,7 +113,7 @@ Classify every turn into one of: `clinical`, `nutrition`, `breeding`, `crop`, `s
 - `clinical`, `nutrition`, `breeding`, `crop`, `market`, `weather` → call `search_documents` with concise English keywords (two to eight words, twelve max). When in doubt, retrieve.
 - `scheme` → if runtime Farmer Context shows the signed-in farmer's union, prefer `get_union_scheme_data(scheme_name=...)` for that union (especially Banas or Kutch). Use `search_documents` only when union cache is unavailable or the question is not about the signed-in farmer's union schemes.
 - For milk collection, fat, S N F, milk payment, deduction, milk account, or collection history: call `get_farmer_milk_collection_details`. Never use `search_documents` for these account lookups.
-- `services` involving artificial insemination booking ("beech daan", "beej daan", "A I booking") → run the AI booking flow below; eventually call `create_ai_call`.
+- `services` involving artificial insemination booking ("beech daan", "beej daan", "A I booking") → run the AI booking flow below; eventually call `create_ai_call` unless the context says AI calls are not allowed for this union.
 - `services` involving veterinary visit or emergency health booking → run the health-call flow below; eventually call `create_health_call`.
 - `profile` → use `get_farmer_profile`, `get_herd_summary`, `list_animal_tags` as needed. Compress per the rule below.
 - `language_switch` → ignore silently. Do not retrieve. Do not mention language.
@@ -142,7 +142,7 @@ After retrieval, give the smallest useful answer: one main recommendation, optio
 
 # Tool: `create_ai_call` (artificial insemination booking)
 
-When the caller asks to book artificial insemination, beech daan, beej daan, or A I booking, **you MUST run this flow and call `create_ai_call`** — do not chat around it.
+When the caller asks to book artificial insemination, beech daan, beej daan, or A I booking, **you MUST run this flow** — do not chat around it. **Union ban (takes precedence):** If the runtime Farmer Context or internal AI technician context says AI call booking is not allowed for this union, tell the farmer exactly: `Kindly contact your Milk Society to book the service.` Do **not** ask which technician they want. Do **not** call `create_ai_call`. Do **not** treat missing technicians as unavailable / try again later.
 
 1. Check Farmer Context. `union_code`, `society_code`, `farmer_code` must be present on the chosen farmer record. If missing, say their details are not available right now and stop.
 2. If more than one farmer record matches the mobile number, ask which farmer name to use first. Example: "Which farmer name should I use for the booking? I found Rameshbhai and Sureshbhai."
@@ -151,7 +151,7 @@ When the caller asks to book artificial insemination, beech daan, beej daan, or 
 5. If exactly one technician option is available for the chosen farmer, use that technician directly.
 6. If more than one technician option is available, ask the caller which technician they want, naming each by full name in natural spoken form. Use phone number only to disambiguate two similar names. Example: "Which technician should I book with? I can book with Ramesh Patel or Suresh Patel."
 7. **Never ask the caller to choose by position, number, option index, or ordinal** (no "first technician", "second technician", "પહેલા", "બીજા", "ત્રીજા"). Always use the technician's name.
-8. If no technician options exist for the chosen farmer, say technician details are not available right now and ask them to try again later.
+8. If no technician options exist for the chosen farmer **and** the context does not say AI calls are banned for this union, say technician details are not available right now and ask them to try again later.
 9. Ask the species if still missing: "Is this for a cow or buffalo?"
 10. Map the chosen technician to its `id` from the selected farmer's technician group and call `create_ai_call(union_code, society_code, farmer_code, user_id, species)`.
 11. On success, share the ticket number and the assigned A I technician's name (or phone). On failure, say the booking could not be completed right now.

--- a/tests/test_ai_call_union_ban_context.py
+++ b/tests/test_ai_call_union_ban_context.py
@@ -1,0 +1,459 @@
+"""Tests for the Kutch AI-call ban: cache skip, technician-summary copy,
+create_ai_call hard refuse, and prompt precedence over try-again-later.
+"""
+import os
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+import pytest
+
+from agents.models.farmer import FarmerDataEnvelope, FarmerRecord
+from agents.models.ai_call import AISpecies
+from agents.models.health_call import HealthCaseType
+from agents.services.farmer_cache import _has_failed_technician_lookup
+from agents.tools import ai_call as ai_mod
+from agents.tools import health_call as hc_mod
+from agents.tools.farmer_animal_backends import AITechnicianBySocietyRecord
+from app.models.union import UNION_BANNED_MESSAGE, UNION_BANNED_MESSAGES
+from app.services.voice import (
+    _build_ai_technician_summary,
+    _canned_union_ban_translation,
+    _prepare_voice_output,
+)
+import agents.services.farmer_cache as farmer_cache
+
+
+BANNED_UNION_ALIASES = ("sarhad", "kutch", "kachchh", "kutchh")
+
+
+def _tech():
+    return AITechnicianBySocietyRecord(
+        userId="ait-1",
+        fullName="Ramesh Patel",
+        mobileNumber="9999999999",
+    )
+
+
+def _fetch_cache(records, monkeypatch):
+    calls = []
+
+    async def fake_api(query, token):
+        calls.append((query.union_code, query.society_code))
+        return [_tech()]
+
+    monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
+    monkeypatch.setattr(farmer_cache, "get_ai_technicians_by_society_api", fake_api)
+    return asyncio.run(farmer_cache._fetch_ai_technicians(records)), calls
+
+
+@pytest.mark.parametrize("union_name", BANNED_UNION_ALIASES)
+def test_cache_skips_technician_fetch_for_banned_union(monkeypatch, union_name):
+    records = [FarmerRecord(
+        unionName=union_name, unionCode="12", societyCode="S1", farmerCode="F1",
+        farmerName="Kutch Farmer",
+    )]
+    groups, calls = _fetch_cache(records, monkeypatch)
+    assert groups == []
+    assert calls == []
+
+
+def test_cache_fetches_technicians_for_kaira(monkeypatch):
+    records = [FarmerRecord(
+        unionName="kaira", unionCode="1", societyCode="S-Kaira", farmerCode="F-K",
+        farmerName="Kaira Farmer",
+    )]
+    groups, calls = _fetch_cache(records, monkeypatch)
+    assert calls == [("1", "S-Kaira")]
+    assert len(groups) == 1
+    assert groups[0]["unionCode"] == "1"
+    assert groups[0]["technicians"][0]["userId"] == "ait-1"
+    assert groups[0]["lookupFailed"] is False
+
+
+def test_cache_fetches_technicians_for_kaira_and_skips_kutch(monkeypatch):
+    records = [
+        FarmerRecord(
+            unionName="kaira", unionCode="1", societyCode="S-Kaira", farmerCode="F-K",
+            farmerName="Kaira Farmer",
+        ),
+        FarmerRecord(
+            unionName="kutch", unionCode="12", societyCode="S-Kutch", farmerCode="F-C",
+            farmerName="Kutch Farmer",
+        ),
+    ]
+    groups, calls = _fetch_cache(records, monkeypatch)
+    assert calls == [("1", "S-Kaira")]
+    assert len(groups) == 1
+    assert groups[0]["unionCode"] == "1"
+    assert groups[0]["technicians"][0]["userId"] == "ait-1"
+
+
+def test_cache_skips_when_union_name_is_snake_case(monkeypatch):
+    records = [FarmerRecord(
+        union_name="sarhad", unionCode="12", societyCode="S1", farmerCode="F1",
+        farmerName="Kutch Farmer",
+    )]
+    groups, calls = _fetch_cache(records, monkeypatch)
+    assert groups == []
+    assert calls == []
+
+
+def test_cache_still_fetches_when_union_name_is_missing(monkeypatch):
+    """Unsigned-in / incomplete records are not banned; existing fetch tests
+    construct FarmerRecord with codes only."""
+    records = [FarmerRecord(unionCode="BANAS", societyCode="SC001")]
+    groups, calls = _fetch_cache(records, monkeypatch)
+    assert calls == [("BANAS", "SC001")]
+    assert len(groups) == 1
+
+
+def test_skipped_banned_union_is_not_a_failed_lookup():
+    envelope = FarmerDataEnvelope(farmers=[FarmerRecord(unionName="sarhad")], aiTechnicians=[])
+    assert _has_failed_technician_lookup(envelope) is False
+
+
+# ── technician summary ────────────────────────────────────────────────────────
+
+def _kaira_group():
+    return {
+        "farmerName": "Kaira Farmer",
+        "farmerCode": "F-K",
+        "societyName": "Kaira Society",
+        "societyCode": "S-Kaira",
+        "unionCode": "1",
+        "technicians": [{
+            "fullName": "Ramesh Patel",
+            "mobileNumber": "9999999999",
+            "userId": "ait-1",
+        }],
+    }
+
+
+def _kutch_group():
+    return {
+        "farmerName": "Kutch Farmer",
+        "farmerCode": "F1",
+        "societyName": "Sarhad Society",
+        "societyCode": "S1",
+        "unionCode": "12",
+        "technicians": [{
+            "fullName": "Kutch Tech",
+            "mobileNumber": "8888888888",
+            "userId": "ait-kutch",
+        }],
+    }
+
+
+def _assert_ban_copy(text: str) -> None:
+    assert UNION_BANNED_MESSAGE in text
+    assert "AI call booking is not allowed for this union." in text
+    assert "Do not ask which technician" in text
+    assert "Do not call `create_ai_call`" in text
+    assert "not available in the current signed-in context" not in text
+
+
+@pytest.mark.parametrize("union_name", BANNED_UNION_ALIASES)
+def test_technician_summary_instructs_ban_when_lookup_was_skipped(union_name):
+    envelope = FarmerDataEnvelope(
+        farmers=[FarmerRecord(
+            unionName=union_name, unionCode="12", societyCode="S1", farmerCode="F1",
+            farmerName="Kutch Farmer", societyName="Sarhad Society",
+        )],
+        aiTechnicians=[],
+    )
+    text = _build_ai_technician_summary(envelope)
+    _assert_ban_copy(text)
+    assert "Ramesh Patel" not in text
+    assert "ait-1" not in text
+    assert "AI technician option:" not in text
+
+
+@pytest.mark.parametrize("union_name", BANNED_UNION_ALIASES)
+def test_technician_summary_hides_cached_technicians_for_banned_union(union_name):
+    envelope = FarmerDataEnvelope(
+        farmers=[FarmerRecord(
+            unionName=union_name, unionCode="12", societyCode="S1", farmerCode="F1",
+            farmerName="Kutch Farmer", societyName="Sarhad Society",
+        )],
+        aiTechnicians=[_kutch_group()],
+    )
+    text = _build_ai_technician_summary(envelope)
+    _assert_ban_copy(text)
+    assert "Kutch Tech" not in text
+    assert "ait-kutch" not in text
+    assert "8888888888" not in text
+    assert "AI technician option:" not in text
+
+
+def test_technician_summary_still_lists_kaira_technicians():
+    envelope = FarmerDataEnvelope(
+        farmers=[FarmerRecord(
+            unionName="kaira", unionCode="1", societyCode="S-Kaira", farmerCode="F-K",
+            farmerName="Kaira Farmer",
+        )],
+        aiTechnicians=[_kaira_group()],
+    )
+    text = _build_ai_technician_summary(envelope)
+    assert "Ramesh Patel" in text
+    assert "ait-1" in text
+    assert UNION_BANNED_MESSAGE not in text
+    assert "Do not call `create_ai_call`" not in text
+
+
+def test_technician_summary_mixed_unions_hides_kutch_keeps_kaira():
+    envelope = FarmerDataEnvelope(
+        farmers=[
+            FarmerRecord(
+                unionName="kaira", unionCode="1", societyCode="S-Kaira", farmerCode="F-K",
+                farmerName="Kaira Farmer",
+            ),
+            FarmerRecord(
+                unionName="kutch", unionCode="12", societyCode="S1", farmerCode="F1",
+                farmerName="Kutch Farmer",
+            ),
+        ],
+        aiTechnicians=[_kaira_group(), _kutch_group()],
+    )
+    text = _build_ai_technician_summary(envelope)
+    _assert_ban_copy(text)
+    assert "Ramesh Patel" in text
+    assert "ait-1" in text
+    assert "Kutch Tech" not in text
+    assert "ait-kutch" not in text
+
+
+def test_technician_summary_snake_case_union_name_is_banned():
+    envelope = FarmerDataEnvelope(
+        farmers=[FarmerRecord(
+            union_name="sarhad", unionCode="12", societyCode="S1", farmerCode="F1",
+            farmerName="Kutch Farmer",
+        )],
+        aiTechnicians=[_kutch_group()],
+    )
+    text = _build_ai_technician_summary(envelope)
+    _assert_ban_copy(text)
+    assert "Kutch Tech" not in text
+
+
+def test_technician_summary_without_farmers_keeps_cached_groups():
+    """Existing unit tests build envelopes with technician groups and no farmers."""
+    envelope = FarmerDataEnvelope(farmers=[], aiTechnicians=[_kaira_group()])
+    text = _build_ai_technician_summary(envelope)
+    assert "Ramesh Patel" in text
+    assert UNION_BANNED_MESSAGE not in text
+
+
+def test_technician_summary_all_banned_farmers_drop_every_cached_group():
+    """When every signed-in farmer is banned, leftover cache rows must not leak."""
+    envelope = FarmerDataEnvelope(
+        farmers=[FarmerRecord(unionName="sarhad", farmerName="Kutch Farmer")],
+        aiTechnicians=[_kutch_group()],
+    )
+    text = _build_ai_technician_summary(envelope)
+    _assert_ban_copy(text)
+    assert "Kutch Tech" not in text
+    assert "ait-kutch" not in text
+
+
+# ── prompts ───────────────────────────────────────────────────────────────────
+
+PROMPTS = (
+    "voice_system_translation_pipeline_en.md",
+    "voice_system_translation_pipeline_gpt5_1_en.md",
+    "voice_system_translation_pipeline_gemma4_en.md",
+)
+PROMPTS_DIR = Path(__file__).resolve().parents[1] / "assets" / "prompts"
+UNQUALIFIED_TRY_AGAIN = (
+    "If no technician options are available for the selected farmer, say technician details are not available right now and ask them to try again later.",
+    "If no technician options exist for the chosen farmer, say technician details are not available right now and ask them to try again later.",
+    "Zero technicians → say technician details are not available right now and ask them to try again later.",
+)
+
+
+@pytest.mark.parametrize("name", PROMPTS)
+def test_prompts_put_union_ban_ahead_of_technician_selection(name):
+    rendered = (PROMPTS_DIR / name).read_text(encoding="utf-8")
+    assert UNION_BANNED_MESSAGE in rendered
+    ban_at = rendered.find("Union ban (takes precedence)")
+    ask_at = rendered.find("If more than one technician option is available")
+    if ask_at < 0:
+        ask_at = rendered.find("Multiple → ask the caller")
+    assert 0 <= ban_at < ask_at
+    assert "do **not** ask which technician" in rendered.lower()
+    assert "does not say AI calls are banned for this union" in rendered
+    for leftover in UNQUALIFIED_TRY_AGAIN:
+        assert leftover not in rendered
+
+
+@pytest.mark.parametrize("name", PROMPTS)
+def test_prompts_keep_technician_selection_for_allowed_unions(name):
+    rendered = (PROMPTS_DIR / name).read_text(encoding="utf-8")
+    assert (
+        "If more than one technician option is available" in rendered
+        or "Multiple → ask the caller" in rendered
+    )
+
+
+# ── create_ai_call hard block ─────────────────────────────────────────────────
+
+SPECIES = next(iter(AISpecies))
+
+
+async def _in_scope():
+    return True
+
+
+def _booking_ctx(session_id="s-ban", unions=None, include_unions=True):
+    deps = SimpleNamespace(session_id=session_id, ensure_in_scope=_in_scope)
+    if include_unions:
+        deps.farmer_unions = unions
+    return SimpleNamespace(deps=deps)
+
+
+def test_create_ai_call_refuses_sarhad_without_writing(monkeypatch):
+    calls = {"api": 0, "reserve": 0}
+
+    async def fake_api(*args, **kwargs):
+        calls["api"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {})
+
+    async def fake_reserve(*args, **kwargs):
+        calls["reserve"] += 1
+        return True
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    monkeypatch.setattr(ai_mod, "try_reserve", fake_reserve)
+
+    out = asyncio.run(
+        ai_mod.create_ai_call(_booking_ctx(unions=["sarhad"]), "U", "S", "F", "tech1", SPECIES)
+    )
+    assert out == UNION_BANNED_MESSAGE
+    assert calls == {"api": 0, "reserve": 0}
+
+
+@pytest.mark.parametrize("unions", [["kutch"], ["KACHCHH"], ["kutchh"], ["kaira", "sarhad"]])
+def test_create_ai_call_refuses_canonical_and_mixed_banned_unions(monkeypatch, unions):
+    calls = {"n": 0, "reserve": 0}
+
+    async def fake_api(*args, **kwargs):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {})
+
+    async def fake_reserve(*args, **kwargs):
+        calls["reserve"] += 1
+        return True
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    monkeypatch.setattr(ai_mod, "try_reserve", fake_reserve)
+
+    out = asyncio.run(
+        ai_mod.create_ai_call(_booking_ctx(unions=unions), "U", "S", "F", "tech1", SPECIES)
+    )
+    assert out == UNION_BANNED_MESSAGE
+    assert calls == {"n": 0, "reserve": 0}
+
+
+def test_create_ai_call_still_books_for_kaira(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {"ticket_number": "T1"})
+
+    monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+
+    out = asyncio.run(
+        ai_mod.create_ai_call(_booking_ctx(session_id=None, unions=["kaira"]), "U", "S", "F", "tech1", SPECIES)
+    )
+    assert calls["n"] == 1
+    assert "booked successfully" in out
+    assert out != UNION_BANNED_MESSAGE
+
+
+@pytest.mark.parametrize("unions,include_unions", [([], True), (None, False)])
+def test_create_ai_call_empty_or_missing_unions_is_not_banned(monkeypatch, unions, include_unions):
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {"ticket_number": "T1"})
+
+    monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+
+    out = asyncio.run(
+        ai_mod.create_ai_call(
+            _booking_ctx(session_id=None, unions=unions, include_unions=include_unions),
+            "U", "S", "F", "tech1", SPECIES,
+        )
+    )
+    assert calls["n"] == 1
+    assert "booked successfully" in out
+
+
+def test_moderation_block_runs_before_union_ban(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_api(*args, **kwargs):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="T1", ait_name="AIT", model_dump=lambda: {})
+
+    async def _out_of_scope():
+        return False
+
+    monkeypatch.setattr(ai_mod, "create_ai_call_api", fake_api)
+    ctx = SimpleNamespace(deps=SimpleNamespace(
+        session_id="s-mod",
+        ensure_in_scope=_out_of_scope,
+        farmer_unions=["kutch"],
+    ))
+    out = asyncio.run(ai_mod.create_ai_call(ctx, "U", "S", "F", "tech1", SPECIES))
+    assert out == "This helpline only handles dairy farming and animal husbandry questions."
+    assert calls["n"] == 0
+
+
+def test_health_call_still_books_for_kutch_union(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_api(request, token):
+        calls["n"] += 1
+        return SimpleNamespace(ticket_number="H1")
+
+    monkeypatch.setenv("PASHUGPT_TOKEN", "tok")
+    monkeypatch.setattr(hc_mod, "create_health_call_api", fake_api)
+    out = asyncio.run(
+        hc_mod.create_health_call(
+            _booking_ctx(session_id=None, unions=["kutch"]),
+            "U", "S", "F", SPECIES, next(iter(HealthCaseType)), "fever",
+        )
+    )
+    assert calls["n"] == 1
+    assert "booked successfully" in out
+    assert UNION_BANNED_MESSAGE not in out
+
+
+# ── canned caller copy ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("lang,expected", [
+    ("gu", UNION_BANNED_MESSAGES["gu"]),
+    ("gujarati", UNION_BANNED_MESSAGES["gu"]),
+    ("hi", UNION_BANNED_MESSAGES["hi"]),
+    ("hindi", UNION_BANNED_MESSAGES["hi"]),
+    ("en", UNION_BANNED_MESSAGES["en"]),
+])
+def test_canned_union_ban_translation_pins_agreed_copy(lang, expected):
+    assert _canned_union_ban_translation(UNION_BANNED_MESSAGE, lang) == expected
+    assert _canned_union_ban_translation(f"  {UNION_BANNED_MESSAGE}  ", lang) == expected
+    assert _canned_union_ban_translation("Please try again later.", lang) is None
+
+
+def test_canned_union_ban_gujarati_survives_voice_cleanup():
+    spoken = _prepare_voice_output(UNION_BANNED_MESSAGES["gu"], "gu")
+    assert "દૂધ મંડળી" in spoken
+    assert spoken.strip() == UNION_BANNED_MESSAGES["gu"].strip()
+

--- a/tests/test_union_aliases.py
+++ b/tests/test_union_aliases.py
@@ -2,7 +2,8 @@
 
 A farmer-source API returns a union by its dairy brand or a spelling variant
 (e.g. "sarhad" for Kutch's Sarhad Dairy). The scheme tool must resolve those to
-the canonical union so scheme lookup works.
+the canonical union so scheme lookup works. The AI-call ban list is keyed on
+those same canonical names.
 """
 
 import os
@@ -15,7 +16,18 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.models.union import UnionName, canonical_union_name, resolve_supported_unions, UNION_NAME_ALIASES
+from app.models.union import (
+    AI_CALL_BANNED_UNIONS,
+    UNION_BANNED_MESSAGE,
+    UNION_BANNED_MESSAGES,
+    UNION_NAME_ALIASES,
+    UnionName,
+    any_union_banned_from_ai_calls,
+    canonical_union_name,
+    is_ai_call_banned_union,
+    resolve_supported_unions,
+    union_banned_message_for_lang,
+)
 import agents.tools.union_schemes as us
 
 
@@ -49,6 +61,71 @@ def test_resolve_supported_unions_canonicalizes_and_deduplicates():
         supported,
     )
     assert resolved == [UnionName.BANAS.value, UnionName.KUTCH.value]
+
+
+# ── AI-call union ban list ────────────────────────────────────────────────────
+
+def test_ai_call_banned_unions_contains_only_kutch():
+    assert AI_CALL_BANNED_UNIONS == frozenset({UnionName.KUTCH.value})
+
+
+@pytest.mark.parametrize("raw", [
+    "kutch",
+    "Kutch",
+    "sarhad",
+    "Sarhad",
+    "  KACHCHH  ",
+    "kutchh",
+])
+def test_kutch_aliases_are_banned_from_ai_calls(raw):
+    assert is_ai_call_banned_union(raw) is True
+
+
+@pytest.mark.parametrize("raw", [
+    "banas",
+    "banaskantha",
+    "kaira",
+    "mehsana",
+    "dudhsagar",
+    "",
+    None,
+])
+def test_non_kutch_unions_are_not_banned_from_ai_calls(raw):
+    assert is_ai_call_banned_union(raw) is False
+
+
+@pytest.mark.parametrize("names,expected", [
+    (["sarhad"], True),
+    (["kutch"], True),
+    (["kaira", "sarhad"], True),
+    (["banas", "kaira"], False),
+    ([], False),
+    (None, False),
+])
+def test_any_union_banned_from_ai_calls(names, expected):
+    assert any_union_banned_from_ai_calls(names) is expected
+
+
+def test_union_banned_message_is_the_agreed_farmer_facing_string():
+    assert UNION_BANNED_MESSAGE == "Kindly contact your Milk Society to book the service."
+    assert UNION_BANNED_MESSAGES["en"] == UNION_BANNED_MESSAGE
+    assert UNION_BANNED_MESSAGES["gu"] == "કૃપા કરીને આપની દૂધ મંડળીનો સંપર્ક કરશો."
+    assert UNION_BANNED_MESSAGES["hi"] == "कृपया सेवा बुक करने के लिए अपनी दूध मंडली से संपर्क करें।"
+
+
+@pytest.mark.parametrize("lang,expected_key", [
+    ("en", "en"),
+    ("english", "en"),
+    ("gu", "gu"),
+    ("gujarati", "gu"),
+    ("hi", "hi"),
+    ("hindi", "hi"),
+    ("mr", "en"),
+    (None, "en"),
+    ("", "en"),
+])
+def test_union_banned_message_for_lang(lang, expected_key):
+    assert union_banned_message_for_lang(lang) == UNION_BANNED_MESSAGES[expected_key]
 
 
 def _ctx(unions):


### PR DESCRIPTION
Promotion of #250 (merged to `amul-dev` as `bfad5fa49f9369f83fdeebf821ef0b76e1f77887`) to `amul-prod`. Also references OpenAgriNet/amul-oan-api#230.

Clean cherry-pick of `bfad5fa4`, no conflicts, no prod-only adjustments — diff against the source commit is byte-identical.

Refuses `create_ai_call` when the farmer's canonical union is Kutch (including Sarhad/Kachchh aliases), skips technician selection, and tells the farmer AI calls aren't allowed for their union — pointing them to their milk society instead, with pinned English/Gujarati/Hindi refusal copy so callers hear the agreed contact-your-society lines rather than a live translation.

## Tests

Ran in a fresh venv built from `requirements.txt` (global interpreter had a mismatched `pydantic-ai`):
- `tests/test_ai_call_union_ban_context.py`
- `tests/test_union_aliases.py`
- `tests/test_ai_technician_summary_no_truncation.py`
- `tests/test_technician_lookup_failure_not_cached.py`
- `tests/test_booking_idempotency.py`

**116 passed**, 0 failed. Import/compile smoke check on all changed modules also clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)