### PR TITLE
feat(voice): enable Sumul and Sursagar union scheme reads

### DIFF
--- a/agents/tools/union_schemes.py
+++ b/agents/tools/union_schemes.py
@@ -9,16 +9,12 @@ from pydantic_ai.tools import ToolDefinition
 from agents.deps import FarmerContext
 from app.models.union import UnionName, resolve_supported_unions
 from app.services.scheme_ingestion import (
+    SUPPORTED_SCHEME_UNIONS,
     SchemeCacheError,
     SchemeDependencyError,
     get_cached_scheme_records_for_union,
 )
 from helpers.utils import get_logger
-
-SUPPORTED_SCHEME_UNIONS = {
-    UnionName.BANAS.value,
-    UnionName.KUTCH.value,
-}
 
 logger = get_logger(__name__)
 

--- a/app/models/union.py
+++ b/app/models/union.py
@@ -27,16 +27,18 @@ class UnionName(str, Enum):
 
 # Brand / spelling variants that farmer-source APIs return for a union, mapped to
 # the canonical UnionName value. A union is often returned by its dairy brand
-# (Kutch -> "Sarhad", Mehsana -> "Dudhsagar") or an alternate spelling
-# ("Kachchh", "Banaskantha"). Normalizing through this map lets union-scoped
-# features (e.g. scheme lookup) resolve a farmer's union regardless of which
-# name the source returns. Keys are lowercase; values equal a UnionName value.
+# (Kutch -> "Sarhad", Mehsana -> "Dudhsagar", Surendranagar -> "Sursagar") or an
+# alternate spelling ("Kachchh", "Banaskantha"). Normalizing through this map
+# lets union-scoped features (e.g. scheme lookup) resolve a farmer's union
+# regardless of which name the source returns. Keys are lowercase; values equal
+# a UnionName value.
 UNION_NAME_ALIASES: dict[str, str] = {
     "sarhad": UnionName.KUTCH.value,
     "kachchh": UnionName.KUTCH.value,
     "kutchh": UnionName.KUTCH.value,
     "banaskantha": UnionName.BANAS.value,
     "dudhsagar": UnionName.MEHSANA.value,
+    "sursagar": UnionName.SURENDRANAGAR.value,
 }
 
 

--- a/app/services/scheme_ingestion.py
+++ b/app/services/scheme_ingestion.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 from app.config import settings
-from app.models.union import UnionName
+from app.models.union import UnionName, canonical_union_name
 from helpers.utils import get_logger
 
 logger = get_logger(__name__)
@@ -25,10 +25,16 @@ class SchemeCacheError(SchemeIngestionError):
     """Raised when Redis cache access fails."""
 
 
+# Cache keys must match amul-oan-api scheme ingestion (chat writes, voice reads).
+# Tool + farmer-context gating derive from this map so a union cannot be
+# exposed without a readable cache source, or vice versa.
 SUPPORTED_UNION_SOURCE_KEYS = {
     UnionName.BANAS.value: ("banasdairy.coop/home/inputactivities#milkproducers",),
     UnionName.KUTCH.value: ("sarhaddairy.coop/for-our-milk-producers",),
+    UnionName.SUMUL.value: ("sumul.com/farmer-section",),
+    UnionName.SURENDRANAGAR.value: ("sursagardairy.com/farmer/milkproducers",),
 }
+SUPPORTED_SCHEME_UNIONS = frozenset(SUPPORTED_UNION_SOURCE_KEYS)
 
 
 def _build_prefixed_key(namespace: str, key: str) -> str:
@@ -43,7 +49,7 @@ def build_scheme_cache_key(source_key: str) -> str:
 
 
 def get_source_keys_for_union(union_name: str) -> tuple[str, ...]:
-    return SUPPORTED_UNION_SOURCE_KEYS.get(union_name, ())
+    return SUPPORTED_UNION_SOURCE_KEYS.get(canonical_union_name(union_name), ())
 
 
 async def get_redis_client():
