### PR TITLE
feat(voice): add callback-aware Beckn transactions

### DIFF
--- a/agents/deps.py
+++ b/agents/deps.py
@@ -41,10 +41,16 @@ class FarmerContext(BaseModel):
     farmer_unions: list[str] = Field(default_factory=list, description="Normalized union names derived from the farmer context.")
     ai_technician_info: str = Field(default="", description="Pre-built internal AI technician context string.")
     signed_in: bool = Field(default=False, description="Whether the session is signed in/authenticated for farmer-specific tools.")
+    identity_verified: bool = Field(default=False, description="Whether mobile/subject were derived from verified JWT claims.")
+    subject_id: Optional[str] = Field(default=None, description="Hashed authenticated subject used for operation ownership.")
     mobile: Optional[str] = Field(default=None, description="Normalized mobile number when available.")
     farmer_accounts: list[FarmerAccount] = Field(
         default_factory=list,
         description="All (union, society, farmer) accounts on the caller's mobile, for multi-account fan-out.",
+    )
+    ai_technician_ids: list[str] = Field(
+        default_factory=list,
+        description="Technician IDs present in the authenticated farmer context.",
     )
 
     # Handle to the per-turn content-moderation task, which now runs concurrently

--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -43,6 +43,14 @@ BASE_TOOLS = [
         takes_ctx=True,
     ),
     Tool(
+        signal_conversation_state,
+        takes_ctx=True,
+        docstring_format='auto',
+    ),
+]
+
+SIGNED_IN_FARMER_TOOLS = [
+    Tool(
         _with_nudge_signal(create_ai_call),
         takes_ctx=True,
         docstring_format='auto',
@@ -61,19 +69,11 @@ BASE_TOOLS = [
         require_parameter_descriptions=True,
     ),
     Tool(
-        signal_conversation_state,
-        takes_ctx=True,
-        docstring_format='auto',
-    ),
-    Tool(
         _with_nudge_signal(check_loan_eligibility),
         takes_ctx=True,
         docstring_format='auto',
-        prepare=prepare_check_loan_eligibility,  # hidden unless feature on + caller phone resolved
+        prepare=prepare_check_loan_eligibility,
     ),
-]
-
-SIGNED_IN_FARMER_TOOLS = [
     # # Get Farmer Profile (disabled — redundant with _build_compact_farmer_summary
     # # context; the brittle farmers[0]-only read returned "not available" when
     # # the cached record was missing fields, while context already had them).

--- a/agents/tools/access.py
+++ b/agents/tools/access.py
@@ -1,0 +1,67 @@
+"""Server-side ownership gates for private and mutating farmer tools."""
+
+from __future__ import annotations
+
+import hmac
+
+from agents.deps import FarmerAccount, FarmerContext
+
+
+class FarmerAccessDenied(ValueError):
+    pass
+
+
+def require_authenticated_farmer(deps: FarmerContext) -> None:
+    if not (
+        deps
+        and getattr(deps, "signed_in", False)
+        and getattr(deps, "identity_verified", False)
+        and getattr(deps, "mobile", None)
+        and getattr(deps, "subject_id", None)
+    ):
+        raise FarmerAccessDenied(
+            "This information or service is available only to the authenticated farmer."
+        )
+
+
+def require_farmer_accounts(deps: FarmerContext) -> list[FarmerAccount]:
+    require_authenticated_farmer(deps)
+    accounts = list(getattr(deps, "farmer_accounts", None) or [])
+    if not accounts:
+        raise FarmerAccessDenied(
+            "No farmer account is available for the authenticated mobile number."
+        )
+    return accounts
+
+
+def resolve_owned_account(
+    deps: FarmerContext,
+    union_code: str,
+    society_code: str,
+    farmer_code: str,
+) -> FarmerAccount:
+    """Return the exact authenticated account; model arguments cannot override it."""
+    supplied = tuple(str(value or "").strip() for value in (union_code, society_code, farmer_code))
+    for account in require_farmer_accounts(deps):
+        candidate = tuple(
+            str(value or "").strip()
+            for value in (account.union_code, account.society_code, account.farmer_code)
+        )
+        if all(hmac.compare_digest(left, right) for left, right in zip(supplied, candidate)):
+            return account
+    raise FarmerAccessDenied(
+        "The selected farmer account does not belong to the authenticated caller."
+    )
+
+
+def require_owned_technician(deps: FarmerContext, technician_id: str) -> str:
+    require_authenticated_farmer(deps)
+    supplied = str(technician_id or "").strip()
+    if not supplied or not any(
+        hmac.compare_digest(supplied, str(allowed))
+        for allowed in (getattr(deps, "ai_technician_ids", None) or [])
+    ):
+        raise FarmerAccessDenied(
+            "The selected technician is not available in the authenticated farmer context."
+        )
+    return supplied

--- a/agents/tools/ai_call.py
+++ b/agents/tools/ai_call.py
@@ -9,7 +9,10 @@ from pydantic_ai import RunContext
 
 from agents.deps import FarmerContext
 from agents.models.ai_call import AICallRequestModel, AISpecies
+from agents.tools.access import FarmerAccessDenied, require_owned_technician, resolve_owned_account
+from agents.tools.beckn_voice import beckn_ai_booking, render_result
 from agents.tools.farmer_animal_backends import create_ai_call_api
+from app.config import settings
 from app.core.cache import cache, try_reserve, release_reservation
 from app.models.union import UNION_BANNED_MESSAGE, any_union_banned_from_ai_calls
 from helpers.utils import get_logger
@@ -54,8 +57,8 @@ async def create_ai_call(
     """
     session_id = ctx.deps.session_id
     logger.info(
-        "AI call tool invoked: session=%s union=%s society=%s farmer=%s user_id=%s species=%s",
-        session_id, union_code, society_code, farmer_code, user_id, species.value,
+        "AI call tool invoked: session=%s species=%s",
+        session_id, species.value,
     )
 
     # Moderation runs concurrently with the agent, so this booking write must
@@ -76,16 +79,27 @@ async def create_ai_call(
         )
         return UNION_BANNED_MESSAGE
 
+    try:
+        account = resolve_owned_account(ctx.deps, union_code, society_code, farmer_code)
+        technician_id = require_owned_technician(ctx.deps, user_id)
+    except FarmerAccessDenied as exc:
+        logger.warning("AI call ownership gate rejected session=%s", session_id)
+        return str(exc)
+
+    if settings.voice_beckn_enabled:
+        result = await beckn_ai_booking(ctx.deps, account, technician_id, species.value)
+        return render_result(result, "Artificial insemination call booking")
+
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
         return "Artificial insemination call booking failed. Service is not configured."
 
     request = AICallRequestModel(
-        unionCode=union_code,
-        societyCode=society_code,
-        farmerCode=farmer_code,
-        userId=user_id,
+        unionCode=account.union_code or "",
+        societyCode=account.society_code or "",
+        farmerCode=account.farmer_code or "",
+        userId=technician_id,
         species=species,
     )
 

--- a/agents/tools/beckn_voice.py
+++ b/agents/tools/beckn_voice.py
@@ -1,0 +1,206 @@
+"""Voice-tool mappings onto the shared Beckn transaction façade."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agents.deps import FarmerAccount, FarmerContext
+from app.services.beckn_transactions import BecknResult, OperationState, get_beckn_facade
+
+
+def _tag_group(code: str, values: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "descriptor": {"code": code},
+        "list": [
+            {"descriptor": {"code": key}, "value": str(value)}
+            for key, value in values.items()
+            if value is not None
+        ],
+    }
+
+
+def _private_customer(deps: FarmerContext) -> dict[str, Any]:
+    return {"person": {"id": deps.subject_id}}
+
+
+def render_result(result: BecknResult, capability: str) -> str:
+    """Stable agent-facing wording for completed, pending, and error states."""
+    if result.state == OperationState.SUCCEEDED:
+        message = (result.payload or {}).get("message") or {}
+        order = message.get("order") or {}
+        if order.get("id"):
+            return f"{capability} completed successfully. Provider reference: {order['id']}."
+        return f"{capability} completed successfully:\n{json.dumps(message, ensure_ascii=False)}"
+    if result.state in {
+        OperationState.CREATED,
+        OperationState.SENT,
+        OperationState.ACKED_WAITING_CALLBACK,
+        OperationState.TIMED_OUT_PENDING,
+        OperationState.UNKNOWN_REQUIRES_RECONCILIATION,
+    }:
+        return (
+            f"{capability} was accepted and is still pending provider confirmation. "
+            f"Reference: {result.transaction_id}. Do not submit it again; its status will be reconciled."
+        )
+    error = result.error or {}
+    detail = error.get("message") or error.get("code") or "The provider could not complete it."
+    return f"{capability} was not completed. {detail} Reference: {result.transaction_id}."
+
+
+async def beckn_document_search(deps: FarmerContext, query: str, top_k: int) -> BecknResult:
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "public",
+        tool_name="search_documents",
+        domain="advisory:amul-vet",
+        action="search",
+        message={"intent": {"item": {"descriptor": {"name": query}}, "tags": [_tag_group("search-options", {"top_k": top_k})]}},
+        business_key=f"{deps.session_id}:document-search:{query}:{top_k}",
+    )
+
+
+async def beckn_ai_booking(
+    deps: FarmerContext,
+    account: FarmerAccount,
+    technician_id: str,
+    species: str,
+) -> BecknResult:
+    message = {
+        "order": {
+            "provider": {"id": "amul-ai-service"},
+            "items": [{"id": f"ait:{technician_id}"}],
+            "fulfillments": [{
+                "id": "fulfillment-1",
+                "type": "TECHNICIAN_VISIT",
+                "customer": _private_customer(deps),
+                "stops": [{"location": {"descriptor": {"code": f"society:{account.society_code}"}}}],
+                "tags": [_tag_group("booking-details", {
+                    "union_code": account.union_code,
+                    "farmer_code": account.farmer_code,
+                    "species": species,
+                })],
+            }],
+        }
+    }
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "",
+        tool_name="create_ai_call",
+        domain="services:amul-vet-booking",
+        action="confirm",
+        message=message,
+        business_key=f"{deps.session_id}:ai-call",
+        side_effecting=True,
+    )
+
+
+async def beckn_health_booking(
+    deps: FarmerContext,
+    account: FarmerAccount,
+    species: str,
+    case_type: str,
+    remark: str | None,
+) -> BecknResult:
+    message = {
+        "order": {
+            "provider": {"id": "amul-animal-health-service"},
+            "items": [{"id": "health-call"}],
+            "fulfillments": [{
+                "id": "fulfillment-1",
+                "type": "VETERINARY_VISIT",
+                "customer": _private_customer(deps),
+                "tags": [_tag_group("health-call-details", {
+                    "union_code": account.union_code,
+                    "society_code": account.society_code,
+                    "farmer_code": account.farmer_code,
+                    "species": species,
+                    "case_type": case_type,
+                    "remark": remark,
+                })],
+            }],
+        }
+    }
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "",
+        tool_name="create_health_call",
+        domain="services:amul-vet-booking",
+        action="confirm",
+        message=message,
+        business_key=f"{deps.session_id}:health-call",
+        side_effecting=True,
+    )
+
+
+async def beckn_milk_statement(
+    deps: FarmerContext,
+    accounts: list[FarmerAccount],
+    fromdate: str,
+    todate: str,
+) -> BecknResult:
+    fulfillments = []
+    for index, account in enumerate(accounts, 1):
+        fulfillments.append({
+            "id": f"account-{index}",
+            "customer": _private_customer(deps),
+            "tags": [_tag_group("statement-request", {
+                "union_code": account.union_code,
+                "society_code": account.society_code,
+                "farmer_code": account.farmer_code,
+                "from_date": fromdate,
+                "to_date": todate,
+            })],
+        })
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "",
+        tool_name="get_farmer_milk_collection_details",
+        domain="services:amul-milk-collection",
+        action="init",
+        message={"order": {
+            "provider": {"id": "amul-milk-data-service"},
+            "items": [{"id": "milk-collection-statement"}],
+            "fulfillments": fulfillments,
+        }},
+        business_key=f"{deps.session_id}:milk:{fromdate}:{todate}",
+    )
+
+
+async def beckn_union_schemes(
+    deps: FarmerContext,
+    union_name: str,
+    scheme_name: str | None,
+) -> BecknResult:
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "",
+        tool_name="get_union_scheme_data",
+        domain="schemes:amul-union",
+        action="search",
+        message={"intent": {
+            "category": {"descriptor": {"code": "milk-producer-schemes"}},
+            "item": {"descriptor": {"name": scheme_name or ""}},
+            "provider": {"descriptor": {"code": union_name}},
+        }},
+        business_key=f"{deps.session_id}:union-schemes:{union_name}:{scheme_name or '*'}",
+    )
+
+
+async def beckn_loan(deps: FarmerContext, confirmed: bool) -> BecknResult:
+    action = "confirm" if confirmed else "init"
+    item_id = "microloan-issuance" if confirmed else "microloan-eligibility"
+    return await get_beckn_facade().execute(
+        session_id=deps.session_id or "no-session",
+        subject_id=deps.subject_id or "",
+        tool_name="check_loan_eligibility",
+        domain="finance:amul-microloan",
+        action=action,
+        message={"order": {
+            "provider": {"id": "amul-cooperative-loan-service"},
+            "items": [{"id": item_id}],
+            "fulfillments": [{"customer": _private_customer(deps)}],
+        }},
+        business_key=f"{deps.session_id}:loan:{action}",
+        side_effecting=confirmed,
+    )

--- a/agents/tools/health_call.py
+++ b/agents/tools/health_call.py
@@ -8,7 +8,10 @@ from pydantic_ai import RunContext
 from agents.deps import FarmerContext
 from agents.models.ai_call import AISpecies
 from agents.models.health_call import HealthCallRequestModel, HealthCaseType
+from agents.tools.access import FarmerAccessDenied, resolve_owned_account
+from agents.tools.beckn_voice import beckn_health_booking, render_result
 from agents.tools.farmer_animal_backends import create_health_call_api
+from app.config import settings
 from app.core.cache import cache, try_reserve, release_reservation
 from helpers.utils import get_logger
 
@@ -46,11 +49,8 @@ async def create_health_call(
     """
     session_id = ctx.deps.session_id
     logger.info(
-        "Health call tool invoked: session=%s union=%s society=%s farmer=%s species=%s case_type=%s",
+        "Health call tool invoked: session=%s species=%s case_type=%s",
         session_id,
-        union_code,
-        society_code,
-        farmer_code,
         species.value,
         case_type.value,
     )
@@ -61,15 +61,31 @@ async def create_health_call(
         logger.info("Health call blocked: query failed moderation; session=%s", session_id)
         return "This helpline only handles dairy farming and animal husbandry questions."
 
+    try:
+        account = resolve_owned_account(ctx.deps, union_code, society_code, farmer_code)
+    except FarmerAccessDenied as exc:
+        logger.warning("Health call ownership gate rejected session=%s", session_id)
+        return str(exc)
+
+    if settings.voice_beckn_enabled:
+        result = await beckn_health_booking(
+            ctx.deps,
+            account,
+            species.value,
+            case_type.value,
+            remark,
+        )
+        return render_result(result, "Health call booking")
+
     token = os.getenv("PASHUGPT_TOKEN")
     if not token:
         logger.error("PASHUGPT_TOKEN is not set")
         return "Health call booking failed.\n\nPASHUGPT_TOKEN is not configured."
 
     request = HealthCallRequestModel(
-        unionCode=union_code,
-        societyCode=society_code,
-        farmerCode=farmer_code,
+        unionCode=account.union_code or "",
+        societyCode=account.society_code or "",
+        farmerCode=account.farmer_code or "",
         species=species,
         caseType=case_type,
         remark=remark,

--- a/agents/tools/loan.py
+++ b/agents/tools/loan.py
@@ -15,6 +15,8 @@ from pydantic_ai.tools import ToolDefinition
 
 from agents.deps import FarmerContext
 from agents.services import loan_eligibility as le
+from agents.tools.access import FarmerAccessDenied, require_authenticated_farmer
+from agents.tools.beckn_voice import beckn_loan, render_result
 from app.config import settings
 from helpers.utils import get_logger
 
@@ -35,10 +37,13 @@ async def prepare_check_loan_eligibility(
     improvise a request for a mobile number it cannot act on."""
     if not settings.loan_feature_enabled:
         return None
-    # Expose whenever the feature is on. If the caller's profile/mobile is not
-    # resolved, the tool still runs and returns a clear "no profile - visit your
-    # local cooperative bank" message, rather than the model improvising a request
-    # for a mobile number (which we cannot act on).
+    if not (
+        getattr(ctx.deps, "signed_in", False)
+        and getattr(ctx.deps, "identity_verified", False)
+        and getattr(ctx.deps, "mobile", None)
+        and getattr(ctx.deps, "subject_id", None)
+    ):
+        return None
     return tool_def
 
 
@@ -130,6 +135,14 @@ async def check_loan_eligibility(ctx: RunContext[FarmerContext], confirmed: bool
         confirmed: Set true ONLY after the farmer has explicitly agreed to avail the
             loan (their yes to the offer). Leave false for the initial eligibility/offer.
     """
+    try:
+        require_authenticated_farmer(ctx.deps)
+    except FarmerAccessDenied as exc:
+        return str(exc)
+
+    if settings.voice_beckn_enabled:
+        return render_result(await beckn_loan(ctx.deps, confirmed), "Micro-loan request")
+
     accounts = await _resolve_accounts(ctx)
     name: Optional[str] = None
     for acct in accounts:

--- a/agents/tools/milk_collection.py
+++ b/agents/tools/milk_collection.py
@@ -5,6 +5,9 @@ from pydantic import ValidationError
 from pydantic_ai import RunContext
 
 from agents.deps import FarmerAccount, FarmerContext
+from agents.tools.access import FarmerAccessDenied, require_farmer_accounts
+from agents.tools.beckn_voice import beckn_milk_statement, render_result
+from app.config import settings
 from app.models.milk_collection import FarmerMilkCollectionRequestModel
 from agents.tools.farmer_animal_backends import get_farmer_milk_collection_details_api
 from helpers.utils import get_logger
@@ -131,21 +134,29 @@ async def get_farmer_milk_collection_details(
         str: Formatted milk collection and deduction details across all of the
              farmer's accounts, or a clear failure message.
     """
-    # Prefer the structured accounts from context (every account on the mobile).
-    # Fall back to the LLM-supplied codes only when context has none.
-    accounts = list(ctx.deps.farmer_accounts) if ctx.deps and ctx.deps.farmer_accounts else []
-    if not accounts:
-        accounts = [
-            FarmerAccount(
-                union_code=union_code,
-                society_code=society_code,
-                farmer_code=farmer_code,
-            )
-        ]
+    try:
+        accounts = require_farmer_accounts(ctx.deps)
+    except FarmerAccessDenied as exc:
+        return str(exc)
     logger.info(
-        "Milk collection tool invoked: accounts=%s from=%s to=%s (llm_codes=%s/%s/%s)",
-        len(accounts), fromdate, todate, union_code, society_code, farmer_code,
+        "Milk collection tool invoked: session=%s accounts=%s from=%s to=%s",
+        ctx.deps.session_id, len(accounts), fromdate, todate,
     )
+
+    try:
+        FarmerMilkCollectionRequestModel(
+            unionCode=accounts[0].union_code or "",
+            societyCode=accounts[0].society_code or "",
+            farmerCode=accounts[0].farmer_code or "",
+            fromdate=fromdate,
+            todate=todate,
+        ).validate_date_range()
+    except (ValidationError, ValueError) as exc:
+        return f"Milk collection lookup failed. {exc}"
+
+    if settings.voice_beckn_enabled:
+        result = await beckn_milk_statement(ctx.deps, accounts, fromdate, todate)
+        return render_result(result, "Milk collection lookup")
     return await fetch_milk_summary_for_accounts(accounts, fromdate, todate)
 
 

--- a/agents/tools/search.py
+++ b/agents/tools/search.py
@@ -13,7 +13,9 @@ from pydantic import BaseModel, Field
 from pydantic_ai import ModelRetry, RunContext
 
 from agents.deps import FarmerContext
+from agents.tools.beckn_voice import beckn_document_search, render_result
 from agents.tools.terms import normalize_text_with_glossary
+from app.config import settings
 from app.observability import start_observation
 from helpers.utils import get_logger
 
@@ -330,8 +332,11 @@ async def search_documents(
         top_k: Requested number of final results (contract-clamped, default: 12)
     """
     try:
-        del ctx
         query = _validate_search_query(query)
+        if settings.voice_beckn_enabled:
+            result = await beckn_document_search(ctx.deps, query, top_k)
+            return render_result(result, "Veterinary document search")
+        del ctx
         endpoint_url = os.getenv('MARQO_ENDPOINT_URL')
         if not endpoint_url:
             raise ValueError("Marqo endpoint URL is required")

--- a/agents/tools/union_schemes.py
+++ b/agents/tools/union_schemes.py
@@ -7,6 +7,9 @@ from pydantic_ai import RunContext
 from pydantic_ai.tools import ToolDefinition
 
 from agents.deps import FarmerContext
+from agents.tools.access import FarmerAccessDenied, require_authenticated_farmer
+from agents.tools.beckn_voice import beckn_union_schemes, render_result
+from app.config import settings
 from app.models.union import UnionName, resolve_supported_unions
 from app.services.scheme_ingestion import (
     SchemeCacheError,
@@ -80,9 +83,22 @@ async def get_union_scheme_data(ctx: RunContext[FarmerContext], scheme_name: str
         return "Scheme data is unavailable because the farmer union could not be determined from the current farmer context."
 
     try:
+        require_authenticated_farmer(ctx.deps)
+    except FarmerAccessDenied as exc:
+        return str(exc)
+
+    try:
         UnionName(normalized_union_name)
     except ValueError:
         return f"Scheme data is only available for supported unions: {', '.join(sorted(SUPPORTED_SCHEME_UNIONS))}."
+
+    if settings.voice_beckn_enabled:
+        result = await beckn_union_schemes(
+            ctx.deps,
+            normalized_union_name,
+            normalized_scheme_name,
+        )
+        return render_result(result, "Union scheme lookup")
 
     try:
         records = await get_cached_scheme_records_for_union(normalized_union_name)

--- a/app/auth/jwt_auth.py
+++ b/app/auth/jwt_auth.py
@@ -116,7 +116,7 @@ async def get_current_user(token: str | None = Depends(oauth2_scheme)):
                 "verify_iss": False,
             },
         )
-        logger.info("Decoded token: %s", decoded_token)
+        logger.info("JWT verified successfully")
         return decoded_token
         
     except jwt.ExpiredSignatureError:

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,34 @@ class Settings(BaseSettings):
     farmer_api_trace_body: bool = _get_bool_env("FARMER_API_TRACE_BODY", default=False)
     farmer_api_trace_body_chars: int = int(os.getenv("FARMER_API_TRACE_BODY_CHARS", "8000"))
 
+    # Beckn transaction bridge for farmer-facing voice capabilities. Disabled by
+    # default until ONIX routes and callback signing are configured in an
+    # environment. When enabled, tools send only through this bridge and never
+    # fall back to a direct upstream call after an ambiguous transaction result.
+    voice_beckn_enabled: bool = _get_bool_env("VOICE_BECKN_ENABLED", default=False)
+    beckn_transaction_bridge_url: Optional[str] = os.getenv("BECKN_TRANSACTION_BRIDGE_URL")
+    beckn_transaction_bridge_token: Optional[str] = os.getenv("BECKN_TRANSACTION_BRIDGE_TOKEN")
+    beckn_callback_token: Optional[str] = os.getenv("BECKN_CALLBACK_TOKEN")
+    beckn_bap_id: str = os.getenv("BECKN_BAP_ID", "bap.amul-net.internal")
+    beckn_bap_uri: str = os.getenv(
+        "BECKN_BAP_URI",
+        "https://beckn-bap.prod.amulai.in/bap/receiver",
+    )
+    beckn_bpp_id: str = os.getenv("BECKN_BPP_ID", "bpp-amul.amul-net.internal")
+    beckn_bpp_uri: str = os.getenv(
+        "BECKN_BPP_URI",
+        "https://beckn-bpp.prod.amulai.in/bpp/receiver",
+    )
+    beckn_location_country: str = os.getenv("BECKN_LOCATION_COUNTRY", "IND")
+    beckn_location_city: str = os.getenv("BECKN_LOCATION_CITY", "std:080")
+    beckn_callback_wait_seconds: float = float(os.getenv("BECKN_CALLBACK_WAIT_SECONDS", "12"))
+    beckn_http_timeout_seconds: float = float(os.getenv("BECKN_HTTP_TIMEOUT_SECONDS", "8"))
+    beckn_poll_interval_seconds: float = float(os.getenv("BECKN_POLL_INTERVAL_SECONDS", "0.15"))
+    beckn_operation_ttl_seconds: int = int(os.getenv("BECKN_OPERATION_TTL_SECONDS", str(60 * 60 * 24)))
+    beckn_session_identity_ttl_seconds: int = int(
+        os.getenv("BECKN_SESSION_IDENTITY_TTL_SECONDS", str(60 * 60 * 24))
+    )
+
     # Logging Configuration
     log_level: str = "INFO"
     log_format: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/app/routers/beckn.py
+++ b/app/routers/beckn.py
@@ -1,0 +1,76 @@
+"""Internal callback ingress and owner-scoped operation status."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from app.auth.jwt_auth import get_current_user
+from app.config import settings
+from app.services.beckn_transactions import (
+    CallbackCorrelationError,
+    common_ack,
+    common_nack,
+    get_beckn_facade,
+)
+from app.services.voice_identity import resolve_caller_identity
+
+router = APIRouter(prefix="/beckn", tags=["beckn"])
+_CALLBACK_ACTIONS = {"on_search", "on_select", "on_init", "on_confirm", "on_status"}
+
+
+def _authorize_callback(x_beckn_callback_token: str | None = Header(None)) -> None:
+    expected = settings.beckn_callback_token or ""
+    supplied = x_beckn_callback_token or ""
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Beckn callback ingress is not configured",
+        )
+    if not hmac.compare_digest(expected, supplied):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid callback token")
+
+
+@router.post("/callbacks/{callback_action}", dependencies=[Depends(_authorize_callback)])
+async def receive_callback(
+    callback_action: str,
+    payload: dict = Body(...),
+):
+    if callback_action not in _CALLBACK_ACTIONS:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=common_nack("UNSUPPORTED_CALLBACK", "Unsupported Beckn callback action"),
+        )
+    try:
+        await get_beckn_facade().accept_callback(callback_action, payload)
+    except CallbackCorrelationError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=common_nack("CALLBACK_CORRELATION_FAILED", str(exc)),
+        )
+    return common_ack()
+
+
+@router.get("/operations/{transaction_id}")
+async def get_operation_status(
+    transaction_id: str,
+    user_info: dict = Depends(get_current_user),
+):
+    identity = resolve_caller_identity(user_info, "anonymous")
+    operation = await get_beckn_facade().get_for_subject(transaction_id, identity.subject_id)
+    if operation is None:
+        # Do not reveal whether another caller owns the transaction.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Operation not found")
+    return {
+        "operation_id": operation.operation_id,
+        "transaction_id": operation.transaction_id,
+        "tool_name": operation.tool_name,
+        "state": operation.state,
+        "provider_order_id": operation.provider_order_id,
+        "error": operation.error_payload,
+        "created_at": operation.created_at,
+        "updated_at": operation.updated_at,
+    }
+

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -7,6 +7,7 @@ from app.services.voice import stream_voice_message
 from app.llm_core import split as _llm_split
 from app.utils import _get_message_history, claim_session_request_ownership
 from app.models.requests import ChatRequest