@@ -94,7 +100,7 @@ async def get_cached_source_records(source_key: str, redis_client=None) -> list[
 
 
 async def get_cached_scheme_records_for_union(union_name: str, redis_client=None) -> list[dict[str, Any]]:
-    normalized_union_name = (union_name or "").strip().lower()
+    normalized_union_name = canonical_union_name(union_name)
     source_keys = get_source_keys_for_union(normalized_union_name)
     if not source_keys:
         return []

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -22,8 +22,9 @@ from agents.services.farmer_cache import (
     should_refresh_farmer_data,
     exceeds_max_serve_stale,
 )
-from app.models.union import UnionName, resolve_supported_unions
+from app.models.union import resolve_supported_unions
 from app.services.scheme_ingestion import (
+    SUPPORTED_SCHEME_UNIONS,
     SchemeCacheError,
     SchemeDependencyError,
     get_cached_scheme_records_for_union,
@@ -792,10 +793,7 @@ def _build_compact_farmer_summary(envelope: Optional[FarmerDataEnvelope]) -> str
     return "\n".join(lines)
 
 
-SUPPORTED_SCHEME_CONTEXT_UNIONS = {
-    UnionName.BANAS.value,
-    UnionName.KUTCH.value,
-}
+SUPPORTED_SCHEME_CONTEXT_UNIONS = SUPPORTED_SCHEME_UNIONS
 
 
 def _collect_farmer_unions(envelope: Optional[FarmerDataEnvelope]) -> list[str]:

--- a/assets/prompts/voice_system_translation_pipeline_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_en.md
@@ -332,7 +332,7 @@ Keep final output English only.
 - Use `get_union_scheme_data` only when a signed-in farmer's union can be inferred from runtime context.
 - Treat union scheme titles listed in Farmer Context as the highest-priority source for available schemes.
 - When the user asks about one specific scheme or benefit, call `get_union_scheme_data` with the shortest matching scheme title or benefit name.
-- Prefer `get_union_scheme_data` over `search_documents` for Banas or Kutch union milk producer scheme questions.
+- Prefer `get_union_scheme_data` over `search_documents` for the signed-in farmer's union milk producer scheme questions.
 - When the union is known from Farmer Context, name it in the answer ("Banas union covers…") instead of saying "your union".
 - If scheme cache data is genuinely unavailable, say exact scheme data is not available right now and ask the farmer to contact their dairy society or union office. (This is the legitimate missing-data deflection allowed by the No Reflex Deflection rule.)
 - If you list multiple available schemes, end with this exact question: "Would you like details about how to apply for any specific scheme?"

--- a/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
+++ b/assets/prompts/voice_system_translation_pipeline_gpt5_1_en.md
@@ -111,7 +111,7 @@ Use this exact response:
 Classify every turn into one of: `clinical`, `nutrition`, `breeding`, `crop`, `scheme`, `market`, `weather`, `services`, `profile`, `language_switch`, `out_of_scope`.
 
 - `clinical`, `nutrition`, `breeding`, `crop`, `market`, `weather` → call `search_documents` with concise English keywords (two to eight words, twelve max). When in doubt, retrieve.
-- `scheme` → if runtime Farmer Context shows the signed-in farmer's union, prefer `get_union_scheme_data(scheme_name=...)` for that union (especially Banas or Kutch). Use `search_documents` only when union cache is unavailable or the question is not about the signed-in farmer's union schemes.
+- `scheme` → if runtime Farmer Context shows the signed-in farmer's union, prefer `get_union_scheme_data(scheme_name=...)` for that union. Use `search_documents` only when union cache is unavailable or the question is not about the signed-in farmer's union schemes.
 - For milk collection, fat, S N F, milk payment, deduction, milk account, or collection history: call `get_farmer_milk_collection_details`. Never use `search_documents` for these account lookups.
 - `services` involving artificial insemination booking ("beech daan", "beej daan", "A I booking") → run the AI booking flow below; eventually call `create_ai_call`.
 - `services` involving veterinary visit or emergency health booking → run the health-call flow below; eventually call `create_health_call`.

--- a/tests/test_union_aliases.py
+++ b/tests/test_union_aliases.py
@@ -28,6 +28,10 @@ import agents.tools.union_schemes as us
     ("banaskantha", "banas"),
     ("banas", "banas"),
     ("dudhsagar", "mehsana"),
+    ("mehsana", "mehsana"),
+    ("sursagar", "surendranagar"),
+    ("Sursagar", "surendranagar"),
+    ("sumul", "sumul"),
     ("kaira", "kaira"),
     ("", ""),
     (None, ""),
@@ -86,3 +90,65 @@ def test_prepare_and_runtime_agree_for_banaskantha(monkeypatch):
 
     out = asyncio.run(us.get_union_scheme_data(_ctx(["banaskantha"]), None))
     assert "Banas Test Scheme" in out
+
+
+def test_prepare_and_runtime_agree_for_sursagar(monkeypatch):
+    sentinel = object()
+
+    async def fake_records(union_name):
+        assert union_name == UnionName.SURENDRANAGAR.value
+        return [{"scheme_title": "Sursagar Test Scheme"}]
+
+    monkeypatch.setattr(us, "get_cached_scheme_records_for_union", fake_records)
+
+    prepared = asyncio.run(us.prepare_get_union_scheme_data(_ctx(["sursagar"]), sentinel))
+    assert prepared is sentinel
+
+    out = asyncio.run(us.get_union_scheme_data(_ctx(["sursagar"]), None))
+    assert "Sursagar Test Scheme" in out
+
+
+def test_prepare_and_runtime_agree_for_sumul(monkeypatch):
+    sentinel = object()
+
+    async def fake_records(union_name):
+        assert union_name == UnionName.SUMUL.value
+        return [{"scheme_title": "Sumul Test Scheme"}]
+
+    monkeypatch.setattr(us, "get_cached_scheme_records_for_union", fake_records)
+
+    prepared = asyncio.run(us.prepare_get_union_scheme_data(_ctx(["sumul"]), sentinel))
+    assert prepared is sentinel
+
+    out = asyncio.run(us.get_union_scheme_data(_ctx(["sumul"]), None))
+    assert "Sumul Test Scheme" in out
+
+
+def test_scheme_cache_keys_match_chat_ingestion_sources():
+    """Voice reads the same Redis keys that amul-oan-api scheme ingestion writes."""
+    from app.services.scheme_ingestion import (
+        SUPPORTED_SCHEME_UNIONS,
+        SUPPORTED_UNION_SOURCE_KEYS,
+        get_source_keys_for_union,
+    )
+
+    assert get_source_keys_for_union(UnionName.BANAS.value) == (
+        "banasdairy.coop/home/inputactivities#milkproducers",
+    )
+    assert get_source_keys_for_union(UnionName.KUTCH.value) == (
+        "sarhaddairy.coop/for-our-milk-producers",
+    )
+    assert get_source_keys_for_union(UnionName.SUMUL.value) == ("sumul.com/farmer-section",)
+    assert get_source_keys_for_union("sursagar") == ("sursagardairy.com/farmer/milkproducers",)
+    assert get_source_keys_for_union(UnionName.SURENDRANAGAR.value) == (
+        "sursagardairy.com/farmer/milkproducers",
+    )
+    assert us.SUPPORTED_SCHEME_UNIONS == frozenset(SUPPORTED_UNION_SOURCE_KEYS)
+    assert SUPPORTED_SCHEME_UNIONS == frozenset(
+        {
+            UnionName.BANAS.value,
+            UnionName.KUTCH.value,
+            UnionName.SUMUL.value,
+            UnionName.SURENDRANAGAR.value,
+        }
+    )

--- a/tests/test_voice_farmer_context.py
+++ b/tests/test_voice_farmer_context.py
@@ -7,9 +7,12 @@ get_farmer_profile tools.
 """
 # Import the app entry first so the pre-existing tools<->farmer_cache cycle
 # resolves in the same order the running app establishes it.
+import asyncio
+
 import app.services.voice as voice
 
 from agents.models.farmer import FarmerDataEnvelope
+from app.models.union import UnionName
 from helpers.gujarati_numbers import mask_tag_identifier
 
 
@@ -71,3 +74,28 @@ def test_signed_in_farmer_tools_drops_brittle_three():
     assert len(SIGNED_IN_FARMER_TOOLS) == 1, (
         f"expected only get_union_scheme_data; got {len(SIGNED_IN_FARMER_TOOLS)} tools"
     )
+
+
+def test_scheme_summary_includes_sumul_and_sursagar(monkeypatch):
+    async def fake_records(union_name):
+        if union_name == UnionName.SUMUL.value:
+            return [{"scheme_title": "Sumul Shed Subsidy", "scheme_url": "https://sumul.example/a.pdf"}]
+        if union_name == UnionName.SURENDRANAGAR.value:
+            return [{"scheme_title": "Sursagar Insurance", "scheme_url": "https://sursagar.example/b.pdf"}]
+        return []
+
+    monkeypatch.setattr(voice, "get_cached_scheme_records_for_union", fake_records)
+
+    sumul_out = asyncio.run(voice._build_union_scheme_summary(["sumul"]))
+    assert "Sumul Shed Subsidy" in sumul_out
+
+    sursagar_out = asyncio.run(voice._build_union_scheme_summary(["sursagar"]))
+    assert "Sursagar Insurance" in sursagar_out
+
+    assert asyncio.run(voice._build_union_scheme_summary(["dudhsagar"])) == ""
+
+
+def test_scheme_context_unions_follow_cache_sources():
+    from app.services.scheme_ingestion import SUPPORTED_SCHEME_UNIONS
+
+    assert voice.SUPPORTED_SCHEME_CONTEXT_UNIONS == SUPPORTED_SCHEME_UNIONS


### PR DESCRIPTION
## Summary
- Enable voice to read Sumul and Sursagar (Surendranagar) union schemes from the same Redis cache keys chat ingestion writes (`sumul.com/farmer-section`, `sursagardairy.com/farmer/milkproducers`).
- Resolve the `sursagar` alias to Surendranagar, and derive tool + farmer-context gating from the cache-key map so a union cannot be exposed without a readable source.
- Ingestion stays on chat only; voice remains a cache reader. Prompts now prefer `get_union_scheme_data` for the signed-in farmer's union instead of a hardcoded Banas/Kutch list.

## Test plan
- [x] `tests/test_union_aliases.py` and `tests/test_voice_farmer_context.py` pass (alias resolution, tool prepare/runtime for Sumul/Sursagar, cache keys, Mehsana still excluded)
- [x] `tests/test_voice_prompt_version.py` passes after prompt wording change
- [ ] Signed-in Sumul farmer: scheme questions use `get_union_scheme_data` and Farmer Context lists scheme titles
- [ ] Signed-in Sursagar/Surendranagar farmer: same as above (`sursagar` alias resolves)
- [ ] Banas/Kutch scheme path unchanged; Dudhsagar/Mehsana still does not see the scheme tool