+from app.services.voice_identity import bind_session_identity, resolve_caller_identity
 from helpers.utils import get_logger
 import time
 import uuid
@@ -27,10 +28,12 @@ async def voice_endpoint(
     JWT is validated using the public key from JWT_PUBLIC_KEY env or JWT_PUBLIC_KEY_PATH file.
     session_id is used for message history and Langfuse Sessions: same ID groups all agent runs for one conversation.
     """
+    identity = resolve_caller_identity(user_info, request.user_id)
     session_id = request.session_id or str(uuid.uuid4())
+    await bind_session_identity(session_id, identity)
     trace = create_voice_trace(
         session_id=session_id,
-        user_id=request.user_id,
+        user_id=identity.trace_id,
         query=request.query,
         source_lang=request.source_lang,
         target_lang=request.target_lang,
@@ -38,7 +41,7 @@ async def voice_endpoint(
         process_id=request.process_id,
     )
     logger.info(
-        f"Voice request received - session_id: {session_id}, user_id: {request.user_id}, "
+        f"Voice request received - session_id: {session_id}, subject: {identity.trace_id}, "
         f"source_lang: {request.source_lang}, "
         f"target_lang: {request.target_lang}, provider: {request.provider}, process_id: {request.process_id}, "
         f"call_type: {request.call_type}, query: {request.query}"
@@ -77,11 +80,13 @@ async def voice_endpoint(
             session_id=session_id,
             source_lang=request.source_lang,
             target_lang=request.target_lang,
-            user_id=request.user_id,
+            user_id=identity.mobile or "anonymous",
             history=history,
             provider=request.provider,
             process_id=request.process_id,
             user_info=user_info,
+            identity_verified=identity.verified,
+            authenticated_subject_id=identity.subject_id,
             owner=owner,
             http_request=http_request,
             trace=trace,

--- a/app/services/beckn_transactions.py
+++ b/app/services/beckn_transactions.py
@@ -1,0 +1,450 @@
+"""Durable, callback-aware Beckn transaction façade for voice tools.
+
+The façade deliberately separates a conversational session from a Beckn
+transaction. It stores correlation state before sending, treats an ACK only as
+acceptance, retains late callbacks, and never blindly resubmits a side effect
+after an ambiguous timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from app.config import settings
+from app.core.cache import build_cache_key, redis_client
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class OperationState(str, Enum):
+    CREATED = "CREATED"
+    SENT = "SENT"
+    ACKED_WAITING_CALLBACK = "ACKED_WAITING_CALLBACK"
+    SUCCEEDED = "SUCCEEDED"
+    BUSINESS_FAILED = "BUSINESS_FAILED"
+    NACKED = "NACKED"
+    TIMED_OUT_PENDING = "TIMED_OUT_PENDING"
+    UNKNOWN_REQUIRES_RECONCILIATION = "UNKNOWN_REQUIRES_RECONCILIATION"
+
+
+TERMINAL_STATES = {
+    OperationState.SUCCEEDED,
+    OperationState.BUSINESS_FAILED,
+    OperationState.NACKED,
+}
+PENDING_STATES = {
+    OperationState.CREATED,
+    OperationState.SENT,
+    OperationState.ACKED_WAITING_CALLBACK,
+    OperationState.TIMED_OUT_PENDING,
+    OperationState.UNKNOWN_REQUIRES_RECONCILIATION,
+}
+
+
+class BecknOperation(BaseModel):
+    operation_id: str
+    session_id: str
+    subject_id: str
+    tool_name: str
+    domain: str
+    action: str
+    transaction_id: str
+    business_key_hash: str
+    request_hash: str
+    side_effecting: bool = False
+    bpp_id: str
+    bpp_uri: str
+    expected_callbacks: dict[str, str] = Field(default_factory=dict)
+    callback_hashes: list[str] = Field(default_factory=list)
+    state: OperationState = OperationState.CREATED
+    response_payload: dict[str, Any] | None = None
+    error_payload: dict[str, Any] | None = None
+    provider_order_id: str | None = None
+    created_at: str
+    updated_at: str
+    deadline_at: str
+
+
+class BecknResult(BaseModel):
+    state: OperationState
+    transaction_id: str
+    operation_id: str
+    payload: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    provider_order_id: str | None = None
+
+    @property
+    def completed(self) -> bool:
+        return self.state == OperationState.SUCCEEDED
+
+    @property
+    def pending(self) -> bool:
+        return self.state in PENDING_STATES
+
+
+class CallbackCorrelationError(ValueError):
+    pass
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _timestamp(value: datetime | None = None) -> str:
+    return (value or _utcnow()).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _canonical_hash(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _operation_key(transaction_id: str) -> str:
+    return build_cache_key(f"beckn:operation:{transaction_id}")
+
+
+def _business_key(key_hash: str) -> str:
+    return build_cache_key(f"beckn:business:{key_hash}")
+
+
+class RedisOperationStore:
+    """Redis persistence with atomic business-idempotency reservation."""
+
+    async def create_or_get(self, operation: BecknOperation) -> tuple[BecknOperation, bool]:
+        operation_json = operation.model_dump_json()
+        script = """
+        local existing = redis.call('get', KEYS[1])
+        if existing then
+          return existing
+        end
+        redis.call('set', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[3]))
+        redis.call('set', KEYS[2], ARGV[2], 'EX', tonumber(ARGV[3]))
+        return ARGV[1]
+        """
+        transaction_id = await redis_client.eval(
+            script,
+            2,
+            _business_key(operation.business_key_hash),
+            _operation_key(operation.transaction_id),
+            operation.transaction_id,
+            operation_json,
+            str(settings.beckn_operation_ttl_seconds),
+        )
+        created = str(transaction_id) == operation.transaction_id
+        if created:
+            return operation, True
+        existing = await self.get(str(transaction_id))
+        if existing is None:
+            # A legacy/expired dangling index must fail closed; silently creating
+            # a second booking would defeat the business idempotency key.
+            raise RuntimeError("Beckn idempotency index points to a missing operation")
+        return existing, False
+
+    async def get(self, transaction_id: str) -> BecknOperation | None:
+        raw = await redis_client.get(_operation_key(transaction_id))
+        return BecknOperation.model_validate_json(raw) if raw else None
+
+    async def save(self, operation: BecknOperation) -> None:
+        operation.updated_at = _timestamp()
+        await redis_client.set(
+            _operation_key(operation.transaction_id),
+            operation.model_dump_json(),
+            ex=settings.beckn_operation_ttl_seconds,
+        )
+        await redis_client.expire(
+            _business_key(operation.business_key_hash),
+            settings.beckn_operation_ttl_seconds,
+        )
+
+
+class BecknTransactionFacade:
+    def __init__(self, store: RedisOperationStore | None = None):
+        self.store = store or RedisOperationStore()
+
+    def _require_config(self) -> None:
+        if not settings.beckn_transaction_bridge_url:
+            raise RuntimeError("BECKN_TRANSACTION_BRIDGE_URL is required when VOICE_BECKN_ENABLED=true")
+        if not settings.beckn_transaction_bridge_token:
+            raise RuntimeError("BECKN_TRANSACTION_BRIDGE_TOKEN is required when VOICE_BECKN_ENABLED=true")
+
+    def _context(
+        self,
+        *,
+        domain: str,
+        action: str,
+        transaction_id: str,
+        message_id: str,
+        bpp_id: str,
+        bpp_uri: str,
+    ) -> dict[str, Any]:
+        return {
+            "domain": domain,
+            "location": {
+                "country": {"code": settings.beckn_location_country},
+                "city": {"code": settings.beckn_location_city},
+            },
+            "action": action,
+            "version": "1.1.0",
+            "bap_id": settings.beckn_bap_id,
+            "bap_uri": settings.beckn_bap_uri,
+            "bpp_id": bpp_id,
+            "bpp_uri": bpp_uri,
+            "transaction_id": transaction_id,
+            "message_id": message_id,
+            "timestamp": _timestamp(),
+            "ttl": "PT30S",
+        }
+
+    async def execute(
+        self,
+        *,
+        session_id: str,
+        subject_id: str,
+        tool_name: str,
+        domain: str,
+        action: str,
+        message: dict[str, Any],
+        business_key: str,
+        side_effecting: bool = False,
+        expected_callback: str | None = None,
+        bpp_id: str | None = None,
+        bpp_uri: str | None = None,
+    ) -> BecknResult:
+        """Create/reuse an operation, send once, then await its paired callback."""
+        self._require_config()
+        callback_action = expected_callback or f"on_{action}"
+        selected_bpp_id = bpp_id or settings.beckn_bpp_id
+        selected_bpp_uri = bpp_uri or settings.beckn_bpp_uri
+        transaction_id = str(uuid.uuid4())
+        message_id = str(uuid.uuid4())
+        business_key_hash = _canonical_hash({"subject": subject_id, "key": business_key})
+        # Work on a detached JSON value so adding the provider-visible stable key
+        # cannot mutate a caller-owned object reused by the agent.
+        message = json.loads(json.dumps(message, ensure_ascii=False))
+        if side_effecting and isinstance(message.get("order"), dict):
+            message["order"].setdefault("tags", []).append({
+                "descriptor": {"code": "client-reference"},
+                "list": [{
+                    "descriptor": {"code": "idempotency_key"},
+                    "value": business_key_hash,
+                }],
+            })
+        context = self._context(
+            domain=domain,
+            action=action,
+            transaction_id=transaction_id,
+            message_id=message_id,
+            bpp_id=selected_bpp_id,
+            bpp_uri=selected_bpp_uri,
+        )
+        envelope = {"context": context, "message": message}
+        now = _utcnow()
+        operation = BecknOperation(
+            operation_id=str(uuid.uuid4()),
+            session_id=session_id,
+            subject_id=subject_id,
+            tool_name=tool_name,
+            domain=domain,
+            action=action,
+            transaction_id=transaction_id,
+            business_key_hash=business_key_hash,
+            request_hash=_canonical_hash(envelope),
+            side_effecting=side_effecting,
+            bpp_id=selected_bpp_id,
+            bpp_uri=selected_bpp_uri,
+            expected_callbacks={callback_action: message_id},
+            created_at=_timestamp(now),
+            updated_at=_timestamp(now),
+            deadline_at=_timestamp(now + timedelta(seconds=settings.beckn_callback_wait_seconds)),
+        )
+
+        operation, created = await self.store.create_or_get(operation)
+        if not created:
+            if operation.state in TERMINAL_STATES:
+                return self._result(operation)
+            if operation.side_effecting and operation.state in {
+                OperationState.TIMED_OUT_PENDING,
+                OperationState.UNKNOWN_REQUIRES_RECONCILIATION,
+            }:
+                operation = await self._recover_status(operation)
+            return await self._wait(operation.transaction_id)
+
+        operation.state = OperationState.SENT
+        await self.store.save(operation)
+        operation = await self._post_forward(operation, action, envelope)
+        if operation.state in TERMINAL_STATES:
+            return self._result(operation)
+        return await self._wait(operation.transaction_id)
+
+    async def _post_forward(
+        self,
+        operation: BecknOperation,
+        action: str,
+        envelope: dict[str, Any],
+    ) -> BecknOperation:
+        url = f"{settings.beckn_transaction_bridge_url.rstrip('/')}/transactions/{action}"
+        headers = {
+            "Authorization": f"Bearer {settings.beckn_transaction_bridge_token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=settings.beckn_http_timeout_seconds) as client:
+                response = await client.post(url, json=envelope, headers=headers)
+            response.raise_for_status()
+            body = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            latest = await self.store.get(operation.transaction_id) or operation
+            if latest.state in TERMINAL_STATES:
+                return latest
+            latest.state = (
+                OperationState.UNKNOWN_REQUIRES_RECONCILIATION
+                if latest.side_effecting
+                else OperationState.TIMED_OUT_PENDING
+            )
+            latest.error_payload = {
+                "code": "FORWARD_RESULT_AMBIGUOUS",
+                "message": type(exc).__name__,
+            }
+            await self.store.save(latest)
+            return latest
+
+        latest = await self.store.get(operation.transaction_id) or operation
+        if latest.state in TERMINAL_STATES:
+            return latest  # fast callback won the race with the HTTP ACK
+        ack_status = str((((body or {}).get("message") or {}).get("ack") or {}).get("status") or "").upper()
+        if ack_status != "ACK":
+            latest.state = OperationState.NACKED
+            latest.error_payload = (body or {}).get("error") or {
+                "code": "FORWARD_NACK",
+                "message": "Beckn participant rejected the request",
+            }
+        else:
+            latest.state = OperationState.ACKED_WAITING_CALLBACK
+            latest.error_payload = None
+        await self.store.save(latest)
+        return latest
+
+    async def _wait(self, transaction_id: str) -> BecknResult:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + settings.beckn_callback_wait_seconds
+        latest: BecknOperation | None = None
+        while loop.time() < deadline:
+            latest = await self.store.get(transaction_id)
+            if latest is None:
+                raise RuntimeError("Beckn operation disappeared while awaiting callback")
+            if latest.state in TERMINAL_STATES:
+                return self._result(latest)
+            await asyncio.sleep(settings.beckn_poll_interval_seconds)
+
+        latest = await self.store.get(transaction_id)
+        if latest is None:
+            raise RuntimeError("Beckn operation disappeared after callback deadline")
+        if latest.state not in TERMINAL_STATES:
+            latest.state = OperationState.TIMED_OUT_PENDING
+            await self.store.save(latest)
+        return self._result(latest)
+
+    async def _recover_status(self, operation: BecknOperation) -> BecknOperation:
+        """Issue one directed status request for an ambiguous side effect."""
+        if "on_status" in operation.expected_callbacks:
+            return operation
+        message_id = str(uuid.uuid4())
+        operation.expected_callbacks["on_status"] = message_id
+        await self.store.save(operation)  # waiter exists before forward send
+        envelope = {
+            "context": self._context(
+                domain=operation.domain,
+                action="status",
+                transaction_id=operation.transaction_id,
+                message_id=message_id,
+                bpp_id=operation.bpp_id,
+                bpp_uri=operation.bpp_uri,
+            ),
+            "message": {
+                "order_id": operation.provider_order_id or operation.business_key_hash,
+            },
+        }
+        return await self._post_forward(operation, "status", envelope)
+
+    async def accept_callback(self, callback_action: str, payload: dict[str, Any]) -> BecknOperation:
+        context = payload.get("context") or {}
+        transaction_id = str(context.get("transaction_id") or "")
+        message_id = str(context.get("message_id") or "")
+        if not transaction_id or not message_id:
+            raise CallbackCorrelationError("callback context requires transaction_id and message_id")
+
+        operation = await self.store.get(transaction_id)
+        if operation is None:
+            raise CallbackCorrelationError("unknown or expired transaction_id")
+        expected_message_id = operation.expected_callbacks.get(callback_action)
+        if not expected_message_id or expected_message_id != message_id:
+            raise CallbackCorrelationError("callback action/message_id does not match the operation")
+        if context.get("domain") != operation.domain:
+            raise CallbackCorrelationError("callback domain does not match the operation")
+        if context.get("bpp_id") != operation.bpp_id:
+            raise CallbackCorrelationError("callback bpp_id does not match the selected provider")
+
+        callback_hash = _canonical_hash(payload)
+        if callback_hash in operation.callback_hashes:
+            return operation
+        operation.callback_hashes.append(callback_hash)
+
+        error = payload.get("error")
+        if error:
+            operation.state = OperationState.BUSINESS_FAILED
+            operation.error_payload = error
+            operation.response_payload = None
+        else:
+            operation.state = OperationState.SUCCEEDED
+            operation.response_payload = payload
+            operation.error_payload = None
+            order = ((payload.get("message") or {}).get("order") or {})
+            if order.get("id"):
+                operation.provider_order_id = str(order["id"])
+        await self.store.save(operation)
+        return operation
+
+    async def get_for_subject(self, transaction_id: str, subject_id: str) -> BecknOperation | None:
+        operation = await self.store.get(transaction_id)
+        if operation is None or not operation.subject_id == subject_id:
+            return None
+        return operation
+
+    @staticmethod
+    def _result(operation: BecknOperation) -> BecknResult:
+        return BecknResult(
+            state=operation.state,
+            transaction_id=operation.transaction_id,
+            operation_id=operation.operation_id,
+            payload=operation.response_payload,
+            error=operation.error_payload,
+            provider_order_id=operation.provider_order_id,
+        )
+
+
+_facade = BecknTransactionFacade()
+
+
+def get_beckn_facade() -> BecknTransactionFacade:
+    return _facade
+
+
+def common_ack() -> dict[str, Any]:
+    return {"message": {"ack": {"status": "ACK"}}}
+
+
+def common_nack(code: str, message: str) -> dict[str, Any]:
+    return {
+        "message": {"ack": {"status": "NACK"}},
+        "error": {"type": "DOMAIN-ERROR", "code": code, "message": message},
+    }

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -603,10 +603,9 @@ def _history_pair(user_text: str, assistant_text: str) -> tuple[ModelRequest, Mo
     )
 
 
-def _is_signed_in_session(user_info: Optional[dict], user_id: str) -> bool:
-    if user_id and user_id != "anonymous":
-        return True
-    return bool(user_info)
+def _is_signed_in_session(identity_verified: bool, mobile: Optional[str], subject_id: Optional[str]) -> bool:
+    """Only an identity resolved from verified JWT claims is signed in."""
+    return bool(identity_verified and mobile and subject_id)
 
 
 async def get_or_fetch_farmer_data(mobile: str):
@@ -1070,6 +1069,32 @@ def _build_ai_technician_summary(envelope: Optional[FarmerDataEnvelope]) -> str:
     return "\n".join(lines)
 
 
+def _collect_ai_technician_ids(envelope: Optional[FarmerDataEnvelope]) -> list[str]:
+    """Return technician IDs from non-banned authenticated farmer groups."""
+    if envelope is None:
+        return []
+    banned_identities: set[tuple[str, str, str]] = set()
+    banned_union_codes: set[str] = set()
+    for farmer in envelope.farmers or []:
+        if not is_ai_call_banned_union(_farmer_record_union_name(farmer)):
+            continue
+        identity = _farmer_record_identity(farmer.model_dump())
+        if identity != ("", "", ""):
+            banned_identities.add(identity)
+        if identity[2]:
+            banned_union_codes.add(identity[2])
+
+    ids: list[str] = []
+    for group in envelope.aiTechnicians or []:
+        if _technician_group_is_banned(group, banned_identities, banned_union_codes):
+            continue
+        for technician in _dedupe_technicians(group.get("technicians") or []):
+            technician_id = str(technician.get("userId") or "").strip()
+            if technician_id and technician_id not in ids:
+                ids.append(technician_id)
+    return ids
+
+
 def should_translate_batch(
     batch_text: str,
     word_count: int,
@@ -1139,11 +1164,15 @@ async def stream_voice_message(
     trace: Optional[VoiceTrace] = None,
     pipeline_profile: str = "managed",
     call_type: str = "inbound",
+    identity_verified: bool = False,
+    authenticated_subject_id: Optional[str] = None,
 #    background_tasks: BackgroundTasks,
 
 ) -> AsyncGenerator[str, None]:
     """Async generator for streaming chat messages."""
     request_started_at = time.monotonic()
+    authoritative_mobile = normalize_phone_to_mobile(user_id) if identity_verified else None
+    safe_user_id = (authenticated_subject_id or "anonymous")[:200]
     # Model selection is resolved by the unified pipeline (the only path): the agent
     # handle, provider, and display model name all come from the resolved primary
     # AGENT tier for this session's profile NAME. For the current env this is the same
@@ -1164,7 +1193,7 @@ async def stream_voice_message(
     last_emitted_sig_char: str | None = None
     trace = trace or create_voice_trace(
         session_id=session_id,
-        user_id=user_id,
+        user_id=safe_user_id,
         query=query,
         source_lang=source_lang,
         target_lang=target_lang,
@@ -1350,14 +1379,14 @@ async def stream_voice_message(
             )
             if outbound_consent_turn:
                 logger.info(
-                    "Outbound consent turn; session_id=%s process_id=%s user_id=%s query=%r",
-                    session_id, process_id, user_id, (query or "")[:60],
+                    "Outbound consent turn; session_id=%s process_id=%s subject=%s query=%r",
+                    session_id, process_id, safe_user_id[:16], (query or "")[:60],
                 )
                 # Warm the milk summary alongside the consent classifier so an
                 # affirmative reply does not pay the upstream lookup serially.
                 # There is no longer a turn of our own to hide it behind. Failure
                 # just means the agent fetches it itself.
-                _prefetch_mobile = normalize_phone_to_mobile(user_id)
+                _prefetch_mobile = authoritative_mobile
                 if _prefetch_mobile:
                     async def _warm_outbound_milk(mobile_number: str = _prefetch_mobile):
                         envelope = await get_or_fetch_farmer_data(mobile_number)
@@ -1575,12 +1604,13 @@ async def stream_voice_message(
             history_user_text = query
             moderation_recent_history = "\n\n".join(format_message_pairs(history, 2))
             non_meaningful_recent_turns = _collect_recent_user_turns_for_non_meaningful(history, query, limit=5)
-            mobile = normalize_phone_to_mobile(user_id)
-            signed_in = _is_signed_in_session(user_info, user_id)
+            mobile = authoritative_mobile
+            signed_in = _is_signed_in_session(identity_verified, mobile, authenticated_subject_id)
             farmer_info = ""
             farmer_unions: list[str] = []
             farmer_accounts: list[FarmerAccount] = []
             ai_technician_info = ""
+            ai_technician_ids: list[str] = []
             farmer_cache_task = (
                 asyncio.create_task(get_or_fetch_farmer_data(mobile))
                 if mobile
@@ -1603,7 +1633,7 @@ async def stream_voice_message(
                     recent_history_text=moderation_recent_history,
                     profile_name=pipeline_profile,
                     session_id=session_id,
-                    user_id=user_id,
+                    user_id=safe_user_id,
                     process_id=process_id or "",
                     pipeline_profile=pipeline_profile,
                 )
@@ -1684,7 +1714,7 @@ async def stream_voice_message(
                                         text=query,
                                         source_lang=requested_source_lang,
                                         session_id=session_id,
-                                        user_id=user_id,
+                                        user_id=safe_user_id,
                                         process_id=process_id or "",
                                         pipeline_profile=pipeline_profile,
                                     )
@@ -1693,7 +1723,7 @@ async def stream_voice_message(
                                         text=query,
                                         source_lang=requested_source_lang,
                                         session_id=session_id,
-                                        user_id=user_id,
+                                        user_id=safe_user_id,
                                         process_id=process_id or "",
                                         pipeline_profile=pipeline_profile,
                                     )
@@ -1795,7 +1825,7 @@ async def stream_voice_message(
                                     text=query,
                                     source_lang=requested_source_lang,
                                     session_id=session_id,
-                                    user_id=user_id,
+                                    user_id=safe_user_id,
                                     process_id=process_id or "",
                                     pipeline_profile=pipeline_profile,
                                 )
@@ -1804,7 +1834,7 @@ async def stream_voice_message(
                                     text=query,
                                     source_lang=requested_source_lang,
                                     session_id=session_id,
-                                    user_id=user_id,
+                                    user_id=safe_user_id,
                                     process_id=process_id or "",
                                     pipeline_profile=pipeline_profile,
                                 )
@@ -2294,6 +2324,7 @@ async def stream_voice_message(
                     if scheme_summary:
                         farmer_info = f"{farmer_info}\n{scheme_summary}" if farmer_info else scheme_summary
                     ai_technician_info = _build_ai_technician_summary(envelope)
+                    ai_technician_ids = _collect_ai_technician_ids(envelope)
                     trace.set_farmer_context(
                         source=getattr(envelope, "source", None) if envelope else None,
                         stale=getattr(envelope, "stale", None) if envelope else None,
@@ -2302,8 +2333,8 @@ async def stream_voice_message(
                         technician_info_chars=len(ai_technician_info),
                     )
                     logger.info(
-                        "Farmer summary loaded from cache for mobile %s source=%s stale=%s unions=%s summary_chars=%s technician_chars=%s",
-                        mobile,
+                        "Farmer summary loaded from cache for subject=%s source=%s stale=%s unions=%s summary_chars=%s technician_chars=%s",
+                        safe_user_id[:16],
                         getattr(envelope, "source", None) if envelope else None,
                         getattr(envelope, "stale", None) if envelope else None,
                         farmer_unions,
@@ -2313,13 +2344,13 @@ async def stream_voice_message(
                     if mobile and should_refresh_farmer_data(envelope):
                         await enqueue_farmer_refresh(mobile)
                         logger.info(
-                            "Farmer cache refresh scheduled in background for mobile %s stale=%s status=%s",
-                            mobile,
+                            "Farmer cache refresh scheduled in background for subject=%s stale=%s status=%s",
+                            safe_user_id[:16],
                             getattr(envelope, "stale", None) if envelope else None,
                             getattr(envelope, "lookupStatus", None) if envelope else None,
                         )
                 except Exception as e:
-                    logger.warning(f"Failed to load farmer summary for mobile {mobile}: {e}")
+                    logger.warning("Failed to load farmer summary for subject=%s: %s", safe_user_id[:16], e)
 
             # ── Outbound consent gate ─────────────────────────────────────
             # Turn 2 of an outbound call: the farmer's first reply to the scripted
@@ -2392,7 +2423,6 @@ async def stream_voice_message(
                         yield _emit(_prepare_voice_output(no_data_for_caller, requested_target_lang))
                         return
 
-            logger.info(f"User info: {user_info}")
             deps = FarmerContext(
                 query=processing_query,
                 lang_code=processing_lang,
@@ -2404,8 +2434,11 @@ async def stream_voice_message(
                 farmer_unions=farmer_unions,
                 ai_technician_info=ai_technician_info,
                 signed_in=signed_in,
+                identity_verified=identity_verified,
+                subject_id=authenticated_subject_id,
                 mobile=mobile,
                 farmer_accounts=farmer_accounts,
+                ai_technician_ids=ai_technician_ids,
             )
             # Let side-effecting tools (bookings) self-gate on the concurrent
             # moderation verdict before performing any write.

--- a/app/services/voice_identity.py
+++ b/app/services/voice_identity.py
@@ -1,0 +1,147 @@
+"""Authoritative caller and session identity handling for voice requests.
+
+The telephony ``user_id`` query parameter is routing metadata, not proof of
+identity. Farmer data and operations are therefore bound only to a phone claim
+from the verified JWT. A caller-supplied phone may agree with that claim for
+backwards compatibility, but can never override it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.core.cache import build_cache_key, redis_client
+from helpers.utils import get_logger
+
+logger = get_logger(__name__)
+
+_PHONE_CLAIMS = ("phone", "mobile", "phone_number", "mobile_number")
+_ANONYMOUS_IDS = {"", "anon", "anonymous"}
+
+
+def _normalize_mobile(raw: str) -> str | None:
+    value = str(raw or "").strip()
+    if not value or value.lower() in _ANONYMOUS_IDS:
+        return None
+    try:
+        uuid.UUID(value)
+        return None
+    except (ValueError, AttributeError, TypeError):
+        pass
+    digits = re.sub(r"\D", "", value)
+    return digits[-10:] if len(digits) >= 10 else None
+
+
+@dataclass(frozen=True)
+class CallerIdentity:
+    mobile: str | None
+    subject_id: str
+    verified: bool
+
+    @property
+    def signed_in(self) -> bool:
+        return bool(self.verified and self.mobile)
+
+    @property
+    def trace_id(self) -> str:
+        """Non-reversible identifier suitable for logs and traces."""
+        return self.subject_id[:16]
+
+
+def _subject_id(user_info: Mapping[str, Any], mobile: str | None) -> str:
+    stable_subject = "|".join((
+        str(user_info.get("sub") or "").strip(),
+        str(mobile or "").strip(),
+    )) or "anonymous"
+    return hashlib.sha256(stable_subject.encode("utf-8")).hexdigest()
+
+
+def _jwt_mobile(user_info: Mapping[str, Any]) -> str | None:
+    for claim in _PHONE_CLAIMS:
+        mobile = _normalize_mobile(str(user_info.get(claim) or ""))
+        if mobile:
+            return mobile
+
+    # Amul-issued farmer tokens use the phone as ``sub`` as well. Accept it only
+    # when it is phone-shaped; UUID/user-name subjects are never treated as phone.
+    return _normalize_mobile(str(user_info.get("sub") or ""))
+
+
+def resolve_caller_identity(
+    user_info: Mapping[str, Any] | None,
+    requested_user_id: str | None,
+) -> CallerIdentity:
+    """Resolve identity from verified JWT claims and reject parameter mismatch."""
+    claims = user_info or {}
+    mobile = _jwt_mobile(claims)
+    requested = str(requested_user_id or "").strip()
+    requested_mobile = _normalize_mobile(requested)
+    requested_is_anonymous = requested.lower() in _ANONYMOUS_IDS
+
+    if requested_mobile and not mobile:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The requested farmer identity is not present in the authenticated token",
+        )
+    if requested_mobile and mobile and not hmac.compare_digest(requested_mobile, mobile):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The requested farmer identity does not match the authenticated caller",
+        )
+    if requested and not requested_is_anonymous and not requested_mobile:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="user_id must be anonymous or the authenticated farmer mobile",
+        )
+
+    return CallerIdentity(
+        mobile=mobile,
+        subject_id=_subject_id(claims, mobile),
+        verified=bool(claims),
+    )
+
+
+def _session_identity_key(session_id: str) -> str:
+    return build_cache_key(f"voice_session_identity:{session_id}")
+
+
+async def bind_session_identity(session_id: str, identity: CallerIdentity) -> None:
+    """Atomically bind a conversation session to its authenticated subject.
+
+    This check is intentionally fail-closed: history and pending operations are
+    private data, so a Redis outage must not silently disable ownership checks.
+    """
+    key = _session_identity_key(session_id)
+    try:
+        created = await redis_client.set(
+            key,
+            identity.subject_id,
+            ex=settings.beckn_session_identity_ttl_seconds,
+            nx=True,
+        )
+        if created:
+            return
+        existing = await redis_client.get(key)
+    except Exception as exc:
+        logger.error("Voice session identity binding unavailable: %s", type(exc).__name__)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Session identity service is temporarily unavailable",
+        ) from exc
+
+    if not existing or not hmac.compare_digest(str(existing), identity.subject_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This session belongs to a different authenticated caller",
+        )
+
+    # Refresh only an already-matching binding.
+    await redis_client.expire(key, settings.beckn_session_identity_ttl_seconds)

--- a/example.env
+++ b/example.env
@@ -95,3 +95,18 @@ CONCURRENCY_MAX=10
 # workers (else a scrape sees only one worker and undercounts). Leave UNSET for a
 # single worker. Example:
 # PROMETHEUS_MULTIPROC_DIR=/tmp/prom_multiproc
+# Callback-aware Beckn business-tool transport. Keep disabled until the ONIX
+# transaction bridge, callback route, and shared secrets are configured.
+VOICE_BECKN_ENABLED=false
+BECKN_TRANSACTION_BRIDGE_URL=
+BECKN_TRANSACTION_BRIDGE_TOKEN=
+BECKN_CALLBACK_TOKEN=
+BECKN_BAP_ID=bap.amul-net.internal
+BECKN_BAP_URI=https://beckn-bap.prod.amulai.in/bap/receiver
+BECKN_BPP_ID=bpp-amul.amul-net.internal
+BECKN_BPP_URI=https://beckn-bpp.prod.amulai.in/bpp/receiver
+BECKN_LOCATION_COUNTRY=IND
+BECKN_LOCATION_CITY=std:080
+BECKN_CALLBACK_WAIT_SECONDS=12
+BECKN_HTTP_TIMEOUT_SECONDS=8
+BECKN_OPERATION_TTL_SECONDS=86400

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ load_dotenv()
 import app.observability  # noqa: F401, E402
 
 # Import all routers
-from app.routers import  voice, health
+from app.routers import beckn, health, voice
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -90,3 +90,4 @@ async def metrics():
 
 app.include_router(voice.router, prefix=settings.api_prefix)
 app.include_router(health.router, prefix=settings.api_prefix)
+app.include_router(beckn.router, prefix=settings.api_prefix)

--- a/tests/test_ai_call_union_ban_context.py
+++ b/tests/test_ai_call_union_ban_context.py
@@ -308,7 +308,16 @@ async def _in_scope():
 
 
 def _booking_ctx(session_id="s-ban", unions=None, include_unions=True):
-    deps = SimpleNamespace(session_id=session_id, ensure_in_scope=_in_scope)
+    deps = SimpleNamespace(
+        session_id=session_id,
+        ensure_in_scope=_in_scope,
+        signed_in=True,
+        identity_verified=True,
+        mobile="9924457046",
+        subject_id="subject-1",
+        farmer_accounts=[SimpleNamespace(union_code="U", society_code="S", farmer_code="F")],
+        ai_technician_ids=["tech1"],
+    )
     if include_unions:
         deps.farmer_unions = unions
     return SimpleNamespace(deps=deps)
@@ -456,4 +465,3 @@ def test_canned_union_ban_gujarati_survives_voice_cleanup():
     spoken = _prepare_voice_output(UNION_BANNED_MESSAGES["gu"], "gu")
     assert "દૂધ મંડળી" in spoken
     assert spoken.strip() == UNION_BANNED_MESSAGES["gu"].strip()
-

--- a/tests/test_beckn_transactions.py
+++ b/tests/test_beckn_transactions.py
@@ -1,0 +1,144 @@
+import asyncio
+
+import pytest
+
+from app.services import beckn_transactions as bt
+
+
+class MemoryStore:
+    def __init__(self):
+        self.operations = {}
+        self.business = {}
+
+    async def create_or_get(self, operation):
+        transaction_id = self.business.get(operation.business_key_hash)
+        if transaction_id:
+            return self.operations[transaction_id].model_copy(deep=True), False
+        self.business[operation.business_key_hash] = operation.transaction_id
+        self.operations[operation.transaction_id] = operation.model_copy(deep=True)
+        return operation.model_copy(deep=True), True
+
+    async def get(self, transaction_id):
+        operation = self.operations.get(transaction_id)
+        return operation.model_copy(deep=True) if operation else None
+
+    async def save(self, operation):
+        self.operations[operation.transaction_id] = operation.model_copy(deep=True)
+
+
+def _configure(monkeypatch):
+    monkeypatch.setattr(bt.settings, "beckn_transaction_bridge_url", "https://bridge.test")
+    monkeypatch.setattr(bt.settings, "beckn_transaction_bridge_token", "secret")
+    monkeypatch.setattr(bt.settings, "beckn_callback_wait_seconds", 0.02)
+    monkeypatch.setattr(bt.settings, "beckn_poll_interval_seconds", 0.001)
+
+
+def _execute(facade, *, side_effecting=True):
+    return facade.execute(
+        session_id="session-1",
+        subject_id="subject-1",
+        tool_name="create_ai_call",
+        domain="services:amul-vet-booking",
+        action="confirm",
+        message={"order": {"provider": {"id": "amul-ai-service"}}},
+        business_key="session-1:ai-call",
+        side_effecting=side_effecting,
+    )
+
+
+def _callback(operation, *, message_id=None, error=None):
+    payload = {
+        "context": {
+            "domain": operation.domain,
+            "action": "on_confirm",
+            "bpp_id": operation.bpp_id,
+            "transaction_id": operation.transaction_id,
+            "message_id": message_id or operation.expected_callbacks["on_confirm"],
+        },
+        "message": {"order": {"id": "TICKET-1", "state": "ACTIVE"}},
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+def test_fast_callback_wins_ack_race_and_completes(monkeypatch):
+    _configure(monkeypatch)
+    store = MemoryStore()
+    facade = bt.BecknTransactionFacade(store)
+
+    async def post_with_callback(operation, action, envelope):
+        await facade.accept_callback("on_confirm", _callback(operation))
+        return await store.get(operation.transaction_id)
+
+    monkeypatch.setattr(facade, "_post_forward", post_with_callback)
+    result = asyncio.run(_execute(facade))
+    assert result.state == bt.OperationState.SUCCEEDED
+    assert result.provider_order_id == "TICKET-1"
+
+
+def test_duplicate_business_request_does_not_resubmit_confirm_and_uses_status(monkeypatch):
+    _configure(monkeypatch)
+    store = MemoryStore()
+    facade = bt.BecknTransactionFacade(store)
+    actions = []
+
+    async def ack_without_callback(operation, action, envelope):
+        actions.append(action)
+        operation.state = bt.OperationState.ACKED_WAITING_CALLBACK
+        await store.save(operation)
+        return operation
+
+    monkeypatch.setattr(facade, "_post_forward", ack_without_callback)
+    first = asyncio.run(_execute(facade))
+    second = asyncio.run(_execute(facade))
+
+    assert first.state == bt.OperationState.TIMED_OUT_PENDING
+    assert second.state == bt.OperationState.TIMED_OUT_PENDING
+    assert actions == ["confirm", "status"]
+    assert first.transaction_id == second.transaction_id
+
+
+def test_callback_requires_exact_action_message_domain_and_bpp(monkeypatch):
+    _configure(monkeypatch)
+    store = MemoryStore()
+    facade = bt.BecknTransactionFacade(store)
+
+    async def ack_without_callback(operation, action, envelope):
+        operation.state = bt.OperationState.ACKED_WAITING_CALLBACK
+        await store.save(operation)
+        return operation
+
+    monkeypatch.setattr(facade, "_post_forward", ack_without_callback)
+    pending = asyncio.run(_execute(facade))
+    operation = asyncio.run(store.get(pending.transaction_id))
+
+    with pytest.raises(bt.CallbackCorrelationError):
+        asyncio.run(facade.accept_callback("on_confirm", _callback(operation, message_id="wrong")))
+
+    payload = _callback(operation)
+    payload["context"]["bpp_id"] = "attacker.example"
+    with pytest.raises(bt.CallbackCorrelationError):
+        asyncio.run(facade.accept_callback("on_confirm", payload))
+
+
+def test_duplicate_callback_is_idempotently_accepted(monkeypatch):
+    _configure(monkeypatch)
+    store = MemoryStore()
+    facade = bt.BecknTransactionFacade(store)
+
+    async def ack_without_callback(operation, action, envelope):
+        operation.state = bt.OperationState.ACKED_WAITING_CALLBACK
+        await store.save(operation)
+        return operation
+
+    monkeypatch.setattr(facade, "_post_forward", ack_without_callback)
+    pending = asyncio.run(_execute(facade))
+    operation = asyncio.run(store.get(pending.transaction_id))
+    payload = _callback(operation)
+
+    first = asyncio.run(facade.accept_callback("on_confirm", payload))
+    second = asyncio.run(facade.accept_callback("on_confirm", payload))
+    assert first.state == second.state == bt.OperationState.SUCCEEDED
+    assert len(second.callback_hashes) == 1
+

--- a/tests/test_booking_idempotency.py
+++ b/tests/test_booking_idempotency.py
@@ -22,7 +22,18 @@ def _ctx(session_id):
     async def _ensure_in_scope():
         return True
 
-    return SimpleNamespace(deps=SimpleNamespace(session_id=session_id, ensure_in_scope=_ensure_in_scope))
+    account = SimpleNamespace(union_code="U", society_code="S", farmer_code="F")
+    return SimpleNamespace(deps=SimpleNamespace(
+        session_id=session_id,
+        ensure_in_scope=_ensure_in_scope,
+        farmer_unions=[],
+        signed_in=True,
+        identity_verified=True,
+        mobile="9924457046",
+        subject_id="subject-1",
+        farmer_accounts=[account],
+        ai_technician_ids=["tech1", "t"],
+    ))
 
 
 def _patch_cache(monkeypatch, module):

--- a/tests/test_milk_collection_tool.py
+++ b/tests/test_milk_collection_tool.py
@@ -12,7 +12,14 @@ from agents.tools.milk_collection import get_farmer_milk_collection_details
 
 def _ctx(accounts=None):
     """Minimal RunContext stand-in carrying FarmerContext deps."""
-    deps = FarmerContext(query="milk", farmer_accounts=accounts or [])
+    deps = FarmerContext(
+        query="milk",
+        signed_in=True,
+        identity_verified=True,
+        mobile="9924457046",
+        subject_id="subject-1",
+        farmer_accounts=accounts or [],
+    )
     return SimpleNamespace(deps=deps)
 
 
@@ -91,7 +98,7 @@ class TestMilkCollectionTool:
         assert "quantity 2.38 liters" in result
         assert "quantity 9.68 liters" in result
 
-    def test_falls_back_to_supplied_codes_when_no_accounts_in_context(self, monkeypatch):
+    def test_rejects_supplied_codes_when_no_authenticated_accounts_exist(self, monkeypatch):
         monkeypatch.setenv("PASHUGPT_TOKEN", "test-token")
         seen = {}
 
@@ -106,14 +113,14 @@ class TestMilkCollectionTool:
             _fake_api,
         )
 
-        # Empty context -> use the LLM-supplied codes.
+        # Model-supplied codes can never substitute for an authenticated account.
         result = asyncio.run(
             get_farmer_milk_collection_details(
                 _ctx([]), "2021", "1066", "123", "2026-04-01", "2026-04-01"
             )
         )
-        assert seen["codes"]["farmerCode"] == "123"
-        assert "quantity 5 liters" in result
+        assert "codes" not in seen
+        assert "No farmer account" in result
 
     def test_missing_token_returns_clear_failure_and_does_not_call_backend(self, monkeypatch):
         monkeypatch.delenv("PASHUGPT_TOKEN", raising=False)
@@ -128,7 +135,8 @@ class TestMilkCollectionTool:
 
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                _ctx(), "2021", "1066", "123", "2026-04-01", "2026-04-01"
+                _ctx([FarmerAccount(union_code="2021", society_code="1066", farmer_code="123")]),
+                "2021", "1066", "123", "2026-04-01", "2026-04-01"
             )
         )
 
@@ -168,7 +176,8 @@ class TestMilkCollectionTool:
 
         result = asyncio.run(
             get_farmer_milk_collection_details(
-                _ctx(), "2021", "1066", "123", "2026-04-01", "2026-04-01"
+                _ctx([FarmerAccount(union_code="2021", society_code="1066", farmer_code="123")]),
+                "2021", "1066", "123", "2026-04-01", "2026-04-01"
             )
         )
 

--- a/tests/test_private_tool_access.py
+++ b/tests/test_private_tool_access.py
@@ -1,0 +1,46 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+import pytest
+
+from agents.deps import FarmerAccount, FarmerContext
+from agents.tools.access import (
+    FarmerAccessDenied,
+    require_authenticated_farmer,
+    require_owned_technician,
+    resolve_owned_account,
+)
+
+
+def _deps(**overrides):
+    values = dict(
+        query="book",
+        signed_in=True,
+        identity_verified=True,
+        subject_id="subject-hash",
+        mobile="9924457046",
+        farmer_accounts=[FarmerAccount(union_code="U1", society_code="S1", farmer_code="F1")],
+        ai_technician_ids=["TECH-1"],
+    )
+    values.update(overrides)
+    return FarmerContext(**values)
+
+
+def test_private_access_requires_verified_identity():
+    with pytest.raises(FarmerAccessDenied):
+        require_authenticated_farmer(_deps(identity_verified=False))
+
+
+def test_account_codes_must_match_authenticated_context():
+    account = resolve_owned_account(_deps(), "U1", "S1", "F1")
+    assert account.farmer_code == "F1"
+    with pytest.raises(FarmerAccessDenied):
+        resolve_owned_account(_deps(), "U1", "S1", "OTHER")
+
+
+def test_technician_must_be_in_authenticated_context():
+    assert require_owned_technician(_deps(), "TECH-1") == "TECH-1"
+    with pytest.raises(FarmerAccessDenied):
+        require_owned_technician(_deps(), "TECH-2")

--- a/tests/test_voice_beckn_tool_routes.py
+++ b/tests/test_voice_beckn_tool_routes.py
@@ -1,0 +1,81 @@
+import asyncio
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("LLM_MODEL_NAME", "gpt-test")
+
+from agents.deps import FarmerAccount, FarmerContext
+from agents.tools import BASE_TOOLS, SIGNED_IN_FARMER_TOOLS
+from agents.tools import beckn_voice as routes
+from app.services.beckn_transactions import BecknResult, OperationState
+
+
+class RecordingFacade:
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, **kwargs):
+        self.calls.append(kwargs)
+        return BecknResult(
+            state=OperationState.SUCCEEDED,
+            transaction_id="tx-1",
+            operation_id="op-1",
+            payload={"message": {"order": {"id": "provider-1"}}},
+        )
+
+
+def _deps():
+    return FarmerContext(
+        query="test",
+        session_id="session-1",
+        signed_in=True,
+        identity_verified=True,
+        subject_id="subject-1",
+        mobile="9924457046",
+        farmer_accounts=[FarmerAccount(union_code="U1", society_code="S1", farmer_code="F1")],
+        ai_technician_ids=["TECH-1"],
+    )
+
+
+def test_private_and_mutating_tools_are_not_in_anonymous_base_registry():
+    base = {tool.function.__name__ for tool in BASE_TOOLS}
+    signed = {tool.function.__name__ for tool in SIGNED_IN_FARMER_TOOLS}
+    assert base == {"search_terms", "search_documents", "signal_conversation_state"}
+    assert {
+        "create_ai_call",
+        "create_health_call",
+        "get_farmer_milk_collection_details",
+        "check_loan_eligibility",
+        "get_union_scheme_data",
+    }.issubset(signed)
+
+
+def test_every_voice_business_route_uses_the_shared_facade(monkeypatch):
+    recorder = RecordingFacade()
+    monkeypatch.setattr(routes, "get_beckn_facade", lambda: recorder)
+    deps = _deps()
+    account = deps.farmer_accounts[0]
+
+    async def run_all():
+        await routes.beckn_document_search(deps, "mastitis", 5)
+        await routes.beckn_ai_booking(deps, account, "TECH-1", "cow")
+        await routes.beckn_health_booking(deps, account, "buffalo", "emergency", "fever")
+        await routes.beckn_milk_statement(deps, [account], "2026-08-01", "2026-08-24")
+        await routes.beckn_union_schemes(deps, "banas", "insurance")
+        await routes.beckn_loan(deps, False)
+        await routes.beckn_loan(deps, True)
+
+    asyncio.run(run_all())
+    assert [(call["domain"], call["action"]) for call in recorder.calls] == [
+        ("advisory:amul-vet", "search"),
+        ("services:amul-vet-booking", "confirm"),
+        ("services:amul-vet-booking", "confirm"),
+        ("services:amul-milk-collection", "init"),
+        ("schemes:amul-union", "search"),
+        ("finance:amul-microloan", "init"),
+        ("finance:amul-microloan", "confirm"),
+    ]
+    assert recorder.calls[1]["side_effecting"] is True
+    assert recorder.calls[2]["side_effecting"] is True
+    assert recorder.calls[-1]["side_effecting"] is True
+

--- a/tests/test_voice_farmer_context.py
+++ b/tests/test_voice_farmer_context.py
@@ -68,6 +68,11 @@ def test_signed_in_farmer_tools_drops_brittle_three():
     union-scheme tool remains in SIGNED_IN_FARMER_TOOLS."""
     from agents.tools import SIGNED_IN_FARMER_TOOLS
 
-    assert len(SIGNED_IN_FARMER_TOOLS) == 1, (
-        f"expected only get_union_scheme_data; got {len(SIGNED_IN_FARMER_TOOLS)} tools"
-    )
+    tool_names = {tool.function.__name__ for tool in SIGNED_IN_FARMER_TOOLS}
+    assert tool_names == {
+        "create_ai_call",
+        "get_farmer_milk_collection_details",
+        "create_health_call",
+        "check_loan_eligibility",
+        "get_union_scheme_data",
+    }

--- a/tests/test_voice_identity.py
+++ b/tests/test_voice_identity.py
@@ -1,0 +1,60 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import voice_identity as identity
+
+
+def test_jwt_phone_is_authoritative_and_normalized():
+    resolved = identity.resolve_caller_identity(
+        {"sub": "user-1", "phone": "+91 99244 57046"},
+        "9924457046",
+    )
+    assert resolved.mobile == "9924457046"
+    assert resolved.signed_in is True
+    assert "9924457046" not in resolved.subject_id
+
+
+def test_caller_supplied_phone_cannot_override_jwt():
+    with pytest.raises(HTTPException) as exc:
+        identity.resolve_caller_identity(
+            {"sub": "user-1", "phone": "9924457046"},
+            "9265866812",
+        )
+    assert exc.value.status_code == 403
+
+
+def test_phone_parameter_is_rejected_when_token_has_no_phone_claim():
+    with pytest.raises(HTTPException) as exc:
+        identity.resolve_caller_identity({"sub": "7c477db0-807b-4ee0-a458-eed1dd3c5305"}, "9924457046")
+    assert exc.value.status_code == 403
+
+
+def test_session_binding_rejects_a_different_subject(monkeypatch):
+    values = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in values:
+                return None
+            values[key] = value
+            return True
+
+        async def get(self, key):
+            return values.get(key)
+
+        async def expire(self, key, ttl):
+            return key in values
+
+    monkeypatch.setattr(identity, "redis_client", FakeRedis())
+    first = identity.CallerIdentity(mobile="9924457046", subject_id="a" * 64, verified=True)
+    other = identity.CallerIdentity(mobile="9265866812", subject_id="b" * 64, verified=True)
+
+    asyncio.run(identity.bind_session_identity("session-1", first))
+    asyncio.run(identity.bind_session_identity("session-1", first))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(identity.bind_session_identity("session-1", other))
+    assert exc.value.status_code == 403
+

--- a/tests/test_voice_regressions_apr11_12.py
+++ b/tests/test_voice_regressions_apr11_12.py
@@ -241,7 +241,9 @@ async def _collect_stream(
         history=history,
         provider=None,
         process_id="proc-1",
-        user_info={},
+        user_info={"phone": user_id} if user_id != "anonymous" else {},
+        identity_verified=user_id != "anonymous",
+        authenticated_subject_id="verified-test-subject" if user_id != "anonymous" else None,
         owner=None,
         http_request=None,
     ):
@@ -356,9 +358,9 @@ class TestHelperCoverage:
     def test_signed_in_agent_has_farmer_tools(self):
         base_tool_names = set(voice_agent._function_toolset.tools.keys())
         signed_in_tool_names = set(voice_agent_signed_in._function_toolset.tools.keys())
-        assert {"search_terms", "search_documents", "get_farmer_milk_collection_details", "create_ai_call", "create_health_call"}.issubset(base_tool_names)
-        assert {"get_farmer_profile", "get_herd_summary", "list_animal_tags"}.issubset(signed_in_tool_names)
-        assert "get_farmer_profile" not in base_tool_names
+        assert {"search_terms", "search_documents", "signal_conversation_state"}.issubset(base_tool_names)
+        assert {"get_farmer_milk_collection_details", "create_ai_call", "create_health_call", "get_union_scheme_data"}.issubset(signed_in_tool_names)
+        assert "create_ai_call" not in base_tool_names
 
     def test_voice_system_prompt_is_static(self):
         assert "Today's date:" not in STATIC_VOICE_SYSTEM_PROMPT
@@ -510,9 +512,9 @@ class TestHelperCoverage:
         assert _voice_answer_mode_for_query(query) == expected
 
     def test_signed_in_session_helper(self):
-        assert _is_signed_in_session({"sub": "user-1"}, "anonymous") is True
-        assert _is_signed_in_session({}, "9876543210") is True
-        assert _is_signed_in_session({}, "anonymous") is False
+        assert _is_signed_in_session(True, "9876543210", "subject") is True
+        assert _is_signed_in_session(False, "9876543210", "subject") is False
+        assert _is_signed_in_session(True, None, "subject") is False
 
     def test_compact_farmer_summary_is_small_and_structured(self):
         envelope = FarmerDataEnvelope(


### PR DESCRIPTION
## Summary

- derive farmer mobile authoritatively from verified JWT claims and reject mismatched user_id values
- bind each voice session to a hashed authenticated subject before reading history or creating operations
- move milk, AI booking, health booking, loan, and union-scheme tools behind the signed-in agent and validate account and technician ownership server-side
- add one Redis-backed Beckn transaction facade for document search, union schemes, milk init, AI and health confirm, and loan init or confirm
- persist operation and business idempotency state before sending, distinguish ACK from completion, accept late callbacks, and reconcile ambiguous booking outcomes through status/on_status instead of rebooking
- add token-protected callback ingress and owner-scoped operation status
- keep search_terms and signal_conversation_state local
- keep VOICE_BECKN_ENABLED off by default until ONIX routes, bridge authentication, callback authentication, and BPP support are configured

## Tests

- 72 focused tests pass covering identity binding, private tool gates, account and technician ownership, callback correlation, duplicate callbacks, pending state, status recovery, booking idempotency, and every active voice business-tool route
- python compileall and git diff --check pass

## Existing repository test issues

- unfiltered pytest collection executes scripts/test_goodbye.py at import time and fails without a local Redis instance
- the broader selected suite reports 116 passing and 11 failing in tests/test_voice_regressions_apr11_12.py; two are stale prompt assertions already present on amul-dev and the remaining harness cases invoke real OpenAI with the test key instead of their fake stream

## Staging requirements

Do not enable VOICE_BECKN_ENABLED until the transaction bridge exposes transactions/search, init, confirm, and status, routes callbacks to /api/beckn/callbacks/on_*, and the configured BPPs return ACK plus correlated callbacks. No deployment is included in this PR